### PR TITLE
psql/migrations: fix ordering

### DIFF
--- a/database/pgsql/migrations/00005_ldfv_index.go
+++ b/database/pgsql/migrations/00005_ldfv_index.go
@@ -18,7 +18,7 @@ import "github.com/remind101/migrate"
 
 func init() {
 	RegisterMigration(migrate.Migration{
-		ID: 4,
+		ID: 5,
 		Up: migrate.Queries([]string{
 			`CREATE INDEX layer_diff_featureversion_layer_id_modification_idx ON Layer_diff_FeatureVersion (layer_id, modification);`,
 		}),


### PR DESCRIPTION
There were two migrations with ID 4. 