### PR TITLE
updater: fix typos

### DIFF
--- a/updater/fetchers/debian.go
+++ b/updater/fetchers/debian.go
@@ -58,7 +58,7 @@ func init() {
 
 // FetchUpdate fetches vulnerability updates from the Debian Security Tracker.
 func (fetcher *DebianFetcher) FetchUpdate() (resp updater.FetcherResponse, err error) {
-	log.Info("fetching Debian vulneratibilities")
+	log.Info("fetching Debian vulnerabilities")
 
 	// Download JSON.
 	r, err := http.Get(url)

--- a/updater/fetchers/rhel.go
+++ b/updater/fetchers/rhel.go
@@ -86,7 +86,7 @@ func init() {
 
 // FetchUpdate gets vulnerability updates from the Red Hat OVAL definitions.
 func (f *RHELFetcher) FetchUpdate() (resp updater.FetcherResponse, err error) {
-	log.Info("fetching Red Hat vulneratibilities")
+	log.Info("fetching Red Hat vulnerabilities")
 
 	// Get the first RHSA we have to manage.
 	flagValue, err := database.GetFlagValue(rhelUpdaterFlag)

--- a/updater/fetchers/ubuntu.go
+++ b/updater/fetchers/ubuntu.go
@@ -81,7 +81,7 @@ func init() {
 
 // FetchUpdate gets vulnerability updates from the Ubuntu CVE Tracker.
 func (fetcher *UbuntuFetcher) FetchUpdate() (resp updater.FetcherResponse, err error) {
-	log.Info("fetching Ubuntu vulneratibilities")
+	log.Info("fetching Ubuntu vulnerabilities")
 
 	// Check to see if the repository does not already exist.
 	if _, pathExists := os.Stat(repositoryLocalPath); repositoryLocalPath == "" || os.IsNotExist(pathExists) {


### PR DESCRIPTION
it's a quick'n' simple fix for the word "vulnerabilities" that was mispelled systematically "vulneratibilities" for rhel/debian/ubuntu updater files.
