### PR TITLE
updater: Delete Ubuntu's repository upon bzr errors

### DIFF
--- a/updater/metadata_fetchers/nvd/nvd.go
+++ b/updater/metadata_fetchers/nvd/nvd.go
@@ -129,9 +129,7 @@ func (fetcher *NVDMetadataFetcher) Clean() {
 	fetcher.lock.Lock()
 	defer fetcher.lock.Unlock()
 
-	if fetcher.localPath != "" {
-		os.RemoveAll(fetcher.localPath)
-	}
+	os.RemoveAll(fetcher.localPath)
 }
 
 func getDataFeeds(dataFeedHashes map[string]string, localPath string) (map[string]NestedReadCloser, map[string]string, error) {


### PR DESCRIPTION
By deleting an Ubuntu repository that may be in a bad state, 
Clair will eventually be able to perform the update, instead of retrying
naively.

Fixes #169
