### PR TITLE
Initial support for Oracle Linux

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -30,6 +30,7 @@ import (
 
 	_ "github.com/coreos/clair/updater/fetchers/debian"
 	_ "github.com/coreos/clair/updater/fetchers/rhel"
+	_ "github.com/coreos/clair/updater/fetchers/oracle"
 	_ "github.com/coreos/clair/updater/fetchers/ubuntu"
 	_ "github.com/coreos/clair/updater/metadata_fetchers/nvd"
 

--- a/updater/fetchers/oracle/oracle.go
+++ b/updater/fetchers/oracle/oracle.go
@@ -40,9 +40,7 @@ const (
 var (
 	ignoredCriterions = []string{
 		" is signed with the Oracle Linux",
-		" Client is installed",
-		" Workstation is installed",
-		" ComputeNode is installed",
+		".ksplice1.",
 	}
 
 	elsaRegexp = regexp.MustCompile(`com.oracle.elsa-(\d+).xml`)

--- a/updater/fetchers/oracle/oracle.go
+++ b/updater/fetchers/oracle/oracle.go
@@ -1,0 +1,356 @@
+// Copyright 2015 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"bufio"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/updater"
+	cerrors "github.com/coreos/clair/utils/errors"
+	"github.com/coreos/clair/utils/types"
+	"github.com/coreos/pkg/capnslog"
+)
+
+const (
+	firstOracle5ELSA = 20070057
+	ovalURI          = "https://linux.oracle.com/oval/"
+	elsaFilePrefix   = "com.oracle.elsa-"
+	updaterFlag      = "oracleUpdater"
+)
+
+var (
+	ignoredCriterions = []string{
+		" is signed with the Oracle Linux",
+		" Client is installed",
+		" Workstation is installed",
+		" ComputeNode is installed",
+	}
+
+	elsaRegexp = regexp.MustCompile(`com.oracle.elsa-(\d+).xml`)
+
+	log = capnslog.NewPackageLogger("github.com/coreos/clair", "updater/fetchers/oracle")
+)
+
+type oval struct {
+	Definitions []definition `xml:"definitions>definition"`
+}
+
+type definition struct {
+	Title       string      `xml:"metadata>title"`
+	Description string      `xml:"metadata>description"`
+	References  []reference `xml:"metadata>reference"`
+	Criteria    criteria    `xml:"criteria"`
+}
+
+type reference struct {
+	Source string `xml:"source,attr"`
+	URI    string `xml:"ref_url,attr"`
+}
+
+type criteria struct {
+	Operator   string      `xml:"operator,attr"`
+	Criterias  []*criteria `xml:"criteria"`
+	Criterions []criterion `xml:"criterion"`
+}
+
+type criterion struct {
+	Comment string `xml:"comment,attr"`
+}
+
+// OracleFetcher implements updater.Fetcher and gets vulnerability updates from
+// the Oracle Linux OVAL definitions.
+type OracleFetcher struct{}
+
+func init() {
+	updater.RegisterFetcher("Oracle", &OracleFetcher{})
+}
+
+// FetchUpdate gets vulnerability updates from the Oracle Linux OVAL definitions.
+func (f *OracleFetcher) FetchUpdate(datastore database.Datastore) (resp updater.FetcherResponse, err error) {
+	log.Info("fetching Oracle Linux vulnerabilities")
+
+	// Get the first ELSA we have to manage.
+	flagValue, err := datastore.GetKeyValue(updaterFlag)
+	if err != nil {
+		return resp, err
+	}
+
+	firstELSA, err := strconv.Atoi(flagValue)
+	if firstELSA == 0 || err != nil {
+		firstELSA = firstOracle5ELSA
+	}
+
+
+	// Fetch the update list.
+	r, err := http.Get(ovalURI)
+	if err != nil {
+		log.Errorf("could not download Oracle's update list: %s", err)
+		return resp, cerrors.ErrCouldNotDownload
+	}
+
+	// Get the list of ELSAs that we have to process.
+	var elsaList []int
+	scanner := bufio.NewScanner(r.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		r := elsaRegexp.FindStringSubmatch(line)
+		if len(r) == 2 {
+			elsaNo, _ := strconv.Atoi(r[1])
+			if elsaNo > firstELSA {
+				elsaList = append(elsaList, elsaNo)
+			}
+		}
+	}
+
+	for _, elsa := range elsaList {
+		// Download the ELSA's XML file.
+		r, err := http.Get(ovalURI + elsaFilePrefix + strconv.Itoa(elsa) + ".xml")
+		if err != nil {
+			log.Errorf("could not download Oracle's update file: %s", err)
+			return resp, cerrors.ErrCouldNotDownload
+		}
+
+		// Parse the XML.
+		vs, err := parseELSA(r.Body)
+		if err != nil {
+			return resp, err
+		}
+
+		// Collect vulnerabilities.
+		for _, v := range vs {
+			resp.Vulnerabilities = append(resp.Vulnerabilities, v)
+		}
+	}
+
+	// Set the flag if we found anything.
+	if len(elsaList) > 0 {
+		resp.FlagName = updaterFlag
+		resp.FlagValue = strconv.Itoa(elsaList[len(elsaList)-1])
+	} else {
+		log.Debug("no Oracle Linux update.")
+	}
+
+	return resp, nil
+}
+
+func parseELSA(ovalReader io.Reader) (vulnerabilities []database.Vulnerability, err error) {
+	// Decode the XML.
+	var ov oval
+	err = xml.NewDecoder(ovalReader).Decode(&ov)
+	if err != nil {
+		log.Errorf("could not decode Oracle's XML: %s", err)
+		err = cerrors.ErrCouldNotParse
+		return
+	}
+
+	// Iterate over the definitions and collect any vulnerabilities that affect
+	// at least one package.
+	for _, definition := range ov.Definitions {
+		pkgs := toFeatureVersions(definition.Criteria)
+		if len(pkgs) > 0 {
+			vulnerability := database.Vulnerability{
+				Name:        name(definition),
+				Link:        link(definition),
+				Severity:    priority(definition),
+				Description: description(definition),
+			}
+			for _, p := range pkgs {
+				vulnerability.FixedIn = append(vulnerability.FixedIn, p)
+			}
+			vulnerabilities = append(vulnerabilities, vulnerability)
+		}
+	}
+
+	return
+}
+
+func getCriterions(node criteria) [][]criterion {
+	// Filter useless criterions.
+	var criterions []criterion
+	for _, c := range node.Criterions {
+		ignored := false
+
+		for _, ignoredItem := range ignoredCriterions {
+			if strings.Contains(c.Comment, ignoredItem) {
+				ignored = true
+				break
+			}
+		}
+
+		if !ignored {
+			criterions = append(criterions, c)
+		}
+	}
+
+	if node.Operator == "AND" {
+		return [][]criterion{criterions}
+	} else if node.Operator == "OR" {
+		var possibilities [][]criterion
+		for _, c := range criterions {
+			possibilities = append(possibilities, []criterion{c})
+		}
+		return possibilities
+	}
+
+	return [][]criterion{}
+}
+
+func getPossibilities(node criteria) [][]criterion {
+	if len(node.Criterias) == 0 {
+		return getCriterions(node)
+	}
+
+	var possibilitiesToCompose [][][]criterion
+	for _, criteria := range node.Criterias {
+		possibilitiesToCompose = append(possibilitiesToCompose, getPossibilities(*criteria))
+	}
+	if len(node.Criterions) > 0 {
+		possibilitiesToCompose = append(possibilitiesToCompose, getCriterions(node))
+	}
+
+	var possibilities [][]criterion
+	if node.Operator == "AND" {
+		for _, possibility := range possibilitiesToCompose[0] {
+			possibilities = append(possibilities, possibility)
+		}
+
+		for _, possibilityGroup := range possibilitiesToCompose[1:] {
+			var newPossibilities [][]criterion
+
+			for _, possibility := range possibilities {
+				for _, possibilityInGroup := range possibilityGroup {
+					var p []criterion
+					p = append(p, possibility...)
+					p = append(p, possibilityInGroup...)
+					newPossibilities = append(newPossibilities, p)
+				}
+			}
+
+			possibilities = newPossibilities
+		}
+	} else if node.Operator == "OR" {
+		for _, possibilityGroup := range possibilitiesToCompose {
+			for _, possibility := range possibilityGroup {
+				possibilities = append(possibilities, possibility)
+			}
+		}
+	}
+
+	return possibilities
+}
+
+func toFeatureVersions(criteria criteria) []database.FeatureVersion {
+	// There are duplicates in Oracle .xml files.
+	// This map is for deduplication.
+	featureVersionParameters := make(map[string]database.FeatureVersion)
+
+	possibilities := getPossibilities(criteria)
+	for _, criterions := range possibilities {
+		var (
+			featureVersion database.FeatureVersion
+			osVersion      int
+			err            error
+		)
+
+		// Attempt to parse package data from trees of criterions.
+		for _, c := range criterions {
+			if strings.Contains(c.Comment, " is installed") {
+				const prefixLen = len("Oracle Linux ")
+				osVersion, err = strconv.Atoi(strings.TrimSpace(c.Comment[prefixLen : prefixLen+strings.Index(c.Comment[prefixLen:], " ")]))
+				if err != nil {
+					log.Warningf("could not parse Oracle Linux release version from: '%s'.", c.Comment)
+				}
+			} else if strings.Contains(c.Comment, " is earlier than ") {
+				const prefixLen = len(" is earlier than ")
+				featureVersion.Feature.Name = strings.TrimSpace(c.Comment[:strings.Index(c.Comment, " is earlier than ")])
+				featureVersion.Version, err = types.NewVersion(c.Comment[strings.Index(c.Comment, " is earlier than ")+prefixLen:])
+				if err != nil {
+					log.Warningf("could not parse package version '%s': %s. skipping", c.Comment[strings.Index(c.Comment, " is earlier than ")+prefixLen:], err.Error())
+				}
+			}
+		}
+
+		featureVersion.Feature.Namespace.Name = "oracle" + ":" + strconv.Itoa(osVersion)
+
+		if featureVersion.Feature.Namespace.Name != "" && featureVersion.Feature.Name != "" && featureVersion.Version.String() != "" {
+			featureVersionParameters[featureVersion.Feature.Namespace.Name+":"+featureVersion.Feature.Name] = featureVersion
+		} else {
+			log.Warningf("could not determine a valid package from criterions: %v", criterions)
+		}
+	}
+
+	// Convert the map to slice.
+	var featureVersionParametersArray []database.FeatureVersion
+	for _, fv := range featureVersionParameters {
+		featureVersionParametersArray = append(featureVersionParametersArray, fv)
+	}
+
+	return featureVersionParametersArray
+}
+
+func description(def definition) (desc string) {
+	// It is much more faster to proceed like this than using a Replacer.
+	desc = strings.Replace(def.Description, "\n\n\n", " ", -1)
+	desc = strings.Replace(desc, "\n\n", " ", -1)
+	desc = strings.Replace(desc, "\n", " ", -1)
+	return
+}
+
+func name(def definition) string {
+	return strings.TrimSpace(def.Title[:strings.Index(def.Title, ": ")])
+}
+
+func link(def definition) (link string) {
+	for _, reference := range def.References {
+		if reference.Source == "elsa" {
+			link = reference.URI
+			break
+		}
+	}
+
+	return
+}
+
+func priority(def definition) types.Priority {
+	// Parse the priority.
+	priority := strings.TrimSpace(def.Title[strings.LastIndex(def.Title, "(")+1 : len(def.Title)-2])
+
+	// Normalize the priority.
+	switch priority {
+	case "NA":
+		return types.Negligible
+	case "LOW":
+		return types.Low
+	case "MODERATE":
+		return types.Medium
+	case "IMPORTANT":
+		return types.High
+	case "CRITICAL":
+		return types.Critical
+	default:
+		log.Warning("could not determine vulnerability priority from: %s.", priority)
+		return types.Unknown
+	}
+}
+
+// Clean deletes any allocated resources.
+func (f *OracleFetcher) Clean() {}

--- a/updater/fetchers/oracle/oracle_test.go
+++ b/updater/fetchers/oracle/oracle_test.go
@@ -1,0 +1,98 @@
+// Copyright 2015 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/utils/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOracleParser(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(filename))
+
+	// Test parsing testdata/fetcher_oracle_test.1.xml
+	testFile, _ := os.Open(path + "/testdata/fetcher_oracle_test.1.xml")
+	vulnerabilities, err := parseELSA(testFile)
+	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 1) {
+		assert.Equal(t, "ELSA-2015-1193", vulnerabilities[0].Name)
+		assert.Equal(t, "http://linux.oracle.com/errata/ELSA-2015-1193.html", vulnerabilities[0].Link)
+		assert.Equal(t, types.Medium, vulnerabilities[0].Severity)
+		assert.Equal(t, ` [3.1.1-7] Resolves: rhbz#1217104 CVE-2015-0252 `, vulnerabilities[0].Description)
+
+		expectedFeatureVersions := []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Namespace: database.Namespace{Name: "oracle:7"},
+					Name:      "xerces-c",
+				},
+				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
+			},
+			{
+				Feature: database.Feature{
+					Namespace: database.Namespace{Name: "oracle:7"},
+					Name:      "xerces-c-devel",
+				},
+				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
+			},
+			{
+				Feature: database.Feature{
+					Namespace: database.Namespace{Name: "oracle:7"},
+					Name:      "xerces-c-doc",
+				},
+				Version: types.NewVersionUnsafe("3.1.1-7.el7_1"),
+			},
+		}
+
+		for _, expectedFeatureVersion := range expectedFeatureVersions {
+			assert.Contains(t, vulnerabilities[0].FixedIn, expectedFeatureVersion)
+		}
+	}
+
+	testFile, _ = os.Open(path + "/testdata/fetcher_oracle_test.2.xml")
+	vulnerabilities, err = parseELSA(testFile)
+	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 1) {
+		assert.Equal(t, "ELSA-2015-1207", vulnerabilities[0].Name)
+		assert.Equal(t, "http://linux.oracle.com/errata/ELSA-2015-1207.html", vulnerabilities[0].Link)
+		assert.Equal(t, types.Critical, vulnerabilities[0].Severity)
+		assert.Equal(t, ` [38.1.0-1.0.1.el7_1] - Add firefox-oracle-default-prefs.js and remove the corresponding Red Hat file [38.1.0-1] - Update to 38.1.0 ESR [38.0.1-2] - Fixed rhbz#1222807 by removing preun section `, vulnerabilities[0].Description)
+		expectedFeatureVersions := []database.FeatureVersion{
+			{
+				Feature: database.Feature{
+					Namespace: database.Namespace{Name: "oracle:6"},
+					Name:      "firefox",
+				},
+				Version: types.NewVersionUnsafe("38.1.0-1.0.1.el6_6"),
+			},
+			{
+				Feature: database.Feature{
+					Namespace: database.Namespace{Name: "oracle:7"},
+					Name:      "firefox",
+				},
+				Version: types.NewVersionUnsafe("38.1.0-1.0.1.el7_1"),
+			},
+		}
+
+		for _, expectedFeatureVersion := range expectedFeatureVersions {
+			assert.Contains(t, vulnerabilities[0].FixedIn, expectedFeatureVersion)
+		}
+	}
+}

--- a/updater/fetchers/oracle/testdata/fetcher_oracle_test.1.xml
+++ b/updater/fetchers/oracle/testdata/fetcher_oracle_test.1.xml
@@ -1,0 +1,120 @@
+<oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:red-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">
+<generator>
+<oval:product_name>Oracle Errata System</oval:product_name>
+<oval:product_version>Oracle Linux</oval:product_version>
+<oval:schema_version>5.3</oval:schema_version>
+<oval:timestamp>2015-06-29T00:00:00</oval:timestamp>
+</generator>
+<definitions>
+<definition id="oval:com.oracle.elsa:def:20151193" version="501" class="patch">
+<metadata>
+<title>
+ELSA-2015-1193:  xerces-c security update (MODERATE)
+</title>
+<affected family="unix">
+<platform>Oracle Linux 7</platform>
+
+</affected>
+<reference source="elsa" ref_id="ELSA-2015-1193" ref_url="http://linux.oracle.com/errata/ELSA-2015-1193.html"/>
+<reference source="CVE" ref_id="CVE-2015-0252" ref_url="http://linux.oracle.com/cve/CVE-2015-0252.html"/>
+
+<description>
+[3.1.1-7]
+Resolves: rhbz#1217104 CVE-2015-0252
+</description>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
+-->
+<advisory>
+<severity>MODERATE</severity>
+<rights>Copyright 2015 Oracle, Inc.</rights>
+<issued date="2015-06-29"/>
+<cve href="http://linux.oracle.com/cve/CVE-2015-0252.html">CVE-2015-0252</cve>
+
+</advisory>
+</metadata>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193001" comment="Oracle Linux 7 is installed"/>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193002" comment="xerces-c is earlier than 0:3.1.1-7.el7_1"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193003" comment="xerces-c is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193004" comment="xerces-c-doc is earlier than 0:3.1.1-7.el7_1"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193005" comment="xerces-c-doc is signed with the Oracle Linux 7 key"/>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193006" comment="xerces-c-devel is earlier than 0:3.1.1-7.el7_1"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151193007" comment="xerces-c-devel is signed with the Oracle Linux 7 key"/>
+</criteria>
+</criteria>
+</criteria>
+
+</definition>
+</definitions>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~~   rpminfo tests   ~~~~~~~~~~~~~~~~~~~~~ 
+-->
+<tests>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193001"  version="501" comment="Oracle Linux 7 is installed" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193001" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193002" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193002"  version="501" comment="xerces-c is earlier than 0:3.1.1-7.el7_1" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193003" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193003"  version="501" comment="xerces-c is signed with the Oracle Linux 7 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193001" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193004"  version="501" comment="xerces-c-doc is earlier than 0:3.1.1-7.el7_1" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193003" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193003" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193005"  version="501" comment="xerces-c-doc is signed with the Oracle Linux 7 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193003" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193001" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193006"  version="501" comment="xerces-c-devel is earlier than 0:3.1.1-7.el7_1" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193004" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193003" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151193007"  version="501" comment="xerces-c-devel is signed with the Oracle Linux 7 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151193004" />
+<state state_ref="oval:com.oracle.elsa:ste:20151193001" />
+</rpminfo_test>
+
+</tests>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   rpminfo objects   ~~~~~~~~~~~~~~~~~~~~ 
+-->
+<objects>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151193003" version="501">
+<name>xerces-c-doc</name>
+</rpminfo_object>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151193004" version="501">
+<name>xerces-c-devel</name>
+</rpminfo_object>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151193002" version="501">
+<name>xerces-c</name>
+</rpminfo_object>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151193001" version="501">
+<name>oraclelinux-release</name>
+</rpminfo_object>
+
+</objects>
+<states>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   rpminfo states   ~~~~~~~~~~~~~~~~~~~~~ 
+-->
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151193001" version="501"><signature_keyid operation="equals">72f97b74ec551f03</signature_keyid>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151193002" version="501"><version operation="pattern match">^7</version>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151193003" version="501"><evr datatype="evr_string" operation="less than">0:3.1.1-7.el7_1</evr>
+</rpminfo_state>
+
+</states>
+</oval_definitions>

--- a/updater/fetchers/oracle/testdata/fetcher_oracle_test.2.xml
+++ b/updater/fetchers/oracle/testdata/fetcher_oracle_test.2.xml
@@ -1,0 +1,177 @@
+<oval_definitions xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:red-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#unix unix-definitions-schema.xsd http://oval.mitre.org/XMLSchema/oval-definitions-5#linux linux-definitions-schema.xsd">
+<generator>
+<oval:product_name>Oracle Errata System</oval:product_name>
+<oval:product_version>Oracle Linux</oval:product_version>
+<oval:schema_version>5.3</oval:schema_version>
+<oval:timestamp>2015-07-03T00:00:00</oval:timestamp>
+</generator>
+<definitions>
+<definition id="oval:com.oracle.elsa:def:20151207" version="501" class="patch">
+<metadata>
+<title>
+ELSA-2015-1207:  firefox security update (CRITICAL)
+</title>
+<affected family="unix">
+<platform>Oracle Linux 5</platform>
+<platform>Oracle Linux 6</platform>
+<platform>Oracle Linux 7</platform>
+
+</affected>
+<reference source="elsa" ref_id="ELSA-2015-1207" ref_url="http://linux.oracle.com/errata/ELSA-2015-1207.html"/>
+<reference source="CVE" ref_id="CVE-2015-2722" ref_url="http://linux.oracle.com/cve/CVE-2015-2722.html"/>
+<reference source="CVE" ref_id="CVE-2015-2724" ref_url="http://linux.oracle.com/cve/CVE-2015-2724.html"/>
+<reference source="CVE" ref_id="CVE-2015-2725" ref_url="http://linux.oracle.com/cve/CVE-2015-2725.html"/>
+<reference source="CVE" ref_id="CVE-2015-2727" ref_url="http://linux.oracle.com/cve/CVE-2015-2727.html"/>
+<reference source="CVE" ref_id="CVE-2015-2728" ref_url="http://linux.oracle.com/cve/CVE-2015-2728.html"/>
+<reference source="CVE" ref_id="CVE-2015-2729" ref_url="http://linux.oracle.com/cve/CVE-2015-2729.html"/>
+<reference source="CVE" ref_id="CVE-2015-2731" ref_url="http://linux.oracle.com/cve/CVE-2015-2731.html"/>
+<reference source="CVE" ref_id="CVE-2015-2733" ref_url="http://linux.oracle.com/cve/CVE-2015-2733.html"/>
+<reference source="CVE" ref_id="CVE-2015-2734" ref_url="http://linux.oracle.com/cve/CVE-2015-2734.html"/>
+<reference source="CVE" ref_id="CVE-2015-2735" ref_url="http://linux.oracle.com/cve/CVE-2015-2735.html"/>
+<reference source="CVE" ref_id="CVE-2015-2736" ref_url="http://linux.oracle.com/cve/CVE-2015-2736.html"/>
+<reference source="CVE" ref_id="CVE-2015-2737" ref_url="http://linux.oracle.com/cve/CVE-2015-2737.html"/>
+<reference source="CVE" ref_id="CVE-2015-2738" ref_url="http://linux.oracle.com/cve/CVE-2015-2738.html"/>
+<reference source="CVE" ref_id="CVE-2015-2739" ref_url="http://linux.oracle.com/cve/CVE-2015-2739.html"/>
+<reference source="CVE" ref_id="CVE-2015-2740" ref_url="http://linux.oracle.com/cve/CVE-2015-2740.html"/>
+<reference source="CVE" ref_id="CVE-2015-2741" ref_url="http://linux.oracle.com/cve/CVE-2015-2741.html"/>
+<reference source="CVE" ref_id="CVE-2015-2743" ref_url="http://linux.oracle.com/cve/CVE-2015-2743.html"/>
+
+<description>
+[38.1.0-1.0.1.el7_1]
+- Add firefox-oracle-default-prefs.js and remove the corresponding Red Hat file
+
+[38.1.0-1]
+- Update to 38.1.0 ESR
+
+[38.0.1-2]
+- Fixed rhbz#1222807 by removing preun section
+</description>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   advisory details   ~~~~~~~~~~~~~~~~~~~ 
+-->
+<advisory>
+<severity>CRITICAL</severity>
+<rights>Copyright 2015 Oracle, Inc.</rights>
+<issued date="2015-07-03"/>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2722.html">CVE-2015-2722</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2724.html">CVE-2015-2724</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2725.html">CVE-2015-2725</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2727.html">CVE-2015-2727</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2728.html">CVE-2015-2728</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2729.html">CVE-2015-2729</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2731.html">CVE-2015-2731</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2733.html">CVE-2015-2733</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2734.html">CVE-2015-2734</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2735.html">CVE-2015-2735</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2736.html">CVE-2015-2736</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2737.html">CVE-2015-2737</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2738.html">CVE-2015-2738</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2739.html">CVE-2015-2739</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2740.html">CVE-2015-2740</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2741.html">CVE-2015-2741</cve>
+<cve href="http://linux.oracle.com/cve/CVE-2015-2743.html">CVE-2015-2743</cve>
+
+</advisory>
+</metadata>
+<criteria operator="OR">
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207001" comment="Oracle Linux 5 is installed"/>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207002" comment="firefox is earlier than 0:38.1.0-1.0.1.el5_11"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207003" comment="firefox is signed with the Oracle Linux 5 key"/>
+</criteria>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207004" comment="Oracle Linux 6 is installed"/>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207005" comment="firefox is earlier than 0:38.1.0-1.0.1.el6_6"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207006" comment="firefox is signed with the Oracle Linux 6 key"/>
+</criteria>
+</criteria>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207007" comment="Oracle Linux 7 is installed"/>
+<criteria operator="AND">
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207008" comment="firefox is earlier than 0:38.1.0-1.0.1.el7_1"/>
+<criterion test_ref="oval:com.oracle.elsa:tst:20151207009" comment="firefox is signed with the Oracle Linux 7 key"/>
+</criteria>
+</criteria>
+</criteria>
+</definition>
+</definitions>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~~   rpminfo tests   ~~~~~~~~~~~~~~~~~~~~~ 
+-->
+<tests>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207001"  version="501" comment="Oracle Linux 5 is installed" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207001" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207003" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207002"  version="501" comment="firefox is earlier than 0:38.1.0-1.0.1.el5_11" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207004" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207003"  version="501" comment="firefox is signed with the Oracle Linux 5 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207001" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207004"  version="501" comment="Oracle Linux 6 is installed" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207001" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207005" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207005"  version="501" comment="firefox is earlier than 0:38.1.0-1.0.1.el6_6" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207006" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207006"  version="501" comment="firefox is signed with the Oracle Linux 6 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207002" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207007"  version="501" comment="Oracle Linux 7 is installed" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207001" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207007" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207008"  version="501" comment="firefox is earlier than 0:38.1.0-1.0.1.el7_1" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207008" />
+</rpminfo_test>
+<rpminfo_test id="oval:com.oracle.elsa:tst:20151207009"  version="501" comment="firefox is signed with the Oracle Linux 7 key" check="at least one" xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+<object object_ref="oval:com.oracle.elsa:obj:20151207002" />
+<state state_ref="oval:com.oracle.elsa:ste:20151207002" />
+</rpminfo_test>
+
+</tests>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   rpminfo objects   ~~~~~~~~~~~~~~~~~~~~ 
+-->
+<objects>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151207002" version="501">
+<name>firefox</name>
+</rpminfo_object>
+<rpminfo_object xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:obj:20151207001" version="501">
+<name>oraclelinux-release</name>
+</rpminfo_object>
+
+</objects>
+<states>
+<!--
+ ~~~~~~~~~~~~~~~~~~~~   rpminfo states   ~~~~~~~~~~~~~~~~~~~~~ 
+-->
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207001" version="501"><signature_keyid operation="equals">66ced3de1e5e0159</signature_keyid>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207002" version="501"><signature_keyid operation="equals">72f97b74ec551f03</signature_keyid>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207003" version="501"><version operation="pattern match">^5</version>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207004" version="501"><evr datatype="evr_string" operation="less than">0:38.1.0-1.0.1.el5_11</evr>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207005" version="501"><version operation="pattern match">^6</version>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207006" version="501"><evr datatype="evr_string" operation="less than">0:38.1.0-1.0.1.el6_6</evr>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207007" version="501"><version operation="pattern match">^7</version>
+</rpminfo_state>
+<rpminfo_state xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" id="oval:com.oracle.elsa:ste:20151207008" version="501"><evr datatype="evr_string" operation="less than">0:38.1.0-1.0.1.el7_1</evr>
+</rpminfo_state>
+
+</states>
+</oval_definitions>

--- a/worker/detectors/namespace/osrelease/osrelease.go
+++ b/worker/detectors/namespace/osrelease/osrelease.go
@@ -64,6 +64,12 @@ func (detector *OsReleaseNamespaceDetector) Detect(data map[string][]byte) *data
 		}
 	}
 
+	// Oracle Linux has both /etc/os-release and /etc/oracle-release
+	// Need to map to the correct namespace
+	if OS == "ol" || OS == "ol " {
+		return &database.Namespace{Name: "oracle:" + string(version[0])}
+	}
+
 	if OS != "" && version != "" {
 		return &database.Namespace{Name: OS + ":" + version}
 	}

--- a/worker/detectors/namespace/osrelease/osrelease_test.go
+++ b/worker/detectors/namespace/osrelease/osrelease_test.go
@@ -70,6 +70,49 @@ REDHAT_SUPPORT_PRODUCT="Fedora"
 REDHAT_SUPPORT_PRODUCT_VERSION=20`),
 		},
 	},
+	
+	{ // Doesn't have quotes around VERSION_ID
+                ExpectedNamespace: database.Namespace{Name: "oracle:7"},
+                Data: map[string][]byte{
+                        "etc/os-release": []byte(
+                                `NAME="Oracle Linux Server"
+VERSION="7.2"
+ID="ol"
+VERSION_ID="7.2"
+PRETTY_NAME="Oracle Linux Server 7.2"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:7:2:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 7"
+ORACLE_BUGZILLA_PRODUCT_VERSION=7.2
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=7.2`),
+                },
+        },
+
+	{ // Testing the namespace replacement for Oracle Linux 
+                ExpectedNamespace: database.Namespace{Name: "oracle:6"},
+                Data: map[string][]byte{
+                        "etc/os-release": []byte(
+                                `NAME="Oracle Linux Server"
+VERSION="6.8"
+ID="ol"
+VERSION_ID="6.8"
+PRETTY_NAME="Oracle Linux Server 6.8"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:oracle:linux:6:8:server"
+HOME_URL="https://linux.oracle.com/"
+BUG_REPORT_URL="https://bugzilla.oracle.com/"
+
+ORACLE_BUGZILLA_PRODUCT="Oracle Linux 6"
+ORACLE_BUGZILLA_PRODUCT_VERSION=6.8
+ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+ORACLE_SUPPORT_PRODUCT_VERSION=6.8`),
+                },
+        },
+
 }
 
 func TestOsReleaseNamespaceDetector(t *testing.T) {

--- a/worker/detectors/namespace/redhatrelease/redhatrelease.go
+++ b/worker/detectors/namespace/redhatrelease/redhatrelease.go
@@ -22,10 +22,10 @@ import (
 	"github.com/coreos/clair/worker/detectors"
 )
 
-var redhatReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
+var redhatReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux Server release|Linux release|release) (?P<version>[\d]+)`)
 
 // RedhatReleaseNamespaceDetector implements NamespaceDetector and detects the OS from the
-// /etc/centos-release, /etc/redhat-release and /etc/system-release files.
+// /etc/oracle-release, /etc/centos-release, /etc/redhat-release and /etc/system-release files.
 //
 // Typically for CentOS and Red-Hat like systems
 // eg. CentOS release 5.11 (Final)
@@ -55,5 +55,5 @@ func (detector *RedhatReleaseNamespaceDetector) Detect(data map[string][]byte) *
 
 // GetRequiredFiles returns the list of files that are required for Detect()
 func (detector *RedhatReleaseNamespaceDetector) GetRequiredFiles() []string {
-	return []string{"etc/centos-release", "etc/redhat-release", "etc/system-release"}
+	return []string{"etc/oracle-release", "etc/centos-release", "etc/redhat-release", "etc/system-release"}
 }

--- a/worker/detectors/namespace/redhatrelease/redhatrelease_test.go
+++ b/worker/detectors/namespace/redhatrelease/redhatrelease_test.go
@@ -23,6 +23,18 @@ import (
 
 var redhatReleaseTests = []namespace.NamespaceTest{
 	{
+		ExpectedNamespace: database.Namespace{Name: "oracle:6"},
+		Data: map[string][]byte{
+			"etc/oracle-release": []byte(`Oracle Linux Server release 6.8`),
+		},
+	},
+	{
+		ExpectedNamespace: database.Namespace{Name: "oracle:7"},
+		Data: map[string][]byte{
+			"etc/oracle-release": []byte(`Oracle Linux Server release 7.2`),
+		},
+	},
+	{
 		ExpectedNamespace: database.Namespace{Name: "centos:6"},
 		Data: map[string][]byte{
 			"etc/centos-release": []byte(`CentOS release 6.6 (Final)`),


### PR DESCRIPTION
(Please be gentle when reviewing, this is my first PR to a Go project).

This addresses issue #78 and adds support for Oracle Linux by creating a specific fetcher to grab OVAL content from Oracle and extends the `osrelease` and `redhatrelease` detectors to detect Oracle Linux.

I couldn't find the order in which the detectors are run, so I've adjusted both. Oracle Linux 5 triggers `redhatrelease` while OL6 and OL7 will be detected by `osrelease` because we ship an `/etc/os-release` on both.

Signed-off-by: Avi Miller avi.miller@oracle.com
