### PR TITLE
pgsql/migrations: add ldfv compound index

### DIFF
--- a/database/pgsql/migrations/00004_ldfv_index.go
+++ b/database/pgsql/migrations/00004_ldfv_index.go
@@ -1,0 +1,29 @@
+// Copyright 2016 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import "github.com/remind101/migrate"
+
+func init() {
+	RegisterMigration(migrate.Migration{
+		ID: 4,
+		Up: migrate.Queries([]string{
+			`CREATE INDEX layer_diff_featureversion_layer_id_modification_idx ON Layer_diff_FeatureVersion (layer_id, modification);`,
+		}),
+		Down: migrate.Queries([]string{
+			`DROP INDEX layer_diff_featureversion_layer_id_modification_idx;`,
+		}),
+	})
+}


### PR DESCRIPTION
This speeds up the SearchNotificationLayerIntroducingVulnerability query
by an order magnitude.

After adding this index and vacuuming the table, the following query changes from `570578.327 ms` to `1239.984 ms` execution time:

```sql
EXPLAIN ANALYZE WITH subquery AS (
  SELECT l.ID, l.name
  FROM Vulnerability_Affects_FeatureVersion vafv, FeatureVersion fv, Layer_diff_FeatureVersion ldfv, Layer l
  WHERE l.id >= $2
    AND vafv.vulnerability_id = $1
    AND vafv.featureversion_id = fv.id
    AND ldfv.featureversion_id = fv.id
    AND ldfv.modification = 'add'
    AND ldfv.layer_id = l.id
  ORDER BY l.ID
)
SELECT *
FROM subquery
LIMIT $3;
```