### PR TITLE
Don't pass -z to tar

### DIFF
--- a/contrib/analyze-local-images/main.go
+++ b/contrib/analyze-local-images/main.go
@@ -126,7 +126,7 @@ func save(imageName string) (string, error) {
 	var stderr bytes.Buffer
 	save := exec.Command("docker", "save", imageName)
 	save.Stderr = &stderr
-	extract := exec.Command("tar", "xzf", "-", "-C"+path)
+	extract := exec.Command("tar", "xf", "-", "-C"+path)
 	extract.Stderr = &stderr
 	pipe, err := extract.StdinPipe()
 	if err != nil {


### PR DESCRIPTION
AFAICT `docker save` will produce an uncompressed tar archive.

This prevented successful run of `analyze-local-images`:

```
2015/11/23 13:59:30 - Could not save image: 
gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
```

The patch fixed it. :)

If `docker save` will in fact produce compressed output?- & one's implementation of `tar` is not capable of self-identifying compression, then perhaps this would break things. :\
