### PR TITLE
api/worker: s/Authorization/Headers

### DIFF
--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -34,14 +34,14 @@ type Error struct {
 }
 
 type Layer struct {
-	Name             string    `json:"Name,omitempty"`
-	NamespaceName    string    `json:"NamespaceName,omitempty"`
-	Path             string    `json:"Path,omitempty"`
-	Authorization    string    `json:"Authorization,omitempty"`
-	ParentName       string    `json:"ParentName,omitempty"`
-	Format           string    `json:"Format,omitempty"`
-	IndexedByVersion int       `json:"IndexedByVersion,omitempty"`
-	Features         []Feature `json:"Features,omitempty"`
+	Name             string            `json:"Name,omitempty"`
+	NamespaceName    string            `json:"NamespaceName,omitempty"`
+	Path             string            `json:"Path,omitempty"`
+	Headers          map[string]string `json:"Headers,omitempty"`
+	ParentName       string            `json:"ParentName,omitempty"`
+	Format           string            `json:"Format,omitempty"`
+	IndexedByVersion int               `json:"IndexedByVersion,omitempty"`
+	Features         []Feature         `json:"Features,omitempty"`
 }
 
 func LayerFromDatabaseModel(dbLayer database.Layer, withFeatures, withVulnerabilities bool) Layer {

--- a/api/v1/routes.go
+++ b/api/v1/routes.go
@@ -109,7 +109,7 @@ func postLayer(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx 
 		return postLayerRoute, http.StatusBadRequest
 	}
 
-	err = worker.Process(ctx.Store, request.Layer.Name, request.Layer.ParentName, request.Layer.Path, request.Layer.Authorization, request.Layer.Format)
+	err = worker.Process(ctx.Store, request.Layer.Format, request.Layer.Name, request.Layer.ParentName, request.Layer.Path, request.Layer.Headers)
 	if err != nil {
 		if err == utils.ErrCouldNotExtract ||
 			err == utils.ErrExtractedFileTooBig ||
@@ -131,7 +131,7 @@ func postLayer(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx 
 		Name:             request.Layer.Name,
 		ParentName:       request.Layer.ParentName,
 		Path:             request.Layer.Path,
-		Authorization:    request.Layer.Authorization,
+		Headers:          request.Layer.Headers,
 		Format:           request.Layer.Format,
 		IndexedByVersion: worker.Version,
 	}})

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -47,9 +47,9 @@ func TestProcessWithDistUpgrade(t *testing.T) {
 	// wheezy.tar: FROM debian:wheezy
 	// jessie.tar: RUN sed -i "s/precise/trusty/" /etc/apt/sources.list && apt-get update &&
 	//             apt-get -y dist-upgrade
-	assert.Nil(t, Process(datastore, "blank", "", path+"blank.tar.gz", "", "Docker"))
-	assert.Nil(t, Process(datastore, "wheezy", "blank", path+"wheezy.tar.gz", "", "Docker"))
-	assert.Nil(t, Process(datastore, "jessie", "wheezy", path+"jessie.tar.gz", "", "Docker"))
+	assert.Nil(t, Process(datastore, "Docker", "blank", "", path+"blank.tar.gz", nil))
+	assert.Nil(t, Process(datastore, "Docker", "wheezy", "blank", path+"wheezy.tar.gz", nil))
+	assert.Nil(t, Process(datastore, "Docker", "jessie", "wheezy", path+"jessie.tar.gz", nil))
 
 	wheezy, err := datastore.FindLayer("wheezy", true, false)
 	if assert.Nil(t, err) {


### PR DESCRIPTION
This allows clients to specify any HTTP headers that need to be used in
order to allow Clair to download a layer, rather than just the
Authorization header.
