### PR TITLE
database: Fix incorrect behavior of toValue when reading empty strings.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -139,17 +139,19 @@ func Healthcheck() health.Status {
 // If the path leads to multiple values or if a database error occurs, an empty string and an error are returned
 func toValue(p *path.Path) (string, error) {
 	var value string
+	found := false
 
 	it, _ := p.BuildIterator().Optimize()
 	defer it.Close()
 	for cayley.RawNext(it) {
-		if value != "" {
+		if found {
 			log.Error("failed query in toValue: used on an iterator containing multiple values")
 			return "", ErrInconsistent
 		}
 
 		if it.Result() != nil {
 			value = store.NameOf(it.Result())
+			found = true
 		}
 	}
 	if it.Err() != nil {
@@ -170,10 +172,7 @@ func toValues(p *path.Path) ([]string, error) {
 	defer it.Close()
 	for cayley.RawNext(it) {
 		if it.Result() != nil {
-			value := store.NameOf(it.Result())
-			if value != "" {
-				values = append(values, value)
-			}
+			values = append(values, store.NameOf(it.Result()))
 		}
 	}
 	if it.Err() != nil {

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -72,11 +72,15 @@ func TestToValue(t *testing.T) {
 
 	store.AddQuad(cayley.Triple("bob", "likes", "running"))
 	v, err = toValue(cayley.StartPath(store, "bob").Out("likes"))
-	assert.Nil(t, err, "toValue should have worked")
-	assert.Equal(t, "running", v, "toValue did not return the expected value")
+	assert.NotNil(t, err, "toValue should return an error and an empty string if the path leads to multiple values")
+	assert.Equal(t, "", v, "toValue should return an error and an empty string if the path leads to multiple values")
 
 	store.AddQuad(cayley.Triple("bob", "likes", "swimming"))
 	va, err := toValues(cayley.StartPath(store, "bob").Out("likes"))
 	assert.Nil(t, err, "toValues should have worked")
-	assert.Len(t, va, 2, "toValues should have returned 2 values")
+	if assert.Len(t, va, 3, "toValues should have returned 2 values") {
+		assert.Contains(t, va, "running")
+		assert.Contains(t, va, "swimming")
+		assert.Contains(t, va, "")
+	}
 }


### PR DESCRIPTION
If there are two strings for a path (ie. "", "yes"), always return "yes"
and never "".

Unlikely to happen but, still.
