### PR TITLE
Fix source location in hierarchy

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,11 +17,10 @@ clair:
   database:
     # Database driver
     type: pgsql
+    # PostgreSQL Connection string
+    # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
+    source:
     options:
-      # PostgreSQL Connection string
-      # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-      source:
-
       # Number of elements kept in the cache
       # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.
       cachesize: 16384


### PR DESCRIPTION
The `source` field appears to be at `clair.database.source`, not `clair.database.options.source`.  The latter results in clair complaining that no source has been specified, while the former works as expected.
