### PR TITLE
pgsql: only select distinct layers for LayersIntroducingVulnerability

### DIFF
--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -212,7 +212,7 @@ const (
 
 	searchNotificationLayerIntroducingVulnerability = `
 		WITH LDFV AS (
-		  SELECT ldfv.layer_id
+		  SELECT DISTINCT ldfv.layer_id
 		  FROM Vulnerability_Affects_FeatureVersion vafv, FeatureVersion fv, Layer_diff_FeatureVersion ldfv
 		  WHERE ldfv.layer_id >= $2
 		    AND vafv.vulnerability_id = $1


### PR DESCRIPTION
This removes duplicate Layers from the pagination over GetNotification.

Previously we would show the same Layer multiple times if it had multiple FeatureVersions introducing the the same vulnerability. This was unintuitive to the consumer of the API because the API doesn't return the FeatureVersion, so it just appeared to randomly be returning duplicates.

This should also make the query slightly faster in the cases I tested.