### PR TITLE
travis: Remove 'tip' until 'gimme' fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.5
-  # - tip
+  - tip
 
 sudo: false
 
@@ -30,3 +30,7 @@ addons:
 
 notifications:
   email: false
+
+matrix:
+  allow_failures:
+    - go: tip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.5
-  - tip
+  # - tip
 
 sudo: false
 


### PR DESCRIPTION
`gimme`script of Travis has incorrect behavior for the `tip`command. It return _1.4.1_ instead of _master_.

I propose to remove `tip`until travis-ci/gimme#38 is fixed.
