### PR TITLE
support multiple namespaces in one layer

### DIFF
--- a/api/v1/README.md
+++ b/api/v1/README.md
@@ -129,18 +129,18 @@ Server: clair
 {
   "Layer": {
     "Name": "17675ec01494d651e1ccf81dc9cf63959ebfeed4f978fddb1666b6ead008ed52",
-    "NamespaceName": "debian:8",
+    "Namespaces": [{"Name": "debian", "Version": "8"}],
     "ParentName": "140f9bdfeb9784cf8730e9dab5dd12fbd704151cf555ac8cae650451794e5ac2",
     "IndexedByVersion": 1,
     "Features": [
       {
         "Name": "coreutils",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Version": "8.23-4",
         "Vulnerabilities": [
           {
             "Name": "CVE-2014-9471",
-            "NamespaceName": "debian:8",
+            "Namespace": {"Name": "debian", "Version": "8"},
             "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
             "Severity": "Low",
@@ -196,15 +196,15 @@ Server: clair
 
 {
   "Namespaces": [
-    { "Name": "debian:8" },
-    { "Name": "debian:9" }
+    { "ID": "gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==", "Name": "debian", "Version": "8" },
+    { "ID": "gAAAAABXTQPZmOFlOR8zzuhv8Y2fD7HbUY8O6z_Py2vibB9uveWZoycSY1HDIkcf7lN_UDynom4kWubFS4h9KBCbWwjNIqacsw==", "Name": "debian", "Version": "9" }
   ]
 }
 ```
 
 ## Vulnerabilities
 
-#### GET /namespaces/`:nsName`/vulnerabilities
+#### GET /namespaces/`:nsID`/vulnerabilities
 
 ###### Description
 
@@ -220,7 +220,7 @@ The GET route for the Vulnerabilities resource displays the vulnerabilities data
 ###### Example Request
 
 ```json
-GET http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities?limit=2 HTTP/1.1
+GET http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities?limit=2 HTTP/1.1
 ```
 
 ###### Example Response
@@ -234,14 +234,14 @@ Server: clair
     "Vulnerabilities": [
         {
             "Name": "CVE-1999-1332",
-            "NamespaceName": "debian:8",
+            "Namespace": {"Name": "debian", "Version": "8"},
             "Description": "gzexe in the gzip package on Red Hat Linux 5.0 and earlier allows local users to overwrite files of other users via a symlink attack on a temporary file.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-1999-1332",
             "Severity": "Low"
         },
         {
             "Name": "CVE-1999-1572",
-            "NamespaceName": "debian:8",
+            "Namespace": {"Name": "debian", "Version": "8"},
             "Description": "cpio on FreeBSD 2.1.0, Debian GNU/Linux 3.0, and possibly other operating systems, uses a 0 umask when creating files using the -O (archive) or -F options, which creates the files with mode 0666 and allows local users to read or overwrite those files.",
             "Link": "https://security-tracker.debian.org/tracker/CVE-1999-1572",
             "Severity": "Low",
@@ -259,7 +259,7 @@ Server: clair
 }
 ```
 
-#### POST /namespaces/`:name`/vulnerabilities
+#### POST /namespaces/`:nsID`/vulnerabilities
 
 ###### Description
 
@@ -268,12 +268,12 @@ The POST route for the Vulnerabilities resource creates a new Vulnerability.
 ###### Example Request
 
 ```json
-POST http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities HTTP/1.1
+POST http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities HTTP/1.1
 
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -288,7 +288,7 @@ POST http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities HTTP/1.1
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "NamespaceName": "debian:8",
+                "Namespace": {"Name": "debian", "Version": "8"},
                 "Version": "8.23-1"
             }
         ]
@@ -306,7 +306,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -321,7 +321,7 @@ Server: clair
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "NamespaceName": "debian:8",
+                "Namespace": {"Name": "debian", "Version": "8"},
                 "Version": "8.23-1"
             }
         ]
@@ -329,7 +329,7 @@ Server: clair
 }
 ```
 
-#### GET /namespaces/`:nsName`/vulnerabilities/`:vulnName`
+#### GET /namespaces/`:nsID`/vulnerabilities/`:vulnName`
 
 ###### Description
 
@@ -344,7 +344,7 @@ The GET route for the Vulnerabilities resource displays the current data for a g
 ###### Example Request
 
 ```json
-GET http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471?fixedIn HTTP/1.1
+GET http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471?fixedIn HTTP/1.1
 ```
 
 ###### Example Response
@@ -357,7 +357,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -372,7 +372,7 @@ Server: clair
         "FixedIn": [
             {
                 "Name": "coreutils",
-                "NamespaceName": "debian:8",
+                "Namespace": {"Name": "debian", "Version": "8"},
                 "Version": "8.23-1"
             }
         ]
@@ -380,7 +380,7 @@ Server: clair
 }
 ```
 
-#### PUT /namespaces/`:nsName`/vulnerabilities/`:vulnName`
+#### PUT /namespaces/`:nsID`/vulnerabilities/`:vulnName`
 
 ###### Description
 
@@ -392,12 +392,12 @@ If this vulnerability was inserted by a Fetcher, changes may be lost when the Fe
 ###### Example Request
 
 ```json
-PUT http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471
+PUT http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471
 
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -422,7 +422,7 @@ Server: clair
 {
     "Vulnerability": {
         "Name": "CVE-2014-9471",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Link": "https://security-tracker.debian.org/tracker/CVE-2014-9471",
         "Description": "The parse_datetime function in GNU coreutils allows remote attackers to cause a denial of service (crash) or possibly execute arbitrary code via a crafted date string, as demonstrated by the \"--date=TZ=\"123\"345\" @1\" string to the touch or date command.",
         "Severity": "Low",
@@ -439,7 +439,7 @@ Server: clair
 ```
 
 
-#### DELETE /namespaces/`:nsName`/vulnerabilities/`:vulnName`
+#### DELETE /namespaces/`:nsID`/vulnerabilities/`:vulnName`
 
 ###### Description
 
@@ -449,7 +449,7 @@ If this vulnerability was inserted by a Fetcher, it may be re-inserted when the 
 ###### Example Request
 
 ```json
-GET http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471 HTTP/1.1
+GET http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471 HTTP/1.1
 ```
 
 ###### Example Response
@@ -461,7 +461,7 @@ Server: clair
 
 ## Fixes
 
-#### GET /namespaces/`:nsName`/vulnerabilities/`:vulnName`/fixes
+#### GET /namespaces/`:nsID`/vulnerabilities/`:vulnName`/fixes
 
 ###### Description
 
@@ -470,7 +470,7 @@ The GET route for the Fixes resource displays the list of Features that fix the 
 ###### Example Request
 
 ```json
-GET http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471/fixes HTTP/1.1
+GET http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471/fixes HTTP/1.1
 ```
 
 ###### Example Response
@@ -484,14 +484,14 @@ Server: clair
   "Features": [
     {
       "Name": "coreutils",
-      "NamespaceName": "debian:8",
+      "Namespace": {"Name": "debian", "Version": "8"},
       "Version": "8.23-1"
     }
   ]
 }
 ```
 
-#### PUT /namespaces/`:nsName`/vulnerabilities/`:vulnName`/fixes/`:featureName`
+#### PUT /namespaces/`:nsID`/vulnerabilities/`:vulnName`/fixes/`:featureName`
 
 ###### Description
 
@@ -500,12 +500,12 @@ The PUT route for the Fixes resource updates a Feature that is the fix for a giv
 ###### Example Request
 
 ```json
-PUT http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471/fixes/coreutils HTTP/1.1
+PUT http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471/fixes/coreutils HTTP/1.1
 
 {
   "Feature": {
     "Name": "coreutils",
-    "NamespaceName": "debian:8",
+    "Namespace": {"Name": "debian", "Version": "8"},
     "Version": "4.24-9"
   }
 }
@@ -520,13 +520,13 @@ Server: clair
 {
   "Feature": {
     "Name": "coreutils",
-    "NamespaceName": "debian:8",
+    "Namespace": {"Name": "debian", "Version": "8"},
     "Version": "4.24-9"
   }
 }
 ```
 
-#### DELETE /namespaces/`:nsName`/vulnerabilities/`:vulnName`/fixes/`:featureName`
+#### DELETE /namespaces/`:nsID`/vulnerabilities/`:vulnName`/fixes/`:featureName`
 
 ###### Description
 
@@ -535,7 +535,7 @@ The DELETE route for the Fixes resource removes a Feature as fix for the given V
 ###### Example Request
 
 ```json
-DELETE http://localhost:6060/v1/namespaces/debian%3A8/vulnerabilities/CVE-2014-9471/fixes/coreutils
+DELETE http://localhost:6060/v1/namespaces/gAAAAABXTQKgma_TLKq0wr1D6wVB507N3fi9wsWMUypYOSXTDVxQ8OR5L5S6PqZ9Wh0IzWojnVmlspyTL4cyjytyra7U9vAHMA==/vulnerabilities/CVE-2014-9471/fixes/coreutils
 ```
 
 ###### Example Response
@@ -585,13 +585,13 @@ Server: clair
     "New": {
       "Vulnerability": {
         "Name": "CVE-TEST",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Description": "New CVE",
         "Severity": "Low",
         "FixedIn": [
           {
             "Name": "grep",
-            "NamespaceName": "debian:8",
+            "Namespace": {"Name": "debian", "Version": "8"},
             "Version": "2.25"
           }
         ]
@@ -604,7 +604,7 @@ Server: clair
     "Old": {
       "Vulnerability": {
         "Name": "CVE-TEST",
-        "NamespaceName": "debian:8",
+        "Namespace": {"Name": "debian", "Version": "8"},
         "Description": "New CVE",
         "Severity": "Low",
         "FixedIn": []

--- a/api/v1/router.go
+++ b/api/v1/router.go
@@ -34,16 +34,16 @@ func NewRouter(ctx *context.RouteContext) *httprouter.Router {
 	router.GET("/namespaces", context.HTTPHandler(getNamespaces, ctx))
 
 	// Vulnerabilities
-	router.GET("/namespaces/:namespaceName/vulnerabilities", context.HTTPHandler(getVulnerabilities, ctx))
-	router.POST("/namespaces/:namespaceName/vulnerabilities", context.HTTPHandler(postVulnerability, ctx))
-	router.GET("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName", context.HTTPHandler(getVulnerability, ctx))
-	router.PUT("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName", context.HTTPHandler(putVulnerability, ctx))
-	router.DELETE("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName", context.HTTPHandler(deleteVulnerability, ctx))
+	router.GET("/namespaces/:namespaceID/vulnerabilities", context.HTTPHandler(getVulnerabilities, ctx))
+	router.POST("/namespaces/:namespaceID/vulnerabilities", context.HTTPHandler(postVulnerability, ctx))
+	router.GET("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName", context.HTTPHandler(getVulnerability, ctx))
+	router.PUT("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName", context.HTTPHandler(putVulnerability, ctx))
+	router.DELETE("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName", context.HTTPHandler(deleteVulnerability, ctx))
 
 	// Fixes
-	router.GET("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName/fixes", context.HTTPHandler(getFixes, ctx))
-	router.PUT("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName/fixes/:fixName", context.HTTPHandler(putFix, ctx))
-	router.DELETE("/namespaces/:namespaceName/vulnerabilities/:vulnerabilityName/fixes/:fixName", context.HTTPHandler(deleteFix, ctx))
+	router.GET("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName/fixes", context.HTTPHandler(getFixes, ctx))
+	router.PUT("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName/fixes/:fixName", context.HTTPHandler(putFix, ctx))
+	router.DELETE("/namespaces/:namespaceID/vulnerabilities/:vulnerabilityName/fixes/:fixName", context.HTTPHandler(deleteFix, ctx))
 
 	// Notifications
 	router.GET("/notifications/:notificationName", context.HTTPHandler(getNotification, ctx))

--- a/database/database.go
+++ b/database/database.go
@@ -93,7 +93,7 @@ type Datastore interface {
 	// The Limit and page parameters are used to paginate the return list.
 	// The first given page should be 0. The function will then return the next available page.
 	// If there is no more page, -1 has to be returned.
-	ListVulnerabilities(namespaceName string, limit int, page int) ([]Vulnerability, int, error)
+	ListVulnerabilities(namespace Namespace, limit int, page int) ([]Vulnerability, int, error)
 
 	// InsertVulnerabilities stores the given Vulnerabilities in the database, updating them if
 	// necessary. A vulnerability is uniquely identified by its Namespace and its Name.
@@ -110,22 +110,22 @@ type Datastore interface {
 	InsertVulnerabilities(vulnerabilities []Vulnerability, createNotification bool) error
 
 	// FindVulnerability retrieves a Vulnerability from the database, including the FixedIn list.
-	FindVulnerability(namespaceName, name string) (Vulnerability, error)
+	FindVulnerability(namespace Namespace, name string) (Vulnerability, error)
 
 	// DeleteVulnerability removes a Vulnerability from the database.
 	// It has to create a Notification that will contain the old Vulnerability.
-	DeleteVulnerability(namespaceName, name string) error
+	DeleteVulnerability(namespace Namespace, name string) error
 
 	// InsertVulnerabilityFixes adds new FixedIn Feature or update the Versions of existing ones to
 	// the specified Vulnerability in the database.
 	// It has has to create a Notification that will contain the old and the updated Vulnerability.
-	InsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabilityName string, fixes []FeatureVersion) error
+	InsertVulnerabilityFixes(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error
 
 	// DeleteVulnerabilityFix removes a FixedIn Feature from the specified Vulnerability in the
 	// database. It can be used to store the fact that a Vulnerability no longer affects the given
 	// Feature in any Version.
 	// It has has to create a Notification that will contain the old and the updated Vulnerability.
-	DeleteVulnerabilityFix(vulnerabilityNamespace, vulnerabilityName, featureName string) error
+	DeleteVulnerabilityFix(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error
 
 	// # Notification
 	// GetAvailableNotification returns the Name, Created, Notified and Deleted fields of a

--- a/database/database.go
+++ b/database/database.go
@@ -67,6 +67,8 @@ type Datastore interface {
 	// # Namespace
 	// ListNamespaces returns the entire list of known Namespaces.
 	ListNamespaces() ([]Namespace, error)
+	// GetNamespaceID returns the id by name and version.
+	GetNamespaceID(Namespace) (int, error)
 
 	// # Layer
 	// InsertLayer stores a Layer in the database.
@@ -93,7 +95,7 @@ type Datastore interface {
 	// The Limit and page parameters are used to paginate the return list.
 	// The first given page should be 0. The function will then return the next available page.
 	// If there is no more page, -1 has to be returned.
-	ListVulnerabilities(namespace Namespace, limit int, page int) ([]Vulnerability, int, error)
+	ListVulnerabilities(namespaceID int, limit int, page int) ([]Vulnerability, int, error)
 
 	// InsertVulnerabilities stores the given Vulnerabilities in the database, updating them if
 	// necessary. A vulnerability is uniquely identified by its Namespace and its Name.
@@ -110,22 +112,22 @@ type Datastore interface {
 	InsertVulnerabilities(vulnerabilities []Vulnerability, createNotification bool) error
 
 	// FindVulnerability retrieves a Vulnerability from the database, including the FixedIn list.
-	FindVulnerability(namespace Namespace, name string) (Vulnerability, error)
+	FindVulnerability(namespaceID int, name string) (Vulnerability, error)
 
 	// DeleteVulnerability removes a Vulnerability from the database.
 	// It has to create a Notification that will contain the old Vulnerability.
-	DeleteVulnerability(namespace Namespace, name string) error
+	DeleteVulnerability(namespaceID int, name string) error
 
 	// InsertVulnerabilityFixes adds new FixedIn Feature or update the Versions of existing ones to
 	// the specified Vulnerability in the database.
 	// It has has to create a Notification that will contain the old and the updated Vulnerability.
-	InsertVulnerabilityFixes(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error
+	InsertVulnerabilityFixes(vulnerabilityNamespaceID int, vulnerabilityName string, fixes []FeatureVersion) error
 
 	// DeleteVulnerabilityFix removes a FixedIn Feature from the specified Vulnerability in the
 	// database. It can be used to store the fact that a Vulnerability no longer affects the given
 	// Feature in any Version.
 	// It has has to create a Notification that will contain the old and the updated Vulnerability.
-	DeleteVulnerabilityFix(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error
+	DeleteVulnerabilityFix(vulnerabilityNamespaceID int, vulnerabilityName, featureName string) error
 
 	// # Notification
 	// GetAvailableNotification returns the Name, Created, Notified and Deleted fields of a

--- a/database/mock.go
+++ b/database/mock.go
@@ -23,12 +23,12 @@ type MockDatastore struct {
 	FctInsertLayer              func(Layer) error
 	FctFindLayer                func(name string, withFeatures, withVulnerabilities bool) (Layer, error)
 	FctDeleteLayer              func(name string) error
-	FctListVulnerabilities      func(namespaceName string, limit int, page int) ([]Vulnerability, int, error)
+	FctListVulnerabilities      func(namespace Namespace, limit int, page int) ([]Vulnerability, int, error)
 	FctInsertVulnerabilities    func(vulnerabilities []Vulnerability, createNotification bool) error
-	FctFindVulnerability        func(namespaceName, name string) (Vulnerability, error)
-	FctDeleteVulnerability      func(namespaceName, name string) error
-	FctInsertVulnerabilityFixes func(vulnerabilityNamespace, vulnerabilityName string, fixes []FeatureVersion) error
-	FctDeleteVulnerabilityFix   func(vulnerabilityNamespace, vulnerabilityName, featureName string) error
+	FctFindVulnerability        func(namespace Namespace, name string) (Vulnerability, error)
+	FctDeleteVulnerability      func(namespace Namespace, name string) error
+	FctInsertVulnerabilityFixes func(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error
+	FctDeleteVulnerabilityFix   func(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error
 	FctGetAvailableNotification func(renotifyInterval time.Duration) (VulnerabilityNotification, error)
 	FctGetNotification          func(name string, limit int, page VulnerabilityNotificationPageNumber) (VulnerabilityNotification, VulnerabilityNotificationPageNumber, error)
 	FctSetNotificationNotified  func(name string) error
@@ -70,9 +70,9 @@ func (mds *MockDatastore) DeleteLayer(name string) error {
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) ListVulnerabilities(namespaceName string, limit int, page int) ([]Vulnerability, int, error) {
+func (mds *MockDatastore) ListVulnerabilities(namespace Namespace, limit int, page int) ([]Vulnerability, int, error) {
 	if mds.FctListVulnerabilities != nil {
-		return mds.FctListVulnerabilities(namespaceName, limit, page)
+		return mds.FctListVulnerabilities(namespace, limit, page)
 	}
 	panic("required mock function not implemented")
 }
@@ -84,28 +84,28 @@ func (mds *MockDatastore) InsertVulnerabilities(vulnerabilities []Vulnerability,
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) FindVulnerability(namespaceName, name string) (Vulnerability, error) {
+func (mds *MockDatastore) FindVulnerability(namespace Namespace, name string) (Vulnerability, error) {
 	if mds.FctFindVulnerability != nil {
-		return mds.FctFindVulnerability(namespaceName, name)
+		return mds.FctFindVulnerability(namespace, name)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) DeleteVulnerability(namespaceName, name string) error {
+func (mds *MockDatastore) DeleteVulnerability(namespace Namespace, name string) error {
 	if mds.FctDeleteVulnerability != nil {
-		return mds.FctDeleteVulnerability(namespaceName, name)
+		return mds.FctDeleteVulnerability(namespace, name)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) InsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabilityName string, fixes []FeatureVersion) error {
+func (mds *MockDatastore) InsertVulnerabilityFixes(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error {
 	if mds.FctInsertVulnerabilityFixes != nil {
 		return mds.FctInsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabilityName, fixes)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) DeleteVulnerabilityFix(vulnerabilityNamespace, vulnerabilityName, featureName string) error {
+func (mds *MockDatastore) DeleteVulnerabilityFix(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error {
 	if mds.FctDeleteVulnerabilityFix != nil {
 		return mds.FctDeleteVulnerabilityFix(vulnerabilityNamespace, vulnerabilityName, featureName)
 	}

--- a/database/mock.go
+++ b/database/mock.go
@@ -20,15 +20,16 @@ import "time"
 // The default behavior of each method is to simply panic.
 type MockDatastore struct {
 	FctListNamespaces           func() ([]Namespace, error)
+	FctGetNamespaceID           func(namespace Namespace) (int, error)
 	FctInsertLayer              func(Layer) error
 	FctFindLayer                func(name string, withFeatures, withVulnerabilities bool) (Layer, error)
 	FctDeleteLayer              func(name string) error
-	FctListVulnerabilities      func(namespace Namespace, limit int, page int) ([]Vulnerability, int, error)
+	FctListVulnerabilities      func(namespaceID int, limit int, page int) ([]Vulnerability, int, error)
 	FctInsertVulnerabilities    func(vulnerabilities []Vulnerability, createNotification bool) error
-	FctFindVulnerability        func(namespace Namespace, name string) (Vulnerability, error)
-	FctDeleteVulnerability      func(namespace Namespace, name string) error
-	FctInsertVulnerabilityFixes func(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error
-	FctDeleteVulnerabilityFix   func(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error
+	FctFindVulnerability        func(namespaceID int, name string) (Vulnerability, error)
+	FctDeleteVulnerability      func(namespaceID int, name string) error
+	FctInsertVulnerabilityFixes func(vulnerabilityNamespaceID int, vulnerabilityName string, fixes []FeatureVersion) error
+	FctDeleteVulnerabilityFix   func(vulnerabilityNamespaceID int, vulnerabilityName, featureName string) error
 	FctGetAvailableNotification func(renotifyInterval time.Duration) (VulnerabilityNotification, error)
 	FctGetNotification          func(name string, limit int, page VulnerabilityNotificationPageNumber) (VulnerabilityNotification, VulnerabilityNotificationPageNumber, error)
 	FctSetNotificationNotified  func(name string) error
@@ -45,6 +46,13 @@ type MockDatastore struct {
 func (mds *MockDatastore) ListNamespaces() ([]Namespace, error) {
 	if mds.FctListNamespaces != nil {
 		return mds.FctListNamespaces()
+	}
+	panic("required mock function not implemented")
+}
+
+func (mds *MockDatastore) GetNamespaceID(namespace Namespace) (int, error) {
+	if mds.FctGetNamespaceID != nil {
+		return mds.FctGetNamespaceID(namespace)
 	}
 	panic("required mock function not implemented")
 }
@@ -70,9 +78,9 @@ func (mds *MockDatastore) DeleteLayer(name string) error {
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) ListVulnerabilities(namespace Namespace, limit int, page int) ([]Vulnerability, int, error) {
+func (mds *MockDatastore) ListVulnerabilities(namespaceID int, limit int, page int) ([]Vulnerability, int, error) {
 	if mds.FctListVulnerabilities != nil {
-		return mds.FctListVulnerabilities(namespace, limit, page)
+		return mds.FctListVulnerabilities(namespaceID, limit, page)
 	}
 	panic("required mock function not implemented")
 }
@@ -84,30 +92,30 @@ func (mds *MockDatastore) InsertVulnerabilities(vulnerabilities []Vulnerability,
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) FindVulnerability(namespace Namespace, name string) (Vulnerability, error) {
+func (mds *MockDatastore) FindVulnerability(namespaceID int, name string) (Vulnerability, error) {
 	if mds.FctFindVulnerability != nil {
-		return mds.FctFindVulnerability(namespace, name)
+		return mds.FctFindVulnerability(namespaceID, name)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) DeleteVulnerability(namespace Namespace, name string) error {
+func (mds *MockDatastore) DeleteVulnerability(namespaceID int, name string) error {
 	if mds.FctDeleteVulnerability != nil {
-		return mds.FctDeleteVulnerability(namespace, name)
+		return mds.FctDeleteVulnerability(namespaceID, name)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) InsertVulnerabilityFixes(vulnerabilityNamespace Namespace, vulnerabilityName string, fixes []FeatureVersion) error {
+func (mds *MockDatastore) InsertVulnerabilityFixes(vulnerabilityNamespaceID int, vulnerabilityName string, fixes []FeatureVersion) error {
 	if mds.FctInsertVulnerabilityFixes != nil {
-		return mds.FctInsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabilityName, fixes)
+		return mds.FctInsertVulnerabilityFixes(vulnerabilityNamespaceID, vulnerabilityName, fixes)
 	}
 	panic("required mock function not implemented")
 }
 
-func (mds *MockDatastore) DeleteVulnerabilityFix(vulnerabilityNamespace Namespace, vulnerabilityName, featureName string) error {
+func (mds *MockDatastore) DeleteVulnerabilityFix(vulnerabilityNamespaceID int, vulnerabilityName, featureName string) error {
 	if mds.FctDeleteVulnerabilityFix != nil {
-		return mds.FctDeleteVulnerabilityFix(vulnerabilityNamespace, vulnerabilityName, featureName)
+		return mds.FctDeleteVulnerabilityFix(vulnerabilityNamespaceID, vulnerabilityName, featureName)
 	}
 	panic("required mock function not implemented")
 }

--- a/database/models.go
+++ b/database/models.go
@@ -33,14 +33,31 @@ type Layer struct {
 	Name          string
 	EngineVersion int
 	Parent        *Layer
-	Namespace     *Namespace
+	Namespaces    []Namespace
 	Features      []FeatureVersion
 }
 
 type Namespace struct {
 	Model
 
-	Name string
+	Name    string
+	Version types.Version
+}
+
+func (ns *Namespace) IsEmpty() bool {
+	if ns.Name == "" && ns.Version.String() == "" {
+		return true
+	}
+
+	return false
+}
+
+func (ns *Namespace) Equal(namespace Namespace) bool {
+	if ns.Name == namespace.Name && ns.Version.Compare(namespace.Version) == 0 {
+		return true
+	}
+
+	return false
 }
 
 type Feature struct {

--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -21,13 +21,13 @@ var DebianReleasesMapping = map[string]string{
 	"wheezy":  "7",
 	"jessie":  "8",
 	"stretch": "9",
-	"sid":     "unstable",
+	"sid":     "10",
 
 	// Class names
 	"oldstable": "7",
 	"stable":    "8",
 	"testing":   "9",
-	"unstable":  "unstable",
+	"unstable":  "10",
 }
 
 // UbuntuReleasesMapping translates Ubuntu code names to version numbers

--- a/database/pgsql/complex_test.go
+++ b/database/pgsql/complex_test.go
@@ -46,8 +46,11 @@ func TestRaceAffects(t *testing.T) {
 
 	// Insert the Feature on which we'll work.
 	feature := database.Feature{
-		Namespace: database.Namespace{Name: "TestRaceAffectsFeatureNamespace1"},
-		Name:      "TestRaceAffecturesFeature1",
+		Namespace: database.Namespace{
+			Name:    "TestRaceAffectsFeatureNamespace",
+			Version: types.NewVersionUnsafe("1.0"),
+		},
+		Name: "TestRaceAffecturesFeature1",
 	}
 	_, err = datastore.insertFeature(feature)
 	if err != nil {

--- a/database/pgsql/feature.go
+++ b/database/pgsql/feature.go
@@ -31,7 +31,7 @@ func (pgSQL *pgSQL) insertFeature(feature database.Feature) (int, error) {
 	// Do cache lookup.
 	if pgSQL.cache != nil {
 		promCacheQueriesTotal.WithLabelValues("feature").Inc()
-		id, found := pgSQL.cache.Get("feature:" + feature.Namespace.Name + ":" + feature.Name)
+		id, found := pgSQL.cache.Get("feature:" + feature.Namespace.Name + ":" + feature.Namespace.Version.String() + ":" + feature.Name)
 		if found {
 			promCacheHitsTotal.WithLabelValues("feature").Inc()
 			return id.(int), nil
@@ -55,7 +55,7 @@ func (pgSQL *pgSQL) insertFeature(feature database.Feature) (int, error) {
 	}
 
 	if pgSQL.cache != nil {
-		pgSQL.cache.Add("feature:"+feature.Namespace.Name+":"+feature.Name, id)
+		pgSQL.cache.Add("feature:"+feature.Namespace.Name+":"+feature.Namespace.Version.String()+":"+feature.Name, id)
 	}
 
 	return id, nil
@@ -67,7 +67,7 @@ func (pgSQL *pgSQL) insertFeatureVersion(featureVersion database.FeatureVersion)
 	}
 
 	// Do cache lookup.
-	cacheIndex := "featureversion:" + featureVersion.Feature.Namespace.Name + ":" + featureVersion.Feature.Name + ":" + featureVersion.Version.String()
+	cacheIndex := "featureversion:" + featureVersion.Feature.Namespace.Name + ":" + featureVersion.Feature.Namespace.Version.String() + ":" + featureVersion.Feature.Name + ":" + featureVersion.Version.String()
 	if pgSQL.cache != nil {
 		promCacheQueriesTotal.WithLabelValues("featureversion").Inc()
 		id, found := pgSQL.cache.Get(cacheIndex)

--- a/database/pgsql/feature_test.go
+++ b/database/pgsql/feature_test.go
@@ -45,8 +45,11 @@ func TestInsertFeature(t *testing.T) {
 
 	// Insert Feature and ensure we can find it.
 	feature := database.Feature{
-		Namespace: database.Namespace{Name: "TestInsertFeatureNamespace1"},
-		Name:      "TestInsertFeature1",
+		Namespace: database.Namespace{
+			Name:    "TestInsertFeatureNamespace",
+			Version: types.NewVersionUnsafe("1.0"),
+		},
+		Name: "TestInsertFeature1",
 	}
 	id1, err := datastore.insertFeature(feature)
 	assert.Nil(t, err)
@@ -69,15 +72,21 @@ func TestInsertFeature(t *testing.T) {
 		},
 		{
 			Feature: database.Feature{
-				Namespace: database.Namespace{Name: "TestInsertFeatureNamespace2"},
-				Name:      "TestInsertFeature2",
+				Namespace: database.Namespace{
+					Name:    "TestInsertFeatureNamespace",
+					Version: types.NewVersionUnsafe("2.0"),
+				},
+				Name: "TestInsertFeature2",
 			},
 			Version: types.NewVersionUnsafe(""),
 		},
 		{
 			Feature: database.Feature{
-				Namespace: database.Namespace{Name: "TestInsertFeatureNamespace2"},
-				Name:      "TestInsertFeature2",
+				Namespace: database.Namespace{
+					Name:    "TestInsertFeatureNamespace",
+					Version: types.NewVersionUnsafe("2.0"),
+				},
+				Name: "TestInsertFeature2",
 			},
 			Version: types.NewVersionUnsafe("bad version"),
 		},
@@ -90,8 +99,11 @@ func TestInsertFeature(t *testing.T) {
 	// Insert FeatureVersion and ensure we can find it.
 	featureVersion := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertFeatureNamespace1"},
-			Name:      "TestInsertFeature1",
+			Namespace: database.Namespace{
+				Name:    "TestInsertFeatureNamespace",
+				Version: types.NewVersionUnsafe("1.0"),
+			},
+			Name: "TestInsertFeature1",
 		},
 		Version: types.NewVersionUnsafe("2:3.0-imba"),
 	}

--- a/database/pgsql/layer.go
+++ b/database/pgsql/layer.go
@@ -52,28 +52,6 @@ func (pgSQL *pgSQL) FindLayer(name string, withFeatures, withVulnerabilities boo
 			Model: database.Model{ID: int(parentID.Int64)},
 			Name:  parentName.String,
 		}
-
-		// Find its parent's namespaces
-		t = time.Now()
-		rows, err := pgSQL.Query(searchLayerNamespace, parentID)
-		observeQueryTime("FindLayer", "searchParentLayerNamespace", t)
-		if err != nil {
-			return layer, handleError("searchLayerNamespace", err)
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var pn database.Namespace
-
-			err = rows.Scan(&pn.ID, &pn.Name, &pn.Version)
-			if err != nil {
-				return layer, handleError("searchLayerNamespace.Scan()", err)
-			}
-			layer.Parent.Namespaces = append(layer.Parent.Namespaces, pn)
-		}
-		if err = rows.Err(); err != nil {
-			return layer, handleError("searchLayerNamespace.Rows()", err)
-		}
 	}
 
 	// Find its namespaces

--- a/database/pgsql/layer_test.go
+++ b/database/pgsql/layer_test.go
@@ -33,13 +33,17 @@ func TestFindLayer(t *testing.T) {
 	}
 	defer datastore.Close()
 
+	testDebian7 := database.Namespace{
+		Name:    "debian",
+		Version: types.NewVersionUnsafe("7"),
+	}
 	// Layer-0: no parent, no namespace, no feature, no vulnerability
 	layer, err := datastore.FindLayer("layer-0", false, false)
 	if assert.Nil(t, err) && assert.NotNil(t, layer) {
 		assert.Equal(t, "layer-0", layer.Name)
-		assert.Nil(t, layer.Namespace)
 		assert.Nil(t, layer.Parent)
 		assert.Equal(t, 1, layer.EngineVersion)
+		assert.Len(t, layer.Namespaces, 0)
 		assert.Len(t, layer.Features, 0)
 	}
 
@@ -52,18 +56,19 @@ func TestFindLayer(t *testing.T) {
 	layer, err = datastore.FindLayer("layer-1", false, false)
 	if assert.Nil(t, err) && assert.NotNil(t, layer) {
 		assert.Equal(t, layer.Name, "layer-1")
-		assert.Equal(t, "debian:7", layer.Namespace.Name)
 		if assert.NotNil(t, layer.Parent) {
 			assert.Equal(t, "layer-0", layer.Parent.Name)
 		}
 		assert.Equal(t, 1, layer.EngineVersion)
+		assert.Len(t, layer.Namespaces, 1)
+		assert.True(t, testDebian7.Equal(layer.Namespaces[0]))
 		assert.Len(t, layer.Features, 0)
 	}
 
 	layer, err = datastore.FindLayer("layer-1", true, false)
 	if assert.Nil(t, err) && assert.NotNil(t, layer) && assert.Len(t, layer.Features, 2) {
 		for _, featureVersion := range layer.Features {
-			assert.Equal(t, "debian:7", featureVersion.Feature.Namespace.Name)
+			assert.True(t, testDebian7.Equal(featureVersion.Feature.Namespace))
 
 			switch featureVersion.Feature.Name {
 			case "wechat":
@@ -79,7 +84,7 @@ func TestFindLayer(t *testing.T) {
 	layer, err = datastore.FindLayer("layer-1", true, true)
 	if assert.Nil(t, err) && assert.NotNil(t, layer) && assert.Len(t, layer.Features, 2) {
 		for _, featureVersion := range layer.Features {
-			assert.Equal(t, "debian:7", featureVersion.Feature.Namespace.Name)
+			assert.True(t, testDebian7.Equal(featureVersion.Feature.Namespace))
 
 			switch featureVersion.Feature.Name {
 			case "wechat":
@@ -88,7 +93,7 @@ func TestFindLayer(t *testing.T) {
 				assert.Equal(t, types.NewVersionUnsafe("1.0"), featureVersion.Version)
 
 				if assert.Len(t, featureVersion.AffectedBy, 1) {
-					assert.Equal(t, "debian:7", featureVersion.AffectedBy[0].Namespace.Name)
+					assert.True(t, testDebian7.Equal(featureVersion.AffectedBy[0].Namespace))
 					assert.Equal(t, "CVE-OPENSSL-1-DEB7", featureVersion.AffectedBy[0].Name)
 					assert.Equal(t, types.High, featureVersion.AffectedBy[0].Severity)
 					assert.Equal(t, "A vulnerability affecting OpenSSL < 2.0 on Debian 7.0", featureVersion.AffectedBy[0].Description)
@@ -137,44 +142,56 @@ func testInsertLayerInvalid(t *testing.T, datastore database.Datastore) {
 }
 
 func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
+	testInsertLayerNamespace1 := database.Namespace{
+		Name:    "TestInsertLayerNamespace",
+		Version: types.NewVersionUnsafe("1"),
+	}
+	testInsertLayerNamespace2 := database.Namespace{
+		Name:    "TestInsertLayerNamespace",
+		Version: types.NewVersionUnsafe("2"),
+	}
+	testInsertLayerNamespace3 := database.Namespace{
+		Name:    "TestInsertLayerNamespace",
+		Version: types.NewVersionUnsafe("3"),
+	}
 	f1 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace2"},
+			Namespace: testInsertLayerNamespace2,
 			Name:      "TestInsertLayerFeature1",
 		},
 		Version: types.NewVersionUnsafe("1.0"),
 	}
 	f2 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace2"},
+			Namespace: testInsertLayerNamespace2,
 			Name:      "TestInsertLayerFeature2",
 		},
 		Version: types.NewVersionUnsafe("0.34"),
 	}
 	f3 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace2"},
+			Namespace: testInsertLayerNamespace2,
 			Name:      "TestInsertLayerFeature3",
 		},
 		Version: types.NewVersionUnsafe("0.56"),
 	}
 	f4 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace3"},
+			Namespace: testInsertLayerNamespace3,
 			Name:      "TestInsertLayerFeature2",
 		},
 		Version: types.NewVersionUnsafe("0.34"),
 	}
 	f5 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace3"},
+			Namespace: testInsertLayerNamespace3,
 			Name:      "TestInsertLayerFeature3",
 		},
 		Version: types.NewVersionUnsafe("0.56"),
 	}
 	f6 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace3"},
+			Namespace: testInsertLayerNamespace3,
 			Name:      "TestInsertLayerFeature4",
 		},
 		Version: types.NewVersionUnsafe("0.666"),
@@ -185,16 +202,16 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 			Name: "TestInsertLayer1",
 		},
 		{
-			Name:      "TestInsertLayer2",
-			Parent:    &database.Layer{Name: "TestInsertLayer1"},
-			Namespace: &database.Namespace{Name: "TestInsertLayerNamespace1"},
+			Name:       "TestInsertLayer2",
+			Parent:     &database.Layer{Name: "TestInsertLayer1"},
+			Namespaces: []database.Namespace{testInsertLayerNamespace1},
 		},
 		// This layer changes the namespace and adds Features.
 		{
-			Name:      "TestInsertLayer3",
-			Parent:    &database.Layer{Name: "TestInsertLayer2"},
-			Namespace: &database.Namespace{Name: "TestInsertLayerNamespace2"},
-			Features:  []database.FeatureVersion{f1, f2, f3},
+			Name:       "TestInsertLayer3",
+			Parent:     &database.Layer{Name: "TestInsertLayer2"},
+			Namespaces: []database.Namespace{testInsertLayerNamespace2},
+			Features:   []database.FeatureVersion{f1, f2, f3},
 		},
 		// This layer covers the case where the last layer doesn't provide any new Feature.
 		{
@@ -206,9 +223,9 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 		// It also modifies the Namespace ("upgrade") but keeps some Features not upgraded, their
 		// Namespaces should then remain unchanged.
 		{
-			Name:      "TestInsertLayer4b",
-			Parent:    &database.Layer{Name: "TestInsertLayer3"},
-			Namespace: &database.Namespace{Name: "TestInsertLayerNamespace3"},
+			Name:       "TestInsertLayer4b",
+			Parent:     &database.Layer{Name: "TestInsertLayer3"},
+			Namespaces: []database.Namespace{testInsertLayerNamespace3},
 			Features: []database.FeatureVersion{
 				// Deletes TestInsertLayerFeature1.
 				// Keep TestInsertLayerFeature2 (old Namespace should be kept):
@@ -238,8 +255,8 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 	}
 
 	l4a := retrievedLayers["TestInsertLayer4a"]
-	if assert.NotNil(t, l4a.Namespace) {
-		assert.Equal(t, "TestInsertLayerNamespace2", l4a.Namespace.Name)
+	if assert.Len(t, l4a.Namespaces, 1) {
+		assert.True(t, testInsertLayerNamespace2.Equal(l4a.Namespaces[0]))
 	}
 	assert.Len(t, l4a.Features, 3)
 	for _, featureVersion := range l4a.Features {
@@ -249,8 +266,8 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 	}
 
 	l4b := retrievedLayers["TestInsertLayer4b"]
-	if assert.NotNil(t, l4b.Namespace) {
-		assert.Equal(t, "TestInsertLayerNamespace3", l4b.Namespace.Name)
+	if assert.Len(t, l4b.Namespaces, 1) {
+		assert.True(t, testInsertLayerNamespace3.Equal(l4b.Namespaces[0]))
 	}
 	assert.Len(t, l4b.Features, 3)
 	for _, featureVersion := range l4b.Features {
@@ -261,9 +278,17 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 }
 
 func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
+	testInsertLayerNamespace3 := database.Namespace{
+		Name:    "TestInsertLayerNamespace",
+		Version: types.NewVersionUnsafe("3"),
+	}
+	testInsertLayerNamespaceUpdated1 := database.Namespace{
+		Name:    "TestInsertLayerNamespaceUpdated",
+		Version: types.NewVersionUnsafe("1"),
+	}
 	f7 := database.FeatureVersion{
 		Feature: database.Feature{
-			Namespace: database.Namespace{Name: "TestInsertLayerNamespace3"},
+			Namespace: testInsertLayerNamespace3,
 			Name:      "TestInsertLayerFeature7",
 		},
 		Version: types.NewVersionUnsafe("0.01"),
@@ -271,10 +296,10 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 
 	l3, _ := datastore.FindLayer("TestInsertLayer3", true, false)
 	l3u := database.Layer{
-		Name:      l3.Name,
-		Parent:    l3.Parent,
-		Namespace: &database.Namespace{Name: "TestInsertLayerNamespaceUpdated1"},
-		Features:  []database.FeatureVersion{f7},
+		Name:       l3.Name,
+		Parent:     l3.Parent,
+		Namespaces: []database.Namespace{testInsertLayerNamespaceUpdated1},
+		Features:   []database.FeatureVersion{f7},
 	}
 
 	l4u := database.Layer{
@@ -290,7 +315,9 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 
 	l3uf, err := datastore.FindLayer(l3u.Name, true, false)
 	if assert.Nil(t, err) {
-		assert.Equal(t, l3.Namespace.Name, l3uf.Namespace.Name)
+		if assert.Len(t, l3.Namespaces, 1) && assert.Len(t, l3uf.Namespaces, 1) {
+			assert.True(t, l3.Namespaces[0].Equal(l3uf.Namespaces[0]))
+		}
 		assert.Equal(t, l3.EngineVersion, l3uf.EngineVersion)
 		assert.Len(t, l3uf.Features, len(l3.Features))
 	}
@@ -303,7 +330,9 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 
 	l3uf, err = datastore.FindLayer(l3u.Name, true, false)
 	if assert.Nil(t, err) {
-		assert.Equal(t, l3u.Namespace.Name, l3uf.Namespace.Name)
+		if assert.Len(t, l3u.Namespaces, 1) && assert.Len(t, l3uf.Namespaces, 2) {
+			assert.True(t, containNS(l3uf.Namespaces, l3u.Namespaces[0]), "Updated layer should have %#v", l3u.Namespaces[0])
+		}
 		assert.Equal(t, l3u.EngineVersion, l3uf.EngineVersion)
 		if assert.Len(t, l3uf.Features, 1) {
 			assert.True(t, cmpFV(l3uf.Features[0], f7), "Updated layer should have %#v but actually have %#v", f7, l3uf.Features[0])
@@ -319,7 +348,9 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 
 	l4uf, err := datastore.FindLayer(l3u.Name, true, false)
 	if assert.Nil(t, err) {
-		assert.Equal(t, l3u.Namespace.Name, l4uf.Namespace.Name)
+		if assert.Len(t, l3u.Namespaces, 1) && assert.Len(t, l4uf.Namespaces, 2) {
+			assert.True(t, containNS(l4uf.Namespaces, l3u.Namespaces[0]), "Updated layer should have %#v", l3u.Namespaces[0])
+		}
 		assert.Equal(t, l4u.EngineVersion, l4uf.EngineVersion)
 		if assert.Len(t, l4uf.Features, 1) {
 			assert.True(t, cmpFV(l3uf.Features[0], f7), "Updated layer should have %#v but actually have %#v", f7, l4uf.Features[0])
@@ -348,4 +379,13 @@ func cmpFV(a, b database.FeatureVersion) bool {
 	return a.Feature.Name == b.Feature.Name &&
 		a.Feature.Namespace.Name == b.Feature.Namespace.Name &&
 		a.Version.String() == b.Version.String()
+}
+
+func containNS(namespaces []database.Namespace, namespace database.Namespace) bool {
+	for _, n := range namespaces {
+		if n.Equal(namespace) {
+			return true
+		}
+	}
+	return false
 }

--- a/database/pgsql/layer_test.go
+++ b/database/pgsql/layer_test.go
@@ -208,23 +208,29 @@ func testInsertLayerTree(t *testing.T, datastore database.Datastore) {
 		},
 		// This layer changes the namespace and adds Features.
 		{
-			Name:       "TestInsertLayer3",
-			Parent:     &database.Layer{Name: "TestInsertLayer2"},
+			Name: "TestInsertLayer3",
+			Parent: &database.Layer{Name: "TestInsertLayer2",
+				Namespaces: []database.Namespace{testInsertLayerNamespace1},
+			},
 			Namespaces: []database.Namespace{testInsertLayerNamespace2},
 			Features:   []database.FeatureVersion{f1, f2, f3},
 		},
 		// This layer covers the case where the last layer doesn't provide any new Feature.
 		{
-			Name:     "TestInsertLayer4a",
-			Parent:   &database.Layer{Name: "TestInsertLayer3"},
+			Name: "TestInsertLayer4a",
+			Parent: &database.Layer{Name: "TestInsertLayer3",
+				Namespaces: []database.Namespace{testInsertLayerNamespace1, testInsertLayerNamespace2},
+			},
 			Features: []database.FeatureVersion{f1, f2, f3},
 		},
 		// This layer covers the case where the last layer provides Features.
 		// It also modifies the Namespace ("upgrade") but keeps some Features not upgraded, their
 		// Namespaces should then remain unchanged.
 		{
-			Name:       "TestInsertLayer4b",
-			Parent:     &database.Layer{Name: "TestInsertLayer3"},
+			Name: "TestInsertLayer4b",
+			Parent: &database.Layer{Name: "TestInsertLayer3",
+				Namespaces: []database.Namespace{testInsertLayerNamespace1, testInsertLayerNamespace2},
+			},
 			Namespaces: []database.Namespace{testInsertLayerNamespace3},
 			Features: []database.FeatureVersion{
 				// Deletes TestInsertLayerFeature1.
@@ -295,6 +301,8 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 	}
 
 	l3, _ := datastore.FindLayer("TestInsertLayer3", true, false)
+	l3Parent, _ := datastore.FindLayer(l3.Parent.Name, false, false)
+	l3.Parent = &l3Parent
 	l3u := database.Layer{
 		Name:       l3.Name,
 		Parent:     l3.Parent,
@@ -304,7 +312,7 @@ func testInsertLayerUpdate(t *testing.T, datastore database.Datastore) {
 
 	l4u := database.Layer{
 		Name:          "TestInsertLayer4",
-		Parent:        &database.Layer{Name: "TestInsertLayer3"},
+		Parent:        &database.Layer{Name: "TestInsertLayer3", Namespaces: l3.Namespaces},
 		Features:      []database.FeatureVersion{f7},
 		EngineVersion: 2,
 	}

--- a/database/pgsql/migrations/20151222113213_Initial.sql
+++ b/database/pgsql/migrations/20151222113213_Initial.sql
@@ -172,3 +172,8 @@ DROP TABLE IF EXISTS Namespace,
                      KeyValue,
                      Lock
             CASCADE;
+
+DROP TYPE IF EXISTS modification,
+                    severity
+            CASCADE;
+

--- a/database/pgsql/migrations/20160524162211_multiple_namespace.sql
+++ b/database/pgsql/migrations/20160524162211_multiple_namespace.sql
@@ -1,0 +1,66 @@
+-- Copyright 2015 clair authors
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- +goose Up
+
+-- -----------------------------------------------------
+-- Namespace table and data
+-- -----------------------------------------------------
+ALTER TABLE Namespace ADD version VARCHAR(128) NULL;
+UPDATE Namespace SET version = split_part(Namespace.Name, ':', 2), name = split_part(Namespace.Name,':', 1);
+
+-- -----------------------------------------------------
+-- LayerNamespace table and data
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS LayerNamespace (
+        id SERIAL PRIMARY KEY,
+	layer_id INT NOT NULL REFERENCES Layer ON DELETE CASCADE,
+        namespace_id INT NOT NULL REFERENCES Namespace ON DELETE CASCADE,
+        UNIQUE (layer_id, namespace_id));
+CREATE INDEX ON LayerNamespace (layer_id);
+CREATE INDEX ON LayerNamespace (layer_id, namespace_id);
+
+INSERT INTO LayerNamespace(layer_id, namespace_id) 
+	SELECT id, namespace_id
+	from Layer;
+
+-- -----------------------------------------------------
+-- Layer table
+-- -----------------------------------------------------
+ALTER TABLE Layer DROP COLUMN namespace_id;
+
+-- +goose Down
+
+-- -----------------------------------------------------
+-- Layer table and data
+-- -----------------------------------------------------
+ALTER TABLE Layer ADD namespace_id INT NULL REFERENCES Namespace;
+                          CREATE INDEX ON Layer (namespace_id);
+
+UPDATE Layer l SET namespace_id = 
+(SELECT namespace_id from LayerNamespace ln
+WHERE l.id = ln.layer_id LIMIT 1);
+
+-- -----------------------------------------------------
+-- LayerNamespace table (and data)
+-- -----------------------------------------------------
+DROP TABLE IF EXISTS LayerNamespace
+            CASCADE;
+
+-- -----------------------------------------------------
+-- LayerNamespace data and table
+-- -----------------------------------------------------
+UPDATE Namespace n SET name = concat(n.name, ':',  n.version);
+
+ALTER TABLE Namespace DROP COLUMN version;

--- a/database/pgsql/migrations/20160524162211_multiple_namespace.sql
+++ b/database/pgsql/migrations/20160524162211_multiple_namespace.sql
@@ -1,4 +1,4 @@
--- Copyright 2015 clair authors
+-- Copyright 2016 clair authors
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ CREATE INDEX ON LayerNamespace (layer_id, namespace_id);
 
 INSERT INTO LayerNamespace(layer_id, namespace_id) 
 	SELECT id, namespace_id
-	from Layer;
+	from Layer WHERE namespace_id IS NOT NULL;
 
 -- -----------------------------------------------------
 -- Layer table

--- a/database/pgsql/namespace_test.go
+++ b/database/pgsql/namespace_test.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInsertNamespace(t *testing.T) {
@@ -37,9 +37,9 @@ func TestInsertNamespace(t *testing.T) {
 	assert.Zero(t, id0)
 
 	// Insert Namespace and ensure we can find it.
-	id1, err := datastore.insertNamespace(database.Namespace{Name: "TestInsertNamespace1"})
+	id1, err := datastore.insertNamespace(database.Namespace{Name: "TestInsertNamespace", Version: types.NewVersionUnsafe("1")})
 	assert.Nil(t, err)
-	id2, err := datastore.insertNamespace(database.Namespace{Name: "TestInsertNamespace1"})
+	id2, err := datastore.insertNamespace(database.Namespace{Name: "TestInsertNamespace", Version: types.NewVersionUnsafe("1")})
 	assert.Nil(t, err)
 	assert.Equal(t, id1, id2)
 }
@@ -55,12 +55,13 @@ func TestListNamespace(t *testing.T) {
 	namespaces, err := datastore.ListNamespaces()
 	assert.Nil(t, err)
 	if assert.Len(t, namespaces, 2) {
+		testDebian7 := database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("7")}
+		testDebian8 := database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")}
 		for _, namespace := range namespaces {
-			switch namespace.Name {
-			case "debian:7", "debian:8":
+			if namespace.Equal(testDebian7) || namespace.Equal(testDebian8) {
 				continue
-			default:
-				assert.Error(t, fmt.Errorf("ListNamespaces should not have returned '%s'", namespace.Name))
+			} else {
+				assert.Error(t, fmt.Errorf("ListNamespaces should not have returned '%s:%s'", namespace.Name, namespace.Version.String()))
 			}
 		}
 	}

--- a/database/pgsql/notification_test.go
+++ b/database/pgsql/notification_test.go
@@ -39,13 +39,19 @@ func TestNotification(t *testing.T) {
 
 	// Create some data.
 	f1 := database.Feature{
-		Name:      "TestNotificationFeature1",
-		Namespace: database.Namespace{Name: "TestNotificationNamespace1"},
+		Name: "TestNotificationFeature1",
+		Namespace: database.Namespace{
+			Name:    "TestNotificationNamespace",
+			Version: types.NewVersionUnsafe("1.0"),
+		},
 	}
 
 	f2 := database.Feature{
-		Name:      "TestNotificationFeature2",
-		Namespace: database.Namespace{Name: "TestNotificationNamespace1"},
+		Name: "TestNotificationFeature2",
+		Namespace: database.Namespace{
+			Name:    "TestNotificationNamespace",
+			Version: types.NewVersionUnsafe("1.0"),
+		},
 	}
 
 	l1 := database.Layer{
@@ -201,7 +207,7 @@ func TestNotification(t *testing.T) {
 	}
 
 	// Delete a vulnerability and verify the notification.
-	if assert.Nil(t, datastore.DeleteVulnerability(v1b.Namespace.Name, v1b.Name)) {
+	if assert.Nil(t, datastore.DeleteVulnerability(v1b.Namespace, v1b.Name)) {
 		notification, err = datastore.GetAvailableNotification(time.Second)
 		assert.Nil(t, err)
 		assert.NotEmpty(t, notification.Name)

--- a/database/pgsql/notification_test.go
+++ b/database/pgsql/notification_test.go
@@ -118,7 +118,8 @@ func TestNotification(t *testing.T) {
 	assert.Nil(t, datastore.insertVulnerability(v1, false, true))
 
 	// Get the notification associated to the previously inserted vulnerability.
-	notification, err := datastore.GetAvailableNotification(time.Second)
+	var notification database.VulnerabilityNotification
+	notification, err = datastore.GetAvailableNotification(time.Second)
 
 	if assert.Nil(t, err) && assert.NotEmpty(t, notification.Name) {
 		// Verify the renotify behaviour.
@@ -206,8 +207,12 @@ func TestNotification(t *testing.T) {
 		}
 	}
 
+	namespaceID, err := datastore.GetNamespaceID(database.Namespace{
+		Name:    "TestNotificationNamespace",
+		Version: types.NewVersionUnsafe("1.0"),
+	})
 	// Delete a vulnerability and verify the notification.
-	if assert.Nil(t, datastore.DeleteVulnerability(v1b.Namespace, v1b.Name)) {
+	if assert.Nil(t, err) && assert.Nil(t, datastore.DeleteVulnerability(namespaceID, v1b.Name)) {
 		notification, err = datastore.GetAvailableNotification(time.Second)
 		assert.Nil(t, err)
 		assert.NotEmpty(t, notification.Name)

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -37,9 +37,9 @@ const (
 		SELECT id FROM Namespace WHERE name = $1 AND version = $2
 		UNION
 		SELECT id FROM new_namespace`
-
-	searchNamespace = `SELECT id FROM Namespace WHERE name = $1 AND version = $2`
-	listNamespace   = `SELECT id, name, version FROM Namespace`
+	getNamespaceID   = `SELECT id FROM Namespace WHERE name = $1 AND version = $2`
+	listNamespace    = `SELECT id, name, version FROM Namespace where version IS NOT NULL`
+	getNamespaceByID = `SELECT name, version FROM Namespace WHERE id = $1`
 
 	// feature.go
 	soiFeature = `
@@ -161,10 +161,10 @@ const (
 	searchVulnerabilityBase = `
 	  SELECT v.id, v.name, n.id, n.name, n.version, v.description, v.link, v.severity, v.metadata
 	  FROM Vulnerability v JOIN Namespace n ON v.namespace_id = n.id`
-	searchVulnerabilityForUpdate          = ` FOR UPDATE OF v`
-	searchVulnerabilityByNamespaceAndName = ` WHERE n.name = $1 AND n.version = $2 AND v.name = $3 AND v.deleted_at IS NULL`
-	searchVulnerabilityByID               = ` WHERE v.id = $1`
-	searchVulnerabilityByNamespaceID      = ` WHERE n.id = $1 AND v.deleted_at IS NULL
+	searchVulnerabilityForUpdate            = ` FOR UPDATE OF v`
+	searchVulnerabilityByNamespaceIDAndName = ` WHERE n.id = $1 AND v.name = $2 AND v.deleted_at IS NULL`
+	searchVulnerabilityByID                 = ` WHERE v.id = $1`
+	searchVulnerabilityByNamespaceID        = ` WHERE n.id = $1 AND v.deleted_at IS NULL
 		  				  AND v.id >= $2
 						  ORDER BY v.id
 						  LIMIT $3`
@@ -189,8 +189,8 @@ const (
 	removeVulnerability = `
 		UPDATE Vulnerability
     SET deleted_at = CURRENT_TIMESTAMP
-    WHERE namespace_id = (SELECT id FROM Namespace WHERE name = $1 AND version = $2)
-          AND name = $3
+    WHERE namespace_id = $1
+          AND name = $2
           AND deleted_at IS NULL
     RETURNING id`
 

--- a/database/pgsql/testdata/data.sql
+++ b/database/pgsql/testdata/data.sql
@@ -12,9 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-INSERT INTO namespace (id, name) VALUES
-  (1, 'debian:7'),
-  (2, 'debian:8');
+INSERT INTO namespace (id, name, version) VALUES
+  (1, 'debian', '7'),
+  (2, 'debian', '8');
 
 INSERT INTO feature (id, namespace_id, name) VALUES
   (1, 1, 'wechat'),
@@ -28,12 +28,18 @@ INSERT INTO featureversion (id, feature_id, version) VALUES
   (3, 2, '2.0'),
   (4, 3, '1.0');
 
-INSERT INTO layer (id, name, engineversion, parent_id, namespace_id) VALUES
-  (1, 'layer-0', 1, NULL, NULL),
-  (2, 'layer-1', 1, 1, 1),
-  (3, 'layer-2', 1, 2, 1),
-  (4, 'layer-3a', 1, 3, 1),
-  (5, 'layer-3b', 1, 3, 2);
+INSERT INTO layer (id, name, engineversion, parent_id) VALUES
+  (1, 'layer-0', 1, NULL),
+  (2, 'layer-1', 1, 1),
+  (3, 'layer-2', 1, 2),
+  (4, 'layer-3a', 1, 3),
+  (5, 'layer-3b', 1, 3);
+
+INSERT INTO layernamespace (id, layer_id, namespace_id) VALUES
+  (1, 2, 1),
+  (2, 3, 1),
+  (3, 4, 1),
+  (4, 5, 2);
 
 INSERT INTO layer_diff_featureversion (id, layer_id, featureversion_id, modification) VALUES
   (1, 2, 1, 'add'),
@@ -58,6 +64,7 @@ SELECT pg_catalog.setval(pg_get_serial_sequence('namespace', 'id'), (SELECT MAX(
 SELECT pg_catalog.setval(pg_get_serial_sequence('feature', 'id'), (SELECT MAX(id) FROM feature)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('featureversion', 'id'), (SELECT MAX(id) FROM featureversion)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('layer', 'id'), (SELECT MAX(id) FROM layer)+1);
+SELECT pg_catalog.setval(pg_get_serial_sequence('layernamespace', 'id'), (SELECT MAX(id) FROM layernamespace)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('layer_diff_featureversion', 'id'), (SELECT MAX(id) FROM layer_diff_featureversion)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('vulnerability', 'id'), (SELECT MAX(id) FROM vulnerability)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('vulnerability_fixedin_feature', 'id'), (SELECT MAX(id) FROM vulnerability_fixedin_feature)+1);

--- a/database/pgsql/vulnerability.go
+++ b/database/pgsql/vulnerability.go
@@ -28,12 +28,12 @@ import (
 	"github.com/guregu/null/zero"
 )
 
-func (pgSQL *pgSQL) ListVulnerabilities(namespaceName string, limit int, startID int) ([]database.Vulnerability, int, error) {
+func (pgSQL *pgSQL) ListVulnerabilities(namespace database.Namespace, limit int, startID int) ([]database.Vulnerability, int, error) {
 	defer observeQueryTime("listVulnerabilities", "all", time.Now())
 
 	// Query Namespace.
 	var id int
-	err := pgSQL.QueryRow(searchNamespace, namespaceName).Scan(&id)
+	err := pgSQL.QueryRow(searchNamespace, namespace.Name, &namespace.Version).Scan(&id)
 	if err != nil {
 		return nil, -1, handleError("searchNamespace", err)
 	} else if id == 0 {
@@ -41,10 +41,10 @@ func (pgSQL *pgSQL) ListVulnerabilities(namespaceName string, limit int, startID
 	}
 
 	// Query.
-	query := searchVulnerabilityBase + searchVulnerabilityByNamespace
-	rows, err := pgSQL.Query(query, namespaceName, startID, limit+1)
+	query := searchVulnerabilityBase + searchVulnerabilityByNamespaceID
+	rows, err := pgSQL.Query(query, id, startID, limit+1)
 	if err != nil {
-		return nil, -1, handleError("searchVulnerabilityByNamespace", err)
+		return nil, -1, handleError("searchVulnerabilityByNamespaceID", err)
 	}
 	defer rows.Close()
 
@@ -60,6 +60,7 @@ func (pgSQL *pgSQL) ListVulnerabilities(namespaceName string, limit int, startID
 			&vulnerability.Name,
 			&vulnerability.Namespace.ID,
 			&vulnerability.Namespace.Name,
+			&vulnerability.Namespace.Version,
 			&vulnerability.Description,
 			&vulnerability.Link,
 			&vulnerability.Severity,
@@ -83,11 +84,11 @@ func (pgSQL *pgSQL) ListVulnerabilities(namespaceName string, limit int, startID
 	return vulns, nextID, nil
 }
 
-func (pgSQL *pgSQL) FindVulnerability(namespaceName, name string) (database.Vulnerability, error) {
-	return findVulnerability(pgSQL, namespaceName, name, false)
+func (pgSQL *pgSQL) FindVulnerability(namespace database.Namespace, name string) (database.Vulnerability, error) {
+	return findVulnerability(pgSQL, namespace, name, false)
 }
 
-func findVulnerability(queryer Queryer, namespaceName, name string, forUpdate bool) (database.Vulnerability, error) {
+func findVulnerability(queryer Queryer, namespace database.Namespace, name string, forUpdate bool) (database.Vulnerability, error) {
 	defer observeQueryTime("findVulnerability", "all", time.Now())
 
 	queryName := "searchVulnerabilityBase+searchVulnerabilityByNamespaceAndName"
@@ -97,7 +98,7 @@ func findVulnerability(queryer Queryer, namespaceName, name string, forUpdate bo
 		query = query + searchVulnerabilityForUpdate
 	}
 
-	return scanVulnerability(queryer, queryName, queryer.QueryRow(query, namespaceName, name))
+	return scanVulnerability(queryer, queryName, queryer.QueryRow(query, namespace.Name, &namespace.Version, name))
 }
 
 func (pgSQL *pgSQL) findVulnerabilityByIDWithDeleted(id int) (database.Vulnerability, error) {
@@ -117,6 +118,7 @@ func scanVulnerability(queryer Queryer, queryName string, vulnerabilityRow *sql.
 		&vulnerability.Name,
 		&vulnerability.Namespace.ID,
 		&vulnerability.Namespace.Name,
+		&vulnerability.Namespace.Version,
 		&vulnerability.Description,
 		&vulnerability.Link,
 		&vulnerability.Severity,
@@ -193,7 +195,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	tf := time.Now()
 
 	// Verify parameters
-	if vulnerability.Name == "" || vulnerability.Namespace.Name == "" {
+	if vulnerability.Name == "" || vulnerability.Namespace.IsEmpty() {
 		return cerrors.NewBadRequestError("insertVulnerability needs at least the Name and the Namespace")
 	}
 	if !onlyFixedIn && !vulnerability.Severity.IsValid() {
@@ -204,11 +206,12 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	for i := 0; i < len(vulnerability.FixedIn); i++ {
 		fifv := &vulnerability.FixedIn[i]
 
-		if fifv.Feature.Namespace.Name == "" {
+		if fifv.Feature.Namespace.IsEmpty() {
 			// As there is no Namespace on that FixedIn FeatureVersion, set it to the Vulnerability's
 			// Namespace.
 			fifv.Feature.Namespace.Name = vulnerability.Namespace.Name
-		} else if fifv.Feature.Namespace.Name != vulnerability.Namespace.Name {
+			fifv.Feature.Namespace.Version = vulnerability.Namespace.Version
+		} else if !fifv.Feature.Namespace.Equal(vulnerability.Namespace) {
 			msg := "could not insert an invalid vulnerability that contains FixedIn FeatureVersion that are not in the same namespace as the Vulnerability"
 			log.Warning(msg)
 			return cerrors.NewBadRequestError(msg)
@@ -226,7 +229,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	}
 
 	// Find existing vulnerability and its Vulnerability_FixedIn_Features (for update).
-	existingVulnerability, err := findVulnerability(tx, vulnerability.Namespace.Name, vulnerability.Name, true)
+	existingVulnerability, err := findVulnerability(tx, vulnerability.Namespace, vulnerability.Name, true)
 	if err != nil && err != cerrors.ErrNotFound {
 		tx.Rollback()
 		return err
@@ -264,7 +267,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 		}
 
 		// Mark the old vulnerability as non latest.
-		_, err = tx.Exec(removeVulnerability, vulnerability.Namespace.Name, vulnerability.Name)
+		_, err = tx.Exec(removeVulnerability, vulnerability.Namespace.Name, &vulnerability.Namespace.Version, vulnerability.Name)
 		if err != nil {
 			tx.Rollback()
 			return handleError("removeVulnerability", err)
@@ -497,13 +500,14 @@ func linkVulnerabilityToFeatureVersions(tx *sql.Tx, fixedInID, vulnerabilityID, 
 	return nil
 }
 
-func (pgSQL *pgSQL) InsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabilityName string, fixes []database.FeatureVersion) error {
+func (pgSQL *pgSQL) InsertVulnerabilityFixes(vulnerabilityNamespace database.Namespace, vulnerabilityName string, fixes []database.FeatureVersion) error {
 	defer observeQueryTime("InsertVulnerabilityFixes", "all", time.Now())
 
 	v := database.Vulnerability{
 		Name: vulnerabilityName,
 		Namespace: database.Namespace{
-			Name: vulnerabilityNamespace,
+			Name:    vulnerabilityNamespace.Name,
+			Version: vulnerabilityNamespace.Version,
 		},
 		FixedIn: fixes,
 	}
@@ -511,20 +515,22 @@ func (pgSQL *pgSQL) InsertVulnerabilityFixes(vulnerabilityNamespace, vulnerabili
 	return pgSQL.insertVulnerability(v, true, true)
 }
 
-func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespace, vulnerabilityName, featureName string) error {
+func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespace database.Namespace, vulnerabilityName, featureName string) error {
 	defer observeQueryTime("DeleteVulnerabilityFix", "all", time.Now())
 
 	v := database.Vulnerability{
 		Name: vulnerabilityName,
 		Namespace: database.Namespace{
-			Name: vulnerabilityNamespace,
+			Name:    vulnerabilityNamespace.Name,
+			Version: vulnerabilityNamespace.Version,
 		},
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
 					Name: featureName,
 					Namespace: database.Namespace{
-						Name: vulnerabilityNamespace,
+						Name:    vulnerabilityNamespace.Name,
+						Version: vulnerabilityNamespace.Version,
 					},
 				},
 				Version: types.MinVersion,
@@ -535,7 +541,7 @@ func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespace, vulnerability
 	return pgSQL.insertVulnerability(v, true, true)
 }
 
-func (pgSQL *pgSQL) DeleteVulnerability(namespaceName, name string) error {
+func (pgSQL *pgSQL) DeleteVulnerability(namespace database.Namespace, name string) error {
 	defer observeQueryTime("DeleteVulnerability", "all", time.Now())
 
 	// Begin transaction.
@@ -546,7 +552,7 @@ func (pgSQL *pgSQL) DeleteVulnerability(namespaceName, name string) error {
 	}
 
 	var vulnerabilityID int
-	err = tx.QueryRow(removeVulnerability, namespaceName, name).Scan(&vulnerabilityID)
+	err = tx.QueryRow(removeVulnerability, namespace.Name, &namespace.Version, name).Scan(&vulnerabilityID)
 	if err != nil {
 		tx.Rollback()
 		return handleError("removeVulnerability", err)

--- a/database/pgsql/vulnerability.go
+++ b/database/pgsql/vulnerability.go
@@ -28,21 +28,12 @@ import (
 	"github.com/guregu/null/zero"
 )
 
-func (pgSQL *pgSQL) ListVulnerabilities(namespace database.Namespace, limit int, startID int) ([]database.Vulnerability, int, error) {
+func (pgSQL *pgSQL) ListVulnerabilities(namespaceID int, limit int, startID int) ([]database.Vulnerability, int, error) {
 	defer observeQueryTime("listVulnerabilities", "all", time.Now())
-
-	// Query Namespace.
-	var id int
-	err := pgSQL.QueryRow(searchNamespace, namespace.Name, &namespace.Version).Scan(&id)
-	if err != nil {
-		return nil, -1, handleError("searchNamespace", err)
-	} else if id == 0 {
-		return nil, -1, cerrors.ErrNotFound
-	}
 
 	// Query.
 	query := searchVulnerabilityBase + searchVulnerabilityByNamespaceID
-	rows, err := pgSQL.Query(query, id, startID, limit+1)
+	rows, err := pgSQL.Query(query, namespaceID, startID, limit+1)
 	if err != nil {
 		return nil, -1, handleError("searchVulnerabilityByNamespaceID", err)
 	}
@@ -84,21 +75,21 @@ func (pgSQL *pgSQL) ListVulnerabilities(namespace database.Namespace, limit int,
 	return vulns, nextID, nil
 }
 
-func (pgSQL *pgSQL) FindVulnerability(namespace database.Namespace, name string) (database.Vulnerability, error) {
-	return findVulnerability(pgSQL, namespace, name, false)
+func (pgSQL *pgSQL) FindVulnerability(namespaceID int, name string) (database.Vulnerability, error) {
+	return findVulnerability(pgSQL, namespaceID, name, false)
 }
 
-func findVulnerability(queryer Queryer, namespace database.Namespace, name string, forUpdate bool) (database.Vulnerability, error) {
+func findVulnerability(queryer Queryer, namespaceID int, name string, forUpdate bool) (database.Vulnerability, error) {
 	defer observeQueryTime("findVulnerability", "all", time.Now())
 
-	queryName := "searchVulnerabilityBase+searchVulnerabilityByNamespaceAndName"
-	query := searchVulnerabilityBase + searchVulnerabilityByNamespaceAndName
+	queryName := "searchVulnerabilityBase+searchVulnerabilityByNamespaceIDAndName"
+	query := searchVulnerabilityBase + searchVulnerabilityByNamespaceIDAndName
 	if forUpdate {
 		queryName = queryName + "+searchVulnerabilityForUpdate"
 		query = query + searchVulnerabilityForUpdate
 	}
 
-	return scanVulnerability(queryer, queryName, queryer.QueryRow(query, namespace.Name, &namespace.Version, name))
+	return scanVulnerability(queryer, queryName, queryer.QueryRow(query, namespaceID, name))
 }
 
 func (pgSQL *pgSQL) findVulnerabilityByIDWithDeleted(id int) (database.Vulnerability, error) {
@@ -195,9 +186,24 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	tf := time.Now()
 
 	// Verify parameters
-	if vulnerability.Name == "" || vulnerability.Namespace.IsEmpty() {
-		return cerrors.NewBadRequestError("insertVulnerability needs at least the Name and the Namespace")
+	if vulnerability.Name == "" {
+		return cerrors.NewBadRequestError("insertVulnerability needs at least the Name")
 	}
+
+	if vulnerability.Namespace.ID <= 0 {
+		// Find or insert Vulnerability's Namespace.
+		namespaceID, err := pgSQL.insertNamespace(vulnerability.Namespace)
+		if err != nil {
+			return err
+		}
+		vulnerability.Namespace.ID = namespaceID
+	} else if vulnerability.Namespace.IsEmpty() {
+		err := pgSQL.QueryRow(getNamespaceByID, vulnerability.Namespace.ID).Scan(&vulnerability.Namespace.Name, &vulnerability.Namespace.Version)
+		if err != nil {
+			return cerrors.NewBadRequestError("could not get the related namespace")
+		}
+	}
+
 	if !onlyFixedIn && !vulnerability.Severity.IsValid() {
 		msg := fmt.Sprintf("could not insert a vulnerability that has an invalid Severity: %s", vulnerability.Severity)
 		log.Warning(msg)
@@ -209,8 +215,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 		if fifv.Feature.Namespace.IsEmpty() {
 			// As there is no Namespace on that FixedIn FeatureVersion, set it to the Vulnerability's
 			// Namespace.
-			fifv.Feature.Namespace.Name = vulnerability.Namespace.Name
-			fifv.Feature.Namespace.Version = vulnerability.Namespace.Version
+			fifv.Feature.Namespace = vulnerability.Namespace
 		} else if !fifv.Feature.Namespace.Equal(vulnerability.Namespace) {
 			msg := "could not insert an invalid vulnerability that contains FixedIn FeatureVersion that are not in the same namespace as the Vulnerability"
 			log.Warning(msg)
@@ -229,7 +234,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	}
 
 	// Find existing vulnerability and its Vulnerability_FixedIn_Features (for update).
-	existingVulnerability, err := findVulnerability(tx, vulnerability.Namespace, vulnerability.Name, true)
+	existingVulnerability, err := findVulnerability(tx, vulnerability.Namespace.ID, vulnerability.Name, true)
 	if err != nil && err != cerrors.ErrNotFound {
 		tx.Rollback()
 		return err
@@ -267,7 +272,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 		}
 
 		// Mark the old vulnerability as non latest.
-		_, err = tx.Exec(removeVulnerability, vulnerability.Namespace.Name, &vulnerability.Namespace.Version, vulnerability.Name)
+		_, err = tx.Exec(removeVulnerability, vulnerability.Namespace.ID, vulnerability.Name)
 		if err != nil {
 			tx.Rollback()
 			return handleError("removeVulnerability", err)
@@ -284,16 +289,10 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 		vulnerability.FixedIn = fixedIn
 	}
 
-	// Find or insert Vulnerability's Namespace.
-	namespaceID, err := pgSQL.insertNamespace(vulnerability.Namespace)
-	if err != nil {
-		return err
-	}
-
 	// Insert vulnerability.
 	err = tx.QueryRow(
 		insertVulnerability,
-		namespaceID,
+		vulnerability.Namespace.ID,
 		vulnerability.Name,
 		vulnerability.Description,
 		vulnerability.Link,
@@ -500,38 +499,41 @@ func linkVulnerabilityToFeatureVersions(tx *sql.Tx, fixedInID, vulnerabilityID, 
 	return nil
 }
 
-func (pgSQL *pgSQL) InsertVulnerabilityFixes(vulnerabilityNamespace database.Namespace, vulnerabilityName string, fixes []database.FeatureVersion) error {
+func (pgSQL *pgSQL) InsertVulnerabilityFixes(vulnerabilityNamespaceID int, vulnerabilityName string, fixes []database.FeatureVersion) error {
 	defer observeQueryTime("InsertVulnerabilityFixes", "all", time.Now())
 
+	var vns database.Namespace
+	if err := pgSQL.QueryRow(getNamespaceByID, vulnerabilityNamespaceID).Scan(&vns.Name, &vns.Version); err != nil {
+		return handleError("getNamespaceByID", err)
+	}
+	vns.ID = vulnerabilityNamespaceID
+
 	v := database.Vulnerability{
-		Name: vulnerabilityName,
-		Namespace: database.Namespace{
-			Name:    vulnerabilityNamespace.Name,
-			Version: vulnerabilityNamespace.Version,
-		},
-		FixedIn: fixes,
+		Name:      vulnerabilityName,
+		Namespace: vns,
+		FixedIn:   fixes,
 	}
 
 	return pgSQL.insertVulnerability(v, true, true)
 }
 
-func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespace database.Namespace, vulnerabilityName, featureName string) error {
+func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespaceID int, vulnerabilityName, featureName string) error {
 	defer observeQueryTime("DeleteVulnerabilityFix", "all", time.Now())
 
+	var vns database.Namespace
+	if err := pgSQL.QueryRow(getNamespaceByID, vulnerabilityNamespaceID).Scan(&vns.Name, &vns.Version); err != nil {
+		return handleError("getNamespaceByID", err)
+	}
+	vns.ID = vulnerabilityNamespaceID
+
 	v := database.Vulnerability{
-		Name: vulnerabilityName,
-		Namespace: database.Namespace{
-			Name:    vulnerabilityNamespace.Name,
-			Version: vulnerabilityNamespace.Version,
-		},
+		Name:      vulnerabilityName,
+		Namespace: vns,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{
-					Name: featureName,
-					Namespace: database.Namespace{
-						Name:    vulnerabilityNamespace.Name,
-						Version: vulnerabilityNamespace.Version,
-					},
+					Name:      featureName,
+					Namespace: vns,
 				},
 				Version: types.MinVersion,
 			},
@@ -541,7 +543,7 @@ func (pgSQL *pgSQL) DeleteVulnerabilityFix(vulnerabilityNamespace database.Names
 	return pgSQL.insertVulnerability(v, true, true)
 }
 
-func (pgSQL *pgSQL) DeleteVulnerability(namespace database.Namespace, name string) error {
+func (pgSQL *pgSQL) DeleteVulnerability(namespaceID int, name string) error {
 	defer observeQueryTime("DeleteVulnerability", "all", time.Now())
 
 	// Begin transaction.
@@ -552,7 +554,7 @@ func (pgSQL *pgSQL) DeleteVulnerability(namespace database.Namespace, name strin
 	}
 
 	var vulnerabilityID int
-	err = tx.QueryRow(removeVulnerability, namespace.Name, &namespace.Version, name).Scan(&vulnerabilityID)
+	err = tx.QueryRow(removeVulnerability, namespaceID, name).Scan(&vulnerabilityID)
 	if err != nil {
 		tx.Rollback()
 		return handleError("removeVulnerability", err)

--- a/database/pgsql/vulnerability_test.go
+++ b/database/pgsql/vulnerability_test.go
@@ -33,8 +33,12 @@ func TestFindVulnerability(t *testing.T) {
 	}
 	defer datastore.Close()
 
+	testExistNamespace := database.Namespace{
+		Name:    "debian",
+		Version: types.NewVersionUnsafe("7"),
+	}
 	// Find a vulnerability that does not exist.
-	_, err = datastore.FindVulnerability("", "")
+	_, err = datastore.FindVulnerability(database.Namespace{}, "")
 	assert.Equal(t, cerrors.ErrNotFound, err)
 
 	// Find a normal vulnerability.
@@ -43,7 +47,7 @@ func TestFindVulnerability(t *testing.T) {
 		Description: "A vulnerability affecting OpenSSL < 2.0 on Debian 7.0",
 		Link:        "http://google.com/#q=CVE-OPENSSL-1-DEB7",
 		Severity:    types.High,
-		Namespace:   database.Namespace{Name: "debian:7"},
+		Namespace:   testExistNamespace,
 		FixedIn: []database.FeatureVersion{
 			{
 				Feature: database.Feature{Name: "openssl"},
@@ -56,7 +60,7 @@ func TestFindVulnerability(t *testing.T) {
 		},
 	}
 
-	v1f, err := datastore.FindVulnerability("debian:7", "CVE-OPENSSL-1-DEB7")
+	v1f, err := datastore.FindVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
 	if assert.Nil(t, err) {
 		equalsVuln(t, &v1, &v1f)
 	}
@@ -65,11 +69,11 @@ func TestFindVulnerability(t *testing.T) {
 	v2 := database.Vulnerability{
 		Name:        "CVE-NOPE",
 		Description: "A vulnerability affecting nothing",
-		Namespace:   database.Namespace{Name: "debian:7"},
+		Namespace:   testExistNamespace,
 		Severity:    types.Unknown,
 	}
 
-	v2f, err := datastore.FindVulnerability("debian:7", "CVE-NOPE")
+	v2f, err := datastore.FindVulnerability(testExistNamespace, "CVE-NOPE")
 	if assert.Nil(t, err) {
 		equalsVuln(t, &v2, &v2f)
 	}
@@ -83,16 +87,24 @@ func TestDeleteVulnerability(t *testing.T) {
 	}
 	defer datastore.Close()
 
+	testExistNamespace := database.Namespace{
+		Name:    "debian",
+		Version: types.NewVersionUnsafe("7"),
+	}
+	testNonExistNamespace := database.Namespace{
+		Name:    "TestDeleteVulnerabilityNamespace",
+		Version: types.NewVersionUnsafe("1.0"),
+	}
 	// Delete non-existing Vulnerability.
-	err = datastore.DeleteVulnerability("TestDeleteVulnerabilityNamespace1", "CVE-OPENSSL-1-DEB7")
+	err = datastore.DeleteVulnerability(testNonExistNamespace, "CVE-OPENSSL-1-DEB7")
 	assert.Equal(t, cerrors.ErrNotFound, err)
-	err = datastore.DeleteVulnerability("debian:7", "TestDeleteVulnerabilityVulnerability1")
+	err = datastore.DeleteVulnerability(testExistNamespace, "TestDeleteVulnerabilityVulnerability1")
 	assert.Equal(t, cerrors.ErrNotFound, err)
 
 	// Delete Vulnerability.
-	err = datastore.DeleteVulnerability("debian:7", "CVE-OPENSSL-1-DEB7")
+	err = datastore.DeleteVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
 	if assert.Nil(t, err) {
-		_, err := datastore.FindVulnerability("debian:7", "CVE-OPENSSL-1-DEB7")
+		_, err := datastore.FindVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
 		assert.Equal(t, cerrors.ErrNotFound, err)
 	}
 }
@@ -106,8 +118,8 @@ func TestInsertVulnerability(t *testing.T) {
 	defer datastore.Close()
 
 	// Create some data.
-	n1 := database.Namespace{Name: "TestInsertVulnerabilityNamespace1"}
-	n2 := database.Namespace{Name: "TestInsertVulnerabilityNamespace2"}
+	n1 := database.Namespace{Name: "TestInsertVulnerabilityNamespace", Version: types.NewVersionUnsafe("1.0")}
+	n2 := database.Namespace{Name: "TestInsertVulnerabilityNamespace", Version: types.NewVersionUnsafe("2.0")}
 
 	f1 := database.FeatureVersion{
 		Feature: database.Feature{
@@ -216,7 +228,7 @@ func TestInsertVulnerability(t *testing.T) {
 	}
 	err = datastore.InsertVulnerabilities([]database.Vulnerability{v1}, true)
 	if assert.Nil(t, err) {
-		v1f, err := datastore.FindVulnerability(n1.Name, v1.Name)
+		v1f, err := datastore.FindVulnerability(n1, v1.Name)
 		if assert.Nil(t, err) {
 			equalsVuln(t, &v1, &v1f)
 		}
@@ -232,7 +244,7 @@ func TestInsertVulnerability(t *testing.T) {
 
 	err = datastore.InsertVulnerabilities([]database.Vulnerability{v1}, true)
 	if assert.Nil(t, err) {
-		v1f, err := datastore.FindVulnerability(n1.Name, v1.Name)
+		v1f, err := datastore.FindVulnerability(n1, v1.Name)
 		if assert.Nil(t, err) {
 			// We already had f1 before the update.
 			// Add it to the struct for comparison.
@@ -252,7 +264,7 @@ func TestInsertVulnerability(t *testing.T) {
 
 func equalsVuln(t *testing.T, expected, actual *database.Vulnerability) {
 	assert.Equal(t, expected.Name, actual.Name)
-	assert.Equal(t, expected.Namespace.Name, actual.Namespace.Name)
+	assert.True(t, expected.Namespace.Equal(actual.Namespace))
 	assert.Equal(t, expected.Description, actual.Description)
 	assert.Equal(t, expected.Link, actual.Link)
 	assert.Equal(t, expected.Severity, actual.Severity)
@@ -265,7 +277,7 @@ func equalsVuln(t *testing.T, expected, actual *database.Vulnerability) {
 				if expectedFeatureVersion.Feature.Name == actualFeatureVersion.Feature.Name {
 					found = true
 
-					assert.Equal(t, expected.Namespace.Name, actualFeatureVersion.Feature.Namespace.Name)
+					assert.True(t, expected.Namespace.Equal(actualFeatureVersion.Feature.Namespace))
 					assert.Equal(t, expectedFeatureVersion.Version, actualFeatureVersion.Version)
 				}
 			}

--- a/database/pgsql/vulnerability_test.go
+++ b/database/pgsql/vulnerability_test.go
@@ -37,8 +37,12 @@ func TestFindVulnerability(t *testing.T) {
 		Name:    "debian",
 		Version: types.NewVersionUnsafe("7"),
 	}
+	var testExistNamespaceID int
+	testExistNamespaceID, err = datastore.GetNamespaceID(testExistNamespace)
+	assert.Nil(t, err)
+
 	// Find a vulnerability that does not exist.
-	_, err = datastore.FindVulnerability(database.Namespace{}, "")
+	_, err = datastore.FindVulnerability(-1, "")
 	assert.Equal(t, cerrors.ErrNotFound, err)
 
 	// Find a normal vulnerability.
@@ -60,7 +64,7 @@ func TestFindVulnerability(t *testing.T) {
 		},
 	}
 
-	v1f, err := datastore.FindVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
+	v1f, err := datastore.FindVulnerability(testExistNamespaceID, "CVE-OPENSSL-1-DEB7")
 	if assert.Nil(t, err) {
 		equalsVuln(t, &v1, &v1f)
 	}
@@ -73,7 +77,7 @@ func TestFindVulnerability(t *testing.T) {
 		Severity:    types.Unknown,
 	}
 
-	v2f, err := datastore.FindVulnerability(testExistNamespace, "CVE-NOPE")
+	v2f, err := datastore.FindVulnerability(testExistNamespaceID, "CVE-NOPE")
 	if assert.Nil(t, err) {
 		equalsVuln(t, &v2, &v2f)
 	}
@@ -91,20 +95,28 @@ func TestDeleteVulnerability(t *testing.T) {
 		Name:    "debian",
 		Version: types.NewVersionUnsafe("7"),
 	}
+	var testExistNamespaceID int
+	testExistNamespaceID, err = datastore.GetNamespaceID(testExistNamespace)
+	assert.Nil(t, err)
+
 	testNonExistNamespace := database.Namespace{
 		Name:    "TestDeleteVulnerabilityNamespace",
 		Version: types.NewVersionUnsafe("1.0"),
 	}
-	// Delete non-existing Vulnerability.
-	err = datastore.DeleteVulnerability(testNonExistNamespace, "CVE-OPENSSL-1-DEB7")
+	var testNonExistNamespaceID int
+	testNonExistNamespaceID, err = datastore.GetNamespaceID(testNonExistNamespace)
 	assert.Equal(t, cerrors.ErrNotFound, err)
-	err = datastore.DeleteVulnerability(testExistNamespace, "TestDeleteVulnerabilityVulnerability1")
+
+	// Delete non-existing Vulnerability.
+	err = datastore.DeleteVulnerability(testNonExistNamespaceID, "CVE-OPENSSL-1-DEB7")
+	assert.Equal(t, cerrors.ErrNotFound, err)
+	err = datastore.DeleteVulnerability(testExistNamespaceID, "TestDeleteVulnerabilityVulnerability1")
 	assert.Equal(t, cerrors.ErrNotFound, err)
 
 	// Delete Vulnerability.
-	err = datastore.DeleteVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
+	err = datastore.DeleteVulnerability(testExistNamespaceID, "CVE-OPENSSL-1-DEB7")
 	if assert.Nil(t, err) {
-		_, err := datastore.FindVulnerability(testExistNamespace, "CVE-OPENSSL-1-DEB7")
+		_, err := datastore.FindVulnerability(testExistNamespaceID, "CVE-OPENSSL-1-DEB7")
 		assert.Equal(t, cerrors.ErrNotFound, err)
 	}
 }
@@ -228,7 +240,11 @@ func TestInsertVulnerability(t *testing.T) {
 	}
 	err = datastore.InsertVulnerabilities([]database.Vulnerability{v1}, true)
 	if assert.Nil(t, err) {
-		v1f, err := datastore.FindVulnerability(n1, v1.Name)
+		var n1ID int
+		var v1f database.Vulnerability
+		n1ID, err := datastore.GetNamespaceID(n1)
+		assert.Nil(t, err)
+		v1f, err = datastore.FindVulnerability(n1ID, v1.Name)
 		if assert.Nil(t, err) {
 			equalsVuln(t, &v1, &v1f)
 		}
@@ -244,7 +260,11 @@ func TestInsertVulnerability(t *testing.T) {
 
 	err = datastore.InsertVulnerabilities([]database.Vulnerability{v1}, true)
 	if assert.Nil(t, err) {
-		v1f, err := datastore.FindVulnerability(n1, v1.Name)
+		var n1ID int
+		var v1f database.Vulnerability
+		n1ID, err := datastore.GetNamespaceID(n1)
+		assert.Nil(t, err)
+		v1f, err = datastore.FindVulnerability(n1ID, v1.Name)
 		if assert.Nil(t, err) {
 			// We already had f1 before the update.
 			// Add it to the struct for comparison.

--- a/updater/fetchers/debian/debian.go
+++ b/updater/fetchers/debian/debian.go
@@ -192,7 +192,8 @@ func parseDebianJSON(data *jsonData) (vulnerabilities []database.Vulnerability, 
 					Feature: database.Feature{
 						Name: pkgName,
 						Namespace: database.Namespace{
-							Name: "debian:" + database.DebianReleasesMapping[releaseName],
+							Name:    "debian",
+							Version: types.NewVersionUnsafe(database.DebianReleasesMapping[releaseName]),
 						},
 					},
 					Version: version,

--- a/updater/fetchers/debian/debian.go
+++ b/updater/fetchers/debian/debian.go
@@ -169,6 +169,7 @@ func parseDebianJSON(data *jsonData) (vulnerabilities []database.Vulnerability, 
 
 				// Determine the version of the package the vulnerability affects.
 				var version types.Version
+				var nsVersion types.Version
 				var err error
 				if releaseNode.FixedVersion == "0" {
 					// This means that the package is not affected by this vulnerability.
@@ -187,13 +188,19 @@ func parseDebianJSON(data *jsonData) (vulnerabilities []database.Vulnerability, 
 					}
 				}
 
+				nsVersion, err = types.NewVersion(database.DebianReleasesMapping[releaseName])
+				if err != nil {
+					log.Warningf("could not parse namespace version '%s': %s. skipping", database.DebianReleasesMapping[releaseName], err.Error())
+					continue
+				}
+
 				// Create and add the feature version.
 				pkg := database.FeatureVersion{
 					Feature: database.Feature{
 						Name: pkgName,
 						Namespace: database.Namespace{
 							Name:    "debian",
-							Version: types.NewVersionUnsafe(database.DebianReleasesMapping[releaseName]),
+							Version: nsVersion,
 						},
 					},
 					Version: version,

--- a/updater/fetchers/debian/debian_test.go
+++ b/updater/fetchers/debian/debian_test.go
@@ -41,14 +41,14 @@ func TestDebianParser(t *testing.T) {
 				expectedFeatureVersions := []database.FeatureVersion{
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:8"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")},
 							Name:      "aptdaemon",
 						},
 						Version: types.MaxVersion,
 					},
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:unstable"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
 
 							Name: "aptdaemon",
 						},
@@ -67,21 +67,21 @@ func TestDebianParser(t *testing.T) {
 				expectedFeatureVersions := []database.FeatureVersion{
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:8"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")},
 							Name:      "aptdaemon",
 						},
 						Version: types.NewVersionUnsafe("0.7.0"),
 					},
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:unstable"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
 							Name:      "aptdaemon",
 						},
 						Version: types.NewVersionUnsafe("0.7.0"),
 					},
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:8"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")},
 							Name:      "asterisk",
 						},
 						Version: types.NewVersionUnsafe("0.5.56"),
@@ -99,7 +99,7 @@ func TestDebianParser(t *testing.T) {
 				expectedFeatureVersions := []database.FeatureVersion{
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian:8"},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")},
 							Name:      "asterisk",
 						},
 						Version: types.MinVersion,

--- a/updater/fetchers/debian/debian_test.go
+++ b/updater/fetchers/debian/debian_test.go
@@ -48,7 +48,7 @@ func TestDebianParser(t *testing.T) {
 					},
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("10")},
 
 							Name: "aptdaemon",
 						},
@@ -74,7 +74,7 @@ func TestDebianParser(t *testing.T) {
 					},
 					{
 						Feature: database.Feature{
-							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
+							Namespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("10")},
 							Name:      "aptdaemon",
 						},
 						Version: types.NewVersionUnsafe("0.7.0"),

--- a/updater/fetchers/rhel/rhel.go
+++ b/updater/fetchers/rhel/rhel.go
@@ -291,13 +291,14 @@ func toFeatureVersions(criteria criteria) []database.FeatureVersion {
 		}
 
 		if osVersion > firstConsideredRHEL {
-			featureVersion.Feature.Namespace.Name = "centos" + ":" + strconv.Itoa(osVersion)
+			featureVersion.Feature.Namespace.Name = "centos"
+			featureVersion.Feature.Namespace.Version = types.NewVersionUnsafe(strconv.Itoa(osVersion))
 		} else {
 			continue
 		}
 
-		if featureVersion.Feature.Namespace.Name != "" && featureVersion.Feature.Name != "" && featureVersion.Version.String() != "" {
-			featureVersionParameters[featureVersion.Feature.Namespace.Name+":"+featureVersion.Feature.Name] = featureVersion
+		if !featureVersion.Feature.Namespace.IsEmpty() && featureVersion.Feature.Name != "" && featureVersion.Version.String() != "" {
+			featureVersionParameters[featureVersion.Feature.Namespace.Name+":"+featureVersion.Feature.Namespace.Version.String()+":"+featureVersion.Feature.Name] = featureVersion
 		} else {
 			log.Warningf("could not determine a valid package from criterions: %v", criterions)
 		}

--- a/updater/fetchers/rhel/rhel.go
+++ b/updater/fetchers/rhel/rhel.go
@@ -291,8 +291,13 @@ func toFeatureVersions(criteria criteria) []database.FeatureVersion {
 		}
 
 		if osVersion > firstConsideredRHEL {
+			nsVersion, err := types.NewVersion(strconv.Itoa(osVersion))
+			if err != nil {
+				log.Warningf("could not parse namespace version '%s': %s. skipping", strconv.Itoa(osVersion), err.Error())
+				continue
+			}
 			featureVersion.Feature.Namespace.Name = "centos"
-			featureVersion.Feature.Namespace.Version = types.NewVersionUnsafe(strconv.Itoa(osVersion))
+			featureVersion.Feature.Namespace.Version = nsVersion
 		} else {
 			continue
 		}

--- a/updater/fetchers/rhel/rhel_test.go
+++ b/updater/fetchers/rhel/rhel_test.go
@@ -41,21 +41,21 @@ func TestRHELParser(t *testing.T) {
 		expectedFeatureVersions := []database.FeatureVersion{
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "centos:7"},
+					Namespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("7")},
 					Name:      "xerces-c",
 				},
 				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
 			},
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "centos:7"},
+					Namespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("7")},
 					Name:      "xerces-c-devel",
 				},
 				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
 			},
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "centos:7"},
+					Namespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("7")},
 					Name:      "xerces-c-doc",
 				},
 				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
@@ -79,14 +79,14 @@ func TestRHELParser(t *testing.T) {
 		expectedFeatureVersions := []database.FeatureVersion{
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "centos:6"},
+					Namespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("6")},
 					Name:      "firefox",
 				},
 				Version: types.NewVersionUnsafe("38.1.0-1.el6_6"),
 			},
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "centos:7"},
+					Namespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("7")},
 					Name:      "firefox",
 				},
 				Version: types.NewVersionUnsafe("38.1.0-1.el7_1"),

--- a/updater/fetchers/ubuntu/ubuntu.go
+++ b/updater/fetchers/ubuntu/ubuntu.go
@@ -376,7 +376,7 @@ func parseUbuntuCVE(fileContent io.Reader) (vulnerability database.Vulnerability
 				// Create and add the new package.
 				featureVersion := database.FeatureVersion{
 					Feature: database.Feature{
-						Namespace: database.Namespace{Name: "ubuntu:" + database.UbuntuReleasesMapping[md["release"]]},
+						Namespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe(database.UbuntuReleasesMapping[md["release"]])},
 						Name:      md["package"],
 					},
 					Version: version,

--- a/updater/fetchers/ubuntu/ubuntu.go
+++ b/updater/fetchers/ubuntu/ubuntu.go
@@ -373,10 +373,15 @@ func parseUbuntuCVE(fileContent io.Reader) (vulnerability database.Vulnerability
 					continue
 				}
 
+				nsVersion, err := types.NewVersion(database.UbuntuReleasesMapping[md["release"]])
+				if err != nil {
+					log.Warningf("could not parse namespace version '%s': %s. skipping", database.UbuntuReleasesMapping[md["release"]], err)
+				}
+
 				// Create and add the new package.
 				featureVersion := database.FeatureVersion{
 					Feature: database.Feature{
-						Namespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe(database.UbuntuReleasesMapping[md["release"]])},
+						Namespace: database.Namespace{Name: "ubuntu", Version: nsVersion},
 						Name:      md["package"],
 					},
 					Version: version,

--- a/updater/fetchers/ubuntu/ubuntu_test.go
+++ b/updater/fetchers/ubuntu/ubuntu_test.go
@@ -45,21 +45,21 @@ func TestUbuntuParser(t *testing.T) {
 		expectedFeatureVersions := []database.FeatureVersion{
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "ubuntu:14.04"},
+					Namespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe("14.04")},
 					Name:      "libmspack",
 				},
 				Version: types.MaxVersion,
 			},
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "ubuntu:15.04"},
+					Namespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe("15.04")},
 					Name:      "libmspack",
 				},
 				Version: types.NewVersionUnsafe("0.4-3"),
 			},
 			{
 				Feature: database.Feature{
-					Namespace: database.Namespace{Name: "ubuntu:15.10"},
+					Namespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe("15.10")},
 					Name:      "libmspack-anotherpkg",
 				},
 				Version: types.NewVersionUnsafe("0.1"),

--- a/worker/detectors/feature/dpkg/dpkg.go
+++ b/worker/detectors/feature/dpkg/dpkg.go
@@ -113,3 +113,16 @@ func (detector *DpkgFeaturesDetector) Detect(data map[string][]byte) ([]database
 func (detector *DpkgFeaturesDetector) GetRequiredFiles() []string {
 	return []string{"var/lib/dpkg/status"}
 }
+
+//Supported checks if the input Namespace is supported by the underling detector
+func (detector *DpkgFeaturesDetector) Supported(namespace database.Namespace) bool {
+	supports := []string{"debian", "ubuntu"}
+
+	for _, support := range supports {
+		if strings.HasPrefix(namespace.Name, support) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/worker/detectors/feature/rpm/rpm.go
+++ b/worker/detectors/feature/rpm/rpm.go
@@ -118,3 +118,16 @@ func (detector *RpmFeaturesDetector) Detect(data map[string][]byte) ([]database.
 func (detector *RpmFeaturesDetector) GetRequiredFiles() []string {
 	return []string{"var/lib/rpm/Packages"}
 }
+
+//Supported checks if the input Namespace is supported by the underling detector
+func (detector *RpmFeaturesDetector) Supported(namespace database.Namespace) bool {
+	supports := []string{"centos", "red hat", "fedora"}
+
+	for _, support := range supports {
+		if strings.HasPrefix(namespace.Name, support) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/worker/detectors/features.go
+++ b/worker/detectors/features.go
@@ -68,8 +68,7 @@ func DetectFeatures(data map[string][]byte, namespaces []database.Namespace) ([]
 				}
 				// Ensure that every feature has a Namespace associated
 				for i := 0; i < len(pkgs); i++ {
-					pkgs[i].Feature.Namespace.Name = namespace.Name
-					pkgs[i].Feature.Namespace.Version = namespace.Version
+					pkgs[i].Feature.Namespace = namespace
 				}
 				packages = append(packages, pkgs...)
 				break

--- a/worker/detectors/namespace.go
+++ b/worker/detectors/namespace.go
@@ -60,18 +60,18 @@ func RegisterNamespaceDetector(name string, f NamespaceDetector) {
 	namespaceDetectors[name] = f
 }
 
-// DetectNamespace finds the OS of the layer by using every registered NamespaceDetector.
-func DetectNamespace(data map[string][]byte) *database.Namespace {
+// DetectNamespaces finds the namespaces of the layer by using every registered NamespaceDetector.
+func DetectNamespaces(data map[string][]byte) (namespaces []database.Namespace) {
 	for _, detector := range namespaceDetectors {
 		if namespace := detector.Detect(data); namespace != nil {
-			return namespace
+			namespaces = append(namespaces, *namespace)
 		}
 	}
 
-	return nil
+	return
 }
 
-// GetRequiredFilesNamespace returns the list of files required for DetectNamespace for every
+// GetRequiredFilesNamespace returns the list of files required for DetectNamespaces for every
 // registered NamespaceDetector, without leading /.
 func GetRequiredFilesNamespace() (files []string) {
 	for _, detector := range namespaceDetectors {

--- a/worker/detectors/namespace/aptsources/aptsources.go
+++ b/worker/detectors/namespace/aptsources/aptsources.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors"
 )
 
@@ -75,7 +76,7 @@ func (detector *AptSourcesNamespaceDetector) Detect(data map[string][]byte) *dat
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS + ":" + version}
+		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/aptsources/aptsources.go
+++ b/worker/detectors/namespace/aptsources/aptsources.go
@@ -76,7 +76,11 @@ func (detector *AptSourcesNamespaceDetector) Detect(data map[string][]byte) *dat
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
+		if nsVersion, err := types.NewVersion(version); err != nil {
+			return nil
+		} else {
+			return &database.Namespace{Name: OS, Version: nsVersion}
+		}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/aptsources/aptsources_test.go
+++ b/worker/detectors/namespace/aptsources/aptsources_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors/namespace"
 )
 
 var aptSourcesOSTests = []namespace.NamespaceTest{
 	{
-		ExpectedNamespace: database.Namespace{Name: "debian:unstable"},
+		ExpectedNamespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
 		Data: map[string][]byte{
 			"etc/os-release": []byte(
 				`PRETTY_NAME="Debian GNU/Linux stretch/sid"

--- a/worker/detectors/namespace/aptsources/aptsources_test.go
+++ b/worker/detectors/namespace/aptsources/aptsources_test.go
@@ -24,7 +24,7 @@ import (
 
 var aptSourcesOSTests = []namespace.NamespaceTest{
 	{
-		ExpectedNamespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("unstable")},
+		ExpectedNamespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("10")},
 		Data: map[string][]byte{
 			"etc/os-release": []byte(
 				`PRETTY_NAME="Debian GNU/Linux stretch/sid"

--- a/worker/detectors/namespace/lsbrelease/lsbrelease.go
+++ b/worker/detectors/namespace/lsbrelease/lsbrelease.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors"
 )
 
@@ -70,7 +71,7 @@ func (detector *LsbReleaseNamespaceDetector) Detect(data map[string][]byte) *dat
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS + ":" + version}
+		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/lsbrelease/lsbrelease.go
+++ b/worker/detectors/namespace/lsbrelease/lsbrelease.go
@@ -71,7 +71,11 @@ func (detector *LsbReleaseNamespaceDetector) Detect(data map[string][]byte) *dat
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
+		if nsVersion, err := types.NewVersion(version); err != nil {
+			return nil
+		} else {
+			return &database.Namespace{Name: OS, Version: nsVersion}
+		}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/lsbrelease/lsbrelease_test.go
+++ b/worker/detectors/namespace/lsbrelease/lsbrelease_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors/namespace"
 )
 
 var lsbReleaseOSTests = []namespace.NamespaceTest{
 	{
-		ExpectedNamespace: database.Namespace{Name: "ubuntu:12.04"},
+		ExpectedNamespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe("12.04")},
 		Data: map[string][]byte{
 			"etc/lsb-release": []byte(
 				`DISTRIB_ID=Ubuntu
@@ -33,7 +34,7 @@ DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"`),
 		},
 	},
 	{ // We don't care about the minor version of Debian
-		ExpectedNamespace: database.Namespace{Name: "debian:7"},
+		ExpectedNamespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("7")},
 		Data: map[string][]byte{
 			"etc/lsb-release": []byte(
 				`DISTRIB_ID=Debian

--- a/worker/detectors/namespace/osrelease/osrelease.go
+++ b/worker/detectors/namespace/osrelease/osrelease.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors"
 )
 
@@ -65,7 +66,7 @@ func (detector *OsReleaseNamespaceDetector) Detect(data map[string][]byte) *data
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS + ":" + version}
+		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/osrelease/osrelease.go
+++ b/worker/detectors/namespace/osrelease/osrelease.go
@@ -66,7 +66,11 @@ func (detector *OsReleaseNamespaceDetector) Detect(data map[string][]byte) *data
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{Name: OS, Version: types.NewVersionUnsafe(version)}
+		if nsVersion, err := types.NewVersion(version); err != nil {
+			return nil
+		} else {
+			return &database.Namespace{Name: OS, Version: nsVersion}
+		}
 	}
 	return nil
 }

--- a/worker/detectors/namespace/osrelease/osrelease_test.go
+++ b/worker/detectors/namespace/osrelease/osrelease_test.go
@@ -18,12 +18,13 @@ import (
 	"testing"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors/namespace"
 )
 
 var osReleaseOSTests = []namespace.NamespaceTest{
 	{
-		ExpectedNamespace: database.Namespace{Name: "debian:8"},
+		ExpectedNamespace: database.Namespace{Name: "debian", Version: types.NewVersionUnsafe("8")},
 		Data: map[string][]byte{
 			"etc/os-release": []byte(
 				`PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
@@ -37,7 +38,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"`),
 		},
 	},
 	{
-		ExpectedNamespace: database.Namespace{Name: "ubuntu:15.10"},
+		ExpectedNamespace: database.Namespace{Name: "ubuntu", Version: types.NewVersionUnsafe("15.10")},
 		Data: map[string][]byte{
 			"etc/os-release": []byte(
 				`NAME="Ubuntu"
@@ -52,7 +53,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`),
 		},
 	},
 	{ // Doesn't have quotes around VERSION_ID
-		ExpectedNamespace: database.Namespace{Name: "fedora:20"},
+		ExpectedNamespace: database.Namespace{Name: "fedora", Version: types.NewVersionUnsafe("20")},
 		Data: map[string][]byte{
 			"etc/os-release": []byte(
 				`NAME=Fedora

--- a/worker/detectors/namespace/redhatrelease/redhatrelease.go
+++ b/worker/detectors/namespace/redhatrelease/redhatrelease.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors"
 )
 
@@ -46,7 +47,7 @@ func (detector *RedhatReleaseNamespaceDetector) Detect(data map[string][]byte) *
 
 		r := redhatReleaseRegexp.FindStringSubmatch(string(f))
 		if len(r) == 4 {
-			return &database.Namespace{Name: strings.ToLower(r[1]) + ":" + r[3]}
+			return &database.Namespace{Name: strings.ToLower(r[1]), Version: types.NewVersionUnsafe(r[3])}
 		}
 	}
 

--- a/worker/detectors/namespace/redhatrelease/redhatrelease.go
+++ b/worker/detectors/namespace/redhatrelease/redhatrelease.go
@@ -47,7 +47,11 @@ func (detector *RedhatReleaseNamespaceDetector) Detect(data map[string][]byte) *
 
 		r := redhatReleaseRegexp.FindStringSubmatch(string(f))
 		if len(r) == 4 {
-			return &database.Namespace{Name: strings.ToLower(r[1]), Version: types.NewVersionUnsafe(r[3])}
+			if nsVersion, err := types.NewVersion(r[3]); err != nil {
+				return nil
+			} else {
+				return &database.Namespace{Name: strings.ToLower(r[1]), Version: nsVersion}
+			}
 		}
 	}
 

--- a/worker/detectors/namespace/redhatrelease/redhatrelease_test.go
+++ b/worker/detectors/namespace/redhatrelease/redhatrelease_test.go
@@ -18,18 +18,19 @@ import (
 	"testing"
 
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
 	"github.com/coreos/clair/worker/detectors/namespace"
 )
 
 var redhatReleaseTests = []namespace.NamespaceTest{
 	{
-		ExpectedNamespace: database.Namespace{Name: "centos:6"},
+		ExpectedNamespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("6")},
 		Data: map[string][]byte{
 			"etc/centos-release": []byte(`CentOS release 6.6 (Final)`),
 		},
 	},
 	{
-		ExpectedNamespace: database.Namespace{Name: "centos:7"},
+		ExpectedNamespace: database.Namespace{Name: "centos", Version: types.NewVersionUnsafe("7")},
 		Data: map[string][]byte{
 			"etc/system-release": []byte(`CentOS Linux release 7.1.1503 (Core)`),
 		},

--- a/worker/detectors/namespace/test.go
+++ b/worker/detectors/namespace/test.go
@@ -29,6 +29,6 @@ type NamespaceTest struct {
 
 func TestNamespaceDetector(t *testing.T, detector detectors.NamespaceDetector, tests []NamespaceTest) {
 	for _, test := range tests {
-		assert.Equal(t, test.ExpectedNamespace, *detector.Detect(test.Data))
+		assert.True(t, test.ExpectedNamespace.Equal(*detector.Detect(test.Data)))
 	}
 }


### PR DESCRIPTION
This implementation mainly adds a 'version' field to database.namespace, this change affects the following things:

1) API
     Since namespace.Name could not represent a namespace, I use the encoded namespace.ID in [Vulnerabilities API ](https://github.com/liangchenye/clair/blob/multiple-detector/api/v1/README.md#vulnerabilities) and [Fixes API](https://github.com/liangchenye/clair/blob/multiple-detector/api/v1/README.md#fixes)
2) vulnerability & fixes sql operation
   Use namespaceID to add/remove/change vulnerabilities.
3) database migration 
   using [sql migration file](https://github.com/liangchenye/clair/blob/multiple-detector/database/pgsql/migrations/20160524162211_multiple_namespace.sql)
detectors
4) test cases
   for example change debian:8 to {Name: "debian", Version: "8"} 
5) debian 'unstable'
   'unstable' is illegal as a version content, change it to '10'.

Close the previous [PR](https://github.com/coreos/clair/pull/157) since that 'head fork' became 'unknown'.
