### PR TITLE
config: add top-level YAML namespace 'clair'

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,55 +13,31 @@
 # limitations under the License.
 
 # The values specified here are the default values that Clair uses if no configuration file is specified or if the keys are not defined.
----
-database:
-  # PostgreSQL Connection string
-  # http://www.postgresql.org/docs/9.4/static/libpq-connect.html
-  source:
+clair:
+  database:
+    # PostgreSQL Connection string
+    # http://www.postgresql.org/docs/9.4/static/libpq-connect.html
+    source:
 
-  # Number of elements kept in the cache
-  # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
-  cacheSize: 16384
+    # Number of elements kept in the cache
+    # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
+    cacheSize: 16384
 
-api:
-  # API server port
-  port: 6060
+  api:
+    # API server port
+    port: 6060
 
-  # Health server port
-  # This is an unencrypted endpoint useful for load balancers to check to healthiness of the clair server.
-  healthport: 6061
+    # Health server port
+    # This is an unencrypted endpoint useful for load balancers to check to healthiness of the clair server.
+    healthport: 6061
 
-  # Deadline before an API request will respond with a 503
-  timeout: 900s
+    # Deadline before an API request will respond with a 503
+    timeout: 900s
 
-  # 32-bit URL-safe base64 key used to encrypt pagination tokens
-  # If one is not provided, it will be generated.
-  # Multiple clair instances in the same cluster need the same value.
-  paginationKey:
-
-  # Optional PKI configuration
-  # If you want to easily generate client certificates and CAs, try the following projects:
-  # https://github.com/coreos/etcd-ca
-  # https://github.com/cloudflare/cfssl
-  cafile:
-  keyfile:
-  certfile:
-
-updater:
-  # Frequency the database will be updated with vulnerabilities from the default data sources
-  # The value 0 disables the updater entirely.
-  interval: 2h
-
-notifier:
-  # Number of attempts before the notification is marked as failed to be sent
-  attempts: 3
-
-  # Duration before a failed notification is retried
-  renotifyInterval: 2h
-
-  http:
-    # Optional endpoint that will receive notifications via POST requests
-    endpoint:
+    # 32-bit URL-safe base64 key used to encrypt pagination tokens
+    # If one is not provided, it will be generated.
+    # Multiple clair instances in the same cluster need the same value.
+    paginationKey:
 
     # Optional PKI configuration
     # If you want to easily generate client certificates and CAs, try the following projects:
@@ -71,3 +47,28 @@ notifier:
     cafile:
     keyfile:
     certfile:
+
+  updater:
+    # Frequency the database will be updated with vulnerabilities from the default data sources
+    # The value 0 disables the updater entirely.
+    interval: 2h
+
+  notifier:
+    # Number of attempts before the notification is marked as failed to be sent
+    attempts: 3
+
+    # Duration before a failed notification is retried
+    renotifyInterval: 2h
+
+    http:
+      # Optional endpoint that will receive notifications via POST requests
+      endpoint:
+
+      # Optional PKI configuration
+      # If you want to easily generate client certificates and CAs, try the following projects:
+      # https://github.com/cloudflare/cfssl
+      # https://github.com/coreos/etcd-ca
+      servername:
+      cafile:
+      keyfile:
+      certfile:

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// File represents a YAML configuration file that namespaces all Clair
+// configuration under the top-level "clair" key.
+type File struct {
+	Clair Config `yaml:"clair"`
+}
+
 // Config is the global configuration for an instance of Clair.
 type Config struct {
 	Database *DatabaseConfig
@@ -97,11 +103,14 @@ func Load(path string) (config *Config, err error) {
 		return
 	}
 
-	err = yaml.Unmarshal(d, config)
+	var cfgFile File
+	err = yaml.Unmarshal(d, &cfgFile)
 	if err != nil {
 		return
 	}
+	config = &cfgFile.Clair
 
+	// Generate a pagination key if none is provided.
 	if config.API.PaginationKey == "" {
 		var key fernet.Key
 		if err = key.Generate(); err != nil {


### PR DESCRIPTION
This enables Clair to use YAML configuration files that contain more
than just a Clair configuration.

Fixes #95.
