### PR TITLE
api/v1: create namespace type

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -122,18 +122,18 @@ Server: clair
 {
   "Layer": {
     "Name": "17675ec01494d651e1ccf81dc9cf63959ebfeed4f978fddb1666b6ead008ed52",
-    "Namespace": "debian:8",
+    "NamespaceName": "debian:8",
     "ParentName": "140f9bdfeb9784cf8730e9dab5dd12fbd704151cf555ac8cae650451794e5ac2",
     "IndexedByVersion": 1,
     "Features": [
       {
         "Name": "coreutils",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Version": "8.23-4",
         "Vulnerabilities": [
           {
             "Name": "CVE-2014-9471",
-            "Namespace": "debian:8",
+            "NamespaceName": "debian:8",
             "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
             "Severity": "Low",
@@ -189,8 +189,8 @@ Server: clair
 
 {
   "Namespaces": [
-    "debian:8",
-    "debian:9"
+    { "Name": "debian:8" },
+    { "Name": "debian:9" }
   ]
 }
 ```
@@ -227,14 +227,14 @@ Server: clair
     "Vulnerabilities": [
         {
             "Name": "CVE-1999-1332",
-            "Namespace": "debian:8",
+            "NamespaceName": "debian:8",
             "Description": "gzexe in the gzip package on Red Hat Linux 5.0 and earlier allows local users to overwrite files of other users via a symlink attack on a temporary file.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-1999-1332",
             "Severity": "Low"
         },
         {
             "Name": "CVE-1999-1572",
-            "Namespace": "debian:8",
+            "NamespaceName": "debian:8",
             "Description": "cpio on FreeBSD 2.1.0, Debian GNU/Linux 3.0, and possibly other operating systems, uses a 0 umask when creating files using the -O (archive) or -F options, which creates the files with mode 0666 and allows local users to read or overwrite those files.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-1999-1572",
             "Severity": "Low",
@@ -266,7 +266,7 @@ POST http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities HTTP/1.1
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -281,7 +281,7 @@ POST http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities HTTP/1.1
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "Namespace": "debian:8",
+                "NamespaceName": "debian:8",
                 "Version": "8.23-1"
             }
         ]
@@ -299,7 +299,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -314,7 +314,7 @@ Server: clair
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "Namespace": "debian:8",
+                "NamespaceName": "debian:8",
                 "Version": "8.23-1"
             }
         ]
@@ -350,7 +350,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -365,7 +365,7 @@ Server: clair
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "Namespace": "debian:8",
+                "NamespaceName": "debian:8",
                 "Version": "8.23-1"
             }
         ]
@@ -390,7 +390,7 @@ PUT http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -415,7 +415,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -477,7 +477,7 @@ Server: clair
   "Features": [
     {
       "Name": "coreutils",
-      "Namespace": "debian:8",
+      "NamespaceName": "debian:8",
       "Version": "8.23-1"
     }
   ]
@@ -498,7 +498,7 @@ PUT http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471
 {
   "Feature": {
     "Name": "coreutils",
-    "Namespace": "debian:8",
+    "NamespaceName": "debian:8",
     "Version": "4.24-9"
   }
 }
@@ -513,7 +513,7 @@ Server: clair
 {
   "Feature": {
     "Name": "coreutils",
-    "Namespace": "debian:8",
+    "NamespaceName": "debian:8",
     "Version": "4.24-9"
   }
 }
@@ -578,13 +578,13 @@ Server: clair
     "New": {
       "Vulnerability": {
         "Name": "CVE-TEST",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Description": "New CVE",
         "Severity": "Low",
         "FixedIn": [
           {
             "Name": "grep",
-            "Namespace": "debian:8",
+            "NamespaceName": "debian:8",
             "Version": "2.25"
           }
         ]
@@ -597,7 +597,7 @@ Server: clair
     "Old": {
       "Vulnerability": {
         "Name": "CVE-TEST",
-        "Namespace": "debian:8",
+        "NamespaceName": "debian:8",
         "Description": "New CVE",
         "Severity": "Low",
         "FixedIn": []

--- a/api/v1/routes.go
+++ b/api/v1/routes.go
@@ -176,9 +176,9 @@ func getNamespaces(w http.ResponseWriter, r *http.Request, p httprouter.Params, 
 		writeResponse(w, r, http.StatusInternalServerError, NamespaceEnvelope{Error: &Error{err.Error()}})
 		return getNamespacesRoute, http.StatusInternalServerError
 	}
-	var namespaces []string
+	var namespaces []Namespace
 	for _, dbNamespace := range dbNamespaces {
-		namespaces = append(namespaces, dbNamespace.Name)
+		namespaces = append(namespaces, Namespace{Name: dbNamespace.Name})
 	}
 
 	writeResponse(w, r, http.StatusOK, NamespaceEnvelope{Namespaces: &namespaces})

--- a/contrib/analyze-local-images/main.go
+++ b/contrib/analyze-local-images/main.go
@@ -127,7 +127,7 @@ func main() {
 
 	isSafe := true
 	for _, feature := range layer.Features {
-		fmt.Printf("## Feature: %s %s (%s)\n", feature.Name, feature.Version, feature.Namespace)
+		fmt.Printf("## Feature: %s %s (%s)\n", feature.Name, feature.Version, feature.NamespaceName)
 
 		if len(feature.Vulnerabilities) > 0 {
 			isSafe = false


### PR DESCRIPTION
This change creates a struct type for namespaces rather than using a
string. This enables us to extend namespaces in the future to contain
metadata. This change also required renaming other field references of
namespaces to "NamespaceName".

Fixes #99
