### PR TITLE
Add Ubuntu yakkety to the namespace mapping.

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -40,4 +40,5 @@ var UbuntuReleasesMapping = map[string]string{
 	"vivid":   "15.04",
 	"wily":    "15.10",
 	"xenial":  "16.04",
+	"yakkety": "16.10",
 }


### PR DESCRIPTION
Unknown Ubuntu mappings cause the revision number to not get [updated](https://github.com/coreos/clair/blob/051564facd852ef5bbb62db9625631a21f2199d5/updater/fetchers/ubuntu/ubuntu.go#L142), and yakkety has started appearing in the feed.  Add the appropriate mapping to restore incrementality.
