### PR TITLE
updater: Add support for Ubuntu Vivid Core and ignore Vivid PhoneOverlay

### DIFF
--- a/database/os_mapping.go
+++ b/database/os_mapping.go
@@ -34,11 +34,12 @@ var DebianReleasesMapping = map[string]string{
 // UbuntuReleasesMapping translates Ubuntu code names to version numbers
 // TODO That should probably be stored in the database or in a file
 var UbuntuReleasesMapping = map[string]string{
-	"precise": "12.04",
-	"quantal": "12.10",
-	"raring":  "13.04",
-	"trusty":  "14.04",
-	"utopic":  "14.10",
-	"vivid":   "15.04",
-	"wily":    "15.10",
+	"precise":           "12.04",
+	"quantal":           "12.10",
+	"raring":            "13.04",
+	"trusty":            "14.04",
+	"utopic":            "14.10",
+	"vivid":             "15.04",
+	"vivid/ubuntu-core": "15.04-core",
+	"wily":              "15.10",
 }

--- a/updater/fetchers/ubuntu.go
+++ b/updater/fetchers/ubuntu.go
@@ -59,6 +59,8 @@ var (
 		"oneiric":  struct{}{},
 		"saucy":    struct{}{},
 
+		"vivid/stable-phone-overlay": struct{}{},
+
 		// Syntax error
 		"Patches": struct{}{},
 		// Product


### PR DESCRIPTION
Reacts to https://bazaar.launchpad.net/~ubuntu-security/ubuntu-cve-tracker/master/revision/10488
