### PR TITLE
pgsql: searchNotificationLayerIntroducingVulnerability order by layer ID

### DIFF
--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -219,7 +219,7 @@ const (
 		    AND vafv.featureversion_id = fv.id
 		    AND ldfv.featureversion_id = fv.id
 		    AND ldfv.modification = 'add'
-		  ORDER BY ldfv.ID
+		  ORDER BY ldfv.layer_id
 		)
 		SELECT l.id, l.name
 		FROM LDFV, Layer l


### PR DESCRIPTION
This fixes a bug where the API was returning Notification pages ordered
by LDFV.ID instead of by Layer ID.