### PR TITLE
database: Find the FeatureVersion we try to insert before doing any lock

### DIFF
--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -52,6 +52,9 @@ const (
 		UNION
 		SELECT id FROM new_feature`
 
+	searchFeatureVersion = `
+		SELECT id FROM FeatureVersion WHERE feature_id = $1 AND version = $2`
+
 	soiFeatureVersion = `
 		WITH new_featureversion AS (
 			INSERT INTO FeatureVersion(feature_id, version)


### PR DESCRIPTION
This commit is issued in order to limit the bottleneck that the
exclusive database lock on Vulnerability_Affects_FeautreVersion
introduces, when we inserting FeatureVersions. This slowdowns a bit
the FeatureVersion insertion on a mostly empty database but should
increase a lot the throughput and parallelism on a populated database.
