### PR TITLE
pgsql: use subquery to plan GetNotification query

### DIFF
--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -205,16 +205,22 @@ const (
 		WHERE name = $1`
 
 	searchNotificationLayerIntroducingVulnerability = `
+	WITH subquery AS (
 		SELECT l.ID, l.name
 		FROM Vulnerability_Affects_FeatureVersion vafv, FeatureVersion fv, Layer_diff_FeatureVersion ldfv, Layer l
 		WHERE l.id >= $2
-					AND vafv.vulnerability_id = $1
-					AND vafv.featureversion_id = fv.id
-					AND ldfv.featureversion_id = fv.id
-					AND ldfv.modification = 'add'
-					AND ldfv.layer_id = l.id
+			AND vafv.vulnerability_id = $1
+			AND vafv.featureversion_id = fv.id
+			AND ldfv.featureversion_id = fv.id
+			AND ldfv.modification = 'add'
+			AND ldfv.layer_id = l.id
 		ORDER BY l.ID
-		LIMIT $3`
+	)
+
+	SELECT *
+	FROM subquery
+	LIMIT $3;
+`
 
 	// complex_test.go
 	searchComplexTestFeatureVersionAffects = `


### PR DESCRIPTION
This change enables the query planner to wait and sort the result set of
our query rather than attempting to re-use the layer table's index for
the ORDER BY clause. Because the result set is always small, this makes
queries that were previous tens of seconds, now tens of milliseconds.
