### PR TITLE
Redhatrelease detector

### DIFF
--- a/updater/fetchers/rhel/rhel.go
+++ b/updater/fetchers/rhel/rhel.go
@@ -291,6 +291,7 @@ func toFeatureVersions(criteria criteria) []database.FeatureVersion {
 		}
 
 		if osVersion >= firstConsideredRHEL {
+			// TODO(vbatts) this is where features need multiple labels ('centos' and 'rhel')
 			featureVersion.Feature.Namespace.Name = "centos" + ":" + strconv.Itoa(osVersion)
 		} else {
 			continue

--- a/worker/detectors/namespace/osrelease/osrelease.go
+++ b/worker/detectors/namespace/osrelease/osrelease.go
@@ -24,6 +24,8 @@ import (
 )
 
 var (
+	//log = capnslog.NewPackageLogger("github.com/coreos/clair", "worker/detectors/namespace/osrelease")
+
 	osReleaseOSRegexp      = regexp.MustCompile(`^ID=(.*)`)
 	osReleaseVersionRegexp = regexp.MustCompile(`^VERSION_ID=(.*)`)
 )
@@ -41,6 +43,12 @@ func init() {
 // /etc/debian_version can't be used, it does not make any difference between testing and unstable, it returns stretch/sid
 func (detector *OsReleaseNamespaceDetector) Detect(data map[string][]byte) *database.Namespace {
 	var OS, version string
+
+	for _, filePath := range detector.getExcludeFiles() {
+		if _, hasFile := data[filePath]; hasFile {
+			return nil
+		}
+	}
 
 	for _, filePath := range detector.GetRequiredFiles() {
 		f, hasFile := data[filePath]
@@ -73,4 +81,9 @@ func (detector *OsReleaseNamespaceDetector) Detect(data map[string][]byte) *data
 // GetRequiredFiles returns the list of files that are required for Detect()
 func (detector *OsReleaseNamespaceDetector) GetRequiredFiles() []string {
 	return []string{"etc/os-release", "usr/lib/os-release"}
+}
+
+// getExcludeFiles returns the list of files that are ought to exclude this detector from Detect()
+func (detector *OsReleaseNamespaceDetector) getExcludeFiles() []string {
+	return []string{"etc/redhat-release", "usr/lib/centos-release"}
 }


### PR DESCRIPTION
Due to the detector registration and fact that their in a non-ordered
map, it is random whether the osrelease or redhatrelease detector would
hit. And likely resulted in alternately formatted namespace strings.

This change causes the osrelease to not detect when data has
centos-release or redhat-release, which is not _great_ because if the
redhatrelease detector is not compiled in, then that would not be a
fallback that the osrelease detector could rely on. :-\

Until https://github.com/coreos/clair/pull/193 is merged, having
vulnerabilities that are tagged both rhel and centos would duplicate in
the database or use a change that requires a migration.

But presently due to the fetcher logic, the rhel provided
vulnerabilities are labelled for centos, and then the namespace does not
match and therefore not tested against.

So until such a day that a vulnerability could have both rhel and centos
label, then hack this in. It'll accomplish the same during this interim.
