### PR TITLE
database: reduce pruneLocks/Unlock transaction.

### DIFF
--- a/database/lock_test.go
+++ b/database/lock_test.go
@@ -35,7 +35,7 @@ func TestLock(t *testing.T) {
 	l, _ = Lock("test1", time.Minute, "owner2")
 	assert.False(t, l)
 	// Renew the lock
-	l, _ = Lock("test1", time.Minute, "owner1")
+	l, _ = Lock("test1", 2*time.Minute, "owner1")
 	assert.True(t, l)
 	// Unlock and then relock by someone else
 	Unlock("test1", "owner1")


### PR DESCRIPTION
pruneLocks could create deadlocked transactions on PostgreSQL if multiple locks expired and pruneLocks is called by multiple instances because Cayley does not guarantee the order.

[InsertNotifications](https://github.com/coreos/clair/blob/8bb6c50f802257228161f9f2d99edaee5b59d18e/database/notification.go#L312) and [InsertVulnerabilities](https://github.com/coreos/clair/blob/8bb6c50f802257228161f9f2d99edaee5b59d18e/database/vulnerability.go#L100) also insert multiple independent items in a single same transaction. Doing so in InsertNotifications helps because as the transaction only contains new quads, COPY can be used. For the same reason, it could not create a deadlocked transaction. In the other hand, InsertVulnerabilities may delete some fields. However, just like InsertNotifications, it is called from the updater - which run only once per cluster: it could not create a deadlocked transaction. Additionally, the updater relies on the fact that these two functions will fail and rollback entirely if any of the elements can't be inserted (for any reason) - in which case it will not mark the update as done and will redo it later. I believe that because of the reasons above, they should not be modified.
