### PR TITLE
Allow host

### DIFF
--- a/contrib/analyze-local-images/main.go
+++ b/contrib/analyze-local-images/main.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -257,7 +258,8 @@ func listenHTTP(path, allowedHost string) {
 
 	restrictedFileServer := func(path, allowedHost string) http.Handler {
 		fc := func(w http.ResponseWriter, r *http.Request) {
-			if r.Host == allowedHost {
+			host, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err == nil && strings.EqualFold(host, allowedHost) {
 				http.FileServer(http.Dir(path)).ServeHTTP(w, r)
 				return
 			}


### PR DESCRIPTION
"r.Host == allowedHost" is not available for testing the func of clair when clair and analyze-local-images are not in the same host, and if the fileserver  want clair to access,itshould use RemoteAddr to determine which host can access
