### PR TITLE
fix error when scanning folders for feteched update for Alpine vulnerabilities

### DIFF
--- a/updater/fetchers/alpine/alpine.go
+++ b/updater/fetchers/alpine/alpine.go
@@ -115,19 +115,22 @@ func detectNamespaces(path string) ([]string, error) {
 	defer dir.Close()
 
 	// Get a list of the namspaces from the directory names.
-	names, err := dir.Readdirnames(0)
+	finfos, err := dir.Readdir(0)
 	if err != nil {
 		return nil, err
 	}
 
 	var namespaces []string
-	for _, name := range names {
+	for _, info := range finfos {
+		if !info.IsDir() {
+			continue
+		}
 		// Filter out hidden directories like `.git`.
-		if strings.HasPrefix(name, ".") {
+		if strings.HasPrefix(info.Name(), ".") {
 			continue
 		}
 
-		namespaces = append(namespaces, name)
+		namespaces = append(namespaces, info.Name())
 	}
 
 	return namespaces, nil


### PR DESCRIPTION
Fix error `updater: an error occured when fetching update 'alpine': open /private/tmp/alpine-secdb808866024/Makefile/main.yaml: not a directory`.

This error happens on MacOS with `go version go1.7.4 darwin/amd64`.

For some strange reason `File.Readdirnames` returns names of directories and **files**. I've changed this code to use `File.Readdir` that returns `[]Fileinfo` and thus adding additional validation that skips non-directories, using `IsDir()` method.
