### PR TITLE
updater: enable fetching of RHEL 5 vulnerabilities

### DIFF
--- a/updater/fetchers/rhel/rhel.go
+++ b/updater/fetchers/rhel/rhel.go
@@ -290,7 +290,7 @@ func toFeatureVersions(criteria criteria) []database.FeatureVersion {
 			}
 		}
 
-		if osVersion > firstConsideredRHEL {
+		if osVersion >= firstConsideredRHEL {
 			featureVersion.Feature.Namespace.Name = "centos" + ":" + strconv.Itoa(osVersion)
 		} else {
 			continue


### PR DESCRIPTION
The RHEL updater currently ignores vulnerabilities for CentOS <= 5.
s the naming of the constant firstConsideredRHEL suggests it, it
should actually considers CentOS 5 and ignores CentOS < 5.

Fixes #215
