### PR TITLE
config: fix wrong location of database config in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,14 +17,14 @@ clair:
   database:
     # Database driver
     type: pgsql
-    options:
-      # PostgreSQL Connection string
-      # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-      source:
 
-      # Number of elements kept in the cache
-      # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
-      cachesize: 16384
+    # PostgreSQL Connection string
+    # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+    source: "postgresql://postgres:password@postgres:5432?sslmode=disable"
+
+    # Number of elements kept in the cache
+    # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
+    cachesize: 16384
 
   api:
     # API server port


### PR DESCRIPTION
This fixes configuration error `main: failed to load configuration: could not load configuration: no database source specified`
when booting clair with following Hello Heartbleed instruction.
