### PR TITLE
skip TLS check for detecting layer data

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/coreos/clair"
 	"github.com/coreos/clair/config"
+	"github.com/coreos/clair/worker/detectors"
 
 	// Register components
 	_ "github.com/coreos/clair/notifier/notifiers"
@@ -57,6 +58,7 @@ func main() {
 	flagConfigPath := flag.String("config", "/etc/clair/config.yaml", "Load configuration from the specified file.")
 	flagCPUProfilePath := flag.String("cpu-profile", "", "Write a CPU profile to the specified file before exiting.")
 	flagLogLevel := flag.String("log-level", "info", "Define the logging level.")
+	flagInsecureTLS := flag.Bool("insecure-tls", false, "Disable TLS check when detect the data of layers.")
 	flag.Parse()
 	// Load configuration
 	config, err := config.Load(*flagConfigPath)
@@ -72,6 +74,11 @@ func main() {
 	// Enable CPU Profiling if specified
 	if *flagCPUProfilePath != "" {
 		defer stopCPUProfiling(startCPUProfiling(*flagCPUProfilePath))
+	}
+
+	// Disable TLS check when detect data if specified
+	if *flagInsecureTLS {
+		detectors.SetInsecureTLS(*flagInsecureTLS)
 	}
 
 	clair.Boot(config)

--- a/worker/detectors/data.go
+++ b/worker/detectors/data.go
@@ -17,6 +17,7 @@
 package detectors
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"math"
@@ -87,7 +88,11 @@ func DetectData(format, path string, headers map[string]string, toExtract []stri
 		}
 
 		// Send the request and handle the response.
-		r, err := http.DefaultClient.Do(request)
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client := &http.Client{Transport: tr}
+		r, err := client.Do(request)
 		if err != nil {
 			log.Warningf("could not download layer: %s", err)
 			return nil, ErrCouldNotFindLayer

--- a/worker/detectors/data.go
+++ b/worker/detectors/data.go
@@ -46,6 +46,10 @@ var (
 
 	// ErrCouldNotFindLayer is returned when we could not download or open the layer file.
 	ErrCouldNotFindLayer = cerrors.NewBadRequestError("could not find layer")
+
+	insecureTLSLock sync.Mutex
+	// insecureTLS controls the TLS check when detect the data of layers, enabled in default.
+	insecureTLS = false
 )
 
 // RegisterDataDetector provides a way to dynamically register an implementation of a
@@ -89,7 +93,7 @@ func DetectData(format, path string, headers map[string]string, toExtract []stri
 
 		// Send the request and handle the response.
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
 		}
 		client := &http.Client{Transport: tr}
 		r, err := client.Do(request)
@@ -124,4 +128,11 @@ func DetectData(format, path string, headers map[string]string, toExtract []stri
 	}
 
 	return nil, cerrors.NewBadRequestError(fmt.Sprintf("unsupported image format '%s'", format))
+}
+
+// SetInsecureTLS sets the insecureTLS to control the TLS check when detect the data of layers.
+func SetInsecureTLS(insecure bool) {
+	insecureTLSLock.Lock()
+	defer insecureTLSLock.Unlock()
+	insecureTLS = insecure
 }


### PR DESCRIPTION
This skips TLS check for detecting layer data from Server 
configured with TLS. 

Fixes #251 
