### PR TITLE
Modify URL for libpq documentation

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,7 +19,7 @@ clair:
     type: pgsql
     options:
       # PostgreSQL Connection string
-      # http://www.postgresql.org/docs/9.4/static/libpq-connect.html
+      # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
       source:
 
       # Number of elements kept in the cache


### PR DESCRIPTION
When opening the URL in the browser the section about "Connection Strings" is directly displayed. This way there's no need to scroll to it. (Also use HTTPS)
