### PR TITLE
config: not properly loaded error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,10 +112,12 @@ func Load(path string) (config *Config, err error) {
 		return
 	}
 	config = &cfgFile.Clair
-	if config.API == nil || config.Database == nil || config.Notifier == nil || config.Updater == nil {
-		err = cerrors.ErrConfigNotLoaded
+
+	if config.Database.Source == "" {
+		err = cerrors.ErrDatasourceNotLoaded
 		return
 	}
+
 	// Generate a pagination key if none is provided.
 	if config.API.PaginationKey == "" {
 		var key fernet.Key

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"time"
 
+	cerrors "github.com/coreos/clair/utils/errors"
 	"github.com/fernet/fernet-go"
 	"gopkg.in/yaml.v2"
 )
@@ -111,7 +112,10 @@ func Load(path string) (config *Config, err error) {
 		return
 	}
 	config = &cfgFile.Clair
-
+	if config.API == nil || config.Database == nil || config.Notifier == nil || config.Updater == nil {
+		err = cerrors.ErrConfigNotLoaded
+		return
+	}
 	// Generate a pagination key if none is provided.
 	if config.API.PaginationKey == "" {
 		var key fernet.Key

--- a/config/config.go
+++ b/config/config.go
@@ -15,14 +15,17 @@
 package config
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"time"
 
-	cerrors "github.com/coreos/clair/utils/errors"
 	"github.com/fernet/fernet-go"
 	"gopkg.in/yaml.v2"
 )
+
+// ErrDatasourceNotLoaded is returned when the datasource variable in the configuration file is not loaded properly
+var ErrDatasourceNotLoaded = errors.New("could not load configuration: no database source specified")
 
 // File represents a YAML configuration file that namespaces all Clair
 // configuration under the top-level "clair" key.
@@ -114,7 +117,7 @@ func Load(path string) (config *Config, err error) {
 	config = &cfgFile.Clair
 
 	if config.Database.Source == "" {
-		err = cerrors.ErrDatasourceNotLoaded
+		err = ErrDatasourceNotLoaded
 		return
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	cerrors "github.com/coreos/clair/utils/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+const wrongConfig = `
+dummyKey:
+    wrong:true
+`
+
+func TestLoadWrongConfiguration(t *testing.T) {
+	tmpfile, err := ioutil.TempFile("", "clair-config")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, err := tmpfile.Write([]byte(wrongConfig)); err != nil {
+		log.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = Load(tmpfile.Name())
+
+	assert.EqualError(t, err, cerrors.ErrConfigNotLoaded.Error())
+}
+
+func TestLoad(t *testing.T) {
+	_, err := Load("../config.example.yaml")
+	assert.NoError(t, err)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,34 @@ dummyKey:
     wrong:true
 `
 
+const goodConfig = `
+clair:
+  database:
+    source: postgresql://postgres:root@postgres:5432?sslmode=disable
+    cacheSize: 16384
+  api:
+    port: 6060
+    healthport: 6061
+    timeout: 900s
+    paginationKey:
+    servername:
+    cafile:
+    keyfile:
+    certfile:
+  updater:
+    interval: 2h
+  notifier:
+    attempts: 3
+    renotifyInterval: 2h
+    http:
+      endpoint:
+      servername:
+      cafile:
+      keyfile:
+      certfile:
+      proxy:
+`
+
 func TestLoadWrongConfiguration(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", "clair-config")
 	if err != nil {
@@ -22,7 +50,6 @@ func TestLoadWrongConfiguration(t *testing.T) {
 	}
 
 	defer os.Remove(tmpfile.Name()) // clean up
-
 	if _, err := tmpfile.Write([]byte(wrongConfig)); err != nil {
 		log.Fatal(err)
 	}
@@ -32,10 +59,24 @@ func TestLoadWrongConfiguration(t *testing.T) {
 
 	_, err = Load(tmpfile.Name())
 
-	assert.EqualError(t, err, cerrors.ErrConfigNotLoaded.Error())
+	assert.EqualError(t, err, cerrors.ErrDatasourceNotLoaded.Error())
 }
 
 func TestLoad(t *testing.T) {
-	_, err := Load("../config.example.yaml")
+	tmpfile, err := ioutil.TempFile("", "clair-config")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer os.Remove(tmpfile.Name()) // clean up
+
+	if _, err := tmpfile.Write([]byte(goodConfig)); err != nil {
+		log.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	_, err = Load(tmpfile.Name())
 	assert.NoError(t, err)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	cerrors "github.com/coreos/clair/utils/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,7 +58,7 @@ func TestLoadWrongConfiguration(t *testing.T) {
 
 	_, err = Load(tmpfile.Name())
 
-	assert.EqualError(t, err, cerrors.ErrDatasourceNotLoaded.Error())
+	assert.EqualError(t, err, ErrDatasourceNotLoaded.Error())
 }
 
 func TestLoad(t *testing.T) {

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -29,9 +29,6 @@ var (
 
 	// ErrCouldNotParse is returned when a fetcher fails to parse the update data.
 	ErrCouldNotParse = errors.New("updater/fetchers: could not parse")
-
-	// ErrDatasourceNotLoaded is returned when the datasource variable in the configuration file is not loaded properly
-	ErrDatasourceNotLoaded = errors.New("could not load datasource configuration properly")
 )
 
 // ErrBadRequest occurs when a method has been passed an inappropriate argument.

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -30,8 +30,8 @@ var (
 	// ErrCouldNotParse is returned when a fetcher fails to parse the update data.
 	ErrCouldNotParse = errors.New("updater/fetchers: could not parse")
 
-	//ErrConfigNotLoaded is returned when the configuration file is not loaded properly
-	ErrConfigNotLoaded = errors.New("could not load configuration properly")
+	// ErrDatasourceNotLoaded is returned when the datasource variable in the configuration file is not loaded properly
+	ErrDatasourceNotLoaded = errors.New("could not load datasource configuration properly")
 )
 
 // ErrBadRequest occurs when a method has been passed an inappropriate argument.

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -29,6 +29,9 @@ var (
 
 	// ErrCouldNotParse is returned when a fetcher fails to parse the update data.
 	ErrCouldNotParse = errors.New("updater/fetchers: could not parse")
+
+	//ErrConfigNotLoaded is returned when the configuration file is not loaded properly
+	ErrConfigNotLoaded = errors.New("could not load configuration properly")
 )
 
 // ErrBadRequest occurs when a method has been passed an inappropriate argument.


### PR DESCRIPTION
When a wrong config file was used, it result in a panic.
Adding some check condition to validate the Unmarshaled configuration
before using it

fixes #134
