### PR TITLE
fetcher: Send BZR_LOG=/dev/null environment variable to bzr

### DIFF
--- a/updater/fetchers/ubuntu/ubuntu.go
+++ b/updater/fetchers/ubuntu/ubuntu.go
@@ -42,6 +42,7 @@ const (
 )
 
 var (
+	bzrEnv            = []string{"BZR_LOG=/dev/null"}
 	ubuntuIgnoredReleases = map[string]struct{}{
 		"upstream": {},
 		"devel":    {},
@@ -227,7 +228,7 @@ func collectModifiedVulnerabilities(revision int, dbRevision, repositoryLocalPat
 	}
 
 	// Handle a database that needs upgrading.
-	out, err := utils.Exec(repositoryLocalPath, "bzr", "log", "--verbose", "-r"+strconv.Itoa(dbRevisionInt+1)+"..", "-n0")
+	out, err := utils.Exec(repositoryLocalPath, bzrEnv, "bzr", "log", "--verbose", "-r"+strconv.Itoa(dbRevisionInt+1)+"..", "-n0")
 	if err != nil {
 		log.Errorf("could not get Ubuntu vulnerabilities repository logs: %s. output: %s", err, out)
 		return nil, cerrors.ErrCouldNotDownload
@@ -249,7 +250,7 @@ func collectModifiedVulnerabilities(revision int, dbRevision, repositoryLocalPat
 
 func createRepository(pathToRepo string) error {
 	// Branch repository
-	out, err := utils.Exec("/tmp/", "bzr", "branch", trackerRepository, pathToRepo)
+	out, err := utils.Exec("/tmp/", bzrEnv, "bzr", "branch", trackerRepository, pathToRepo)
 	if err != nil {
 		log.Errorf("could not branch Ubuntu repository: %s. output: %s", err, out)
 		return cerrors.ErrCouldNotDownload
@@ -259,7 +260,7 @@ func createRepository(pathToRepo string) error {
 
 func updateRepository(pathToRepo string) error {
 	// Pull repository
-	out, err := utils.Exec(pathToRepo, "bzr", "pull", "--overwrite")
+	out, err := utils.Exec(pathToRepo, bzrEnv, "bzr", "pull", "--overwrite")
 	if err != nil {
 		log.Errorf("could not pull Ubuntu repository: %s. output: %s", err, out)
 		return cerrors.ErrCouldNotDownload
@@ -268,7 +269,7 @@ func updateRepository(pathToRepo string) error {
 }
 
 func getRevisionNumber(pathToRepo string) (int, error) {
-	out, err := utils.Exec(pathToRepo, "bzr", "revno")
+	out, err := utils.Exec(pathToRepo, bzrEnv, "bzr", "revno")
 	if err != nil {
 		log.Errorf("could not get Ubuntu repository's revision number: %s. output: %s", err, out)
 		return 0, cerrors.ErrCouldNotDownload

--- a/utils/exec.go
+++ b/utils/exec.go
@@ -20,8 +20,8 @@ import (
 	"os/exec"
 )
 
-// Exec runs the given binary with arguments
-func Exec(dir string, bin string, args ...string) ([]byte, error) {
+// Exec runs the given binary with environment & arguments
+func Exec(dir string, env []string, bin string, args ...string) ([]byte, error) {
 	_, err := exec.LookPath(bin)
 	if err != nil {
 		return nil, err
@@ -29,6 +29,7 @@ func Exec(dir string, bin string, args ...string) ([]byte, error) {
 
 	cmd := exec.Command(bin, args...)
 	cmd.Dir = dir
+	cmd.Env = env
 
 	var buf bytes.Buffer
 	cmd.Stdout = &buf

--- a/worker/detectors/feature/rpm/rpm.go
+++ b/worker/detectors/feature/rpm/rpm.go
@@ -65,7 +65,7 @@ func (detector *RpmFeaturesDetector) Detect(data map[string][]byte) ([]database.
 	// Query RPM
 	// We actually extract binary package names instead of source package names here because RHSA refers to package names
 	// In the dpkg system, we extract the source instead
-	out, err := utils.Exec(tmpDir, "rpm", "--dbpath", tmpDir, "-qa", "--qf", "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE}\n")
+	out, err := utils.Exec(tmpDir, make([]string, 0), "rpm", "--dbpath", tmpDir, "-qa", "--qf", "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE}\n")
 	if err != nil {
 		log.Errorf("could not query RPM: %s. output: %s", err, string(out))
 		// Do not bubble up because we probably won't be able to fix it,


### PR DESCRIPTION
IME (I'm testing on Debian 8), the Ubuntu updater fails on trying to open /nonexistent/.bzr.log - which causes clair to leak socket descriptors. Passing BZR_LOG=/dev/null in environment should solve it.
