### PR TITLE
Relax the version's leading digit check.

### DIFF
--- a/utils/types/version.go
+++ b/utils/types/version.go
@@ -94,10 +94,6 @@ func NewVersion(str string) (Version, error) {
 		return Version{}, errors.New("No version")
 	}
 
-	if !unicode.IsDigit(rune(version.version[0])) {
-		return Version{}, errors.New("version does not start with digit")
-	}
-
 	for i := 0; i < len(version.version); i = i + 1 {
 		r := rune(version.version[i])
 		if !unicode.IsDigit(r) && !unicode.IsLetter(r) && !containsRune(versionAllowedSymbols, r) {

--- a/utils/types/version_test.go
+++ b/utils/types/version_test.go
@@ -101,8 +101,10 @@ func TestParse(t *testing.T) {
 		// Test invalid characters in epoch
 		{"a:0-0", Version{}, true},
 		{"A:0-0", Version{}, true},
-		// Test version not starting with a digit
-		{"0:abc3-0", Version{}, true},
+		// Test version not starting with a digit.
+		// While recommended by the specification, this is not strictly required and
+		// at least one vulnerable Alpine package deviates from this scheme.
+		{"0:abc3-0", Version{epoch: 0, version: "abc3", revision: "0"}, false},
 	}
 	for _, c := range cases {
 		v, err := NewVersion(c.str)


### PR DESCRIPTION
This change relaxes a check in `types.NewVersion` that requires the middle segment of a version string to start with a leading digit.

From the relevant `upstream_version` documentation (link above `NewVersion`, **emphasis** mine): "and **should** start with a digit".

You can see that Alpine deviates from this [here](http://git.alpinelinux.org/cgit/alpine-secdb/tree/v3.3/main.yaml#n72).  This isn't breaking the Clair Alpine ingester (at least yet) because the v3.3 format changed from its own to what the v3.4 file is using, which means Clair currently isn't seeing new vulnerabilities in the v3.3 feed.  While investigating this, I also noticed that there are two additional changes that Clair is missing support for: v3.5 and community.yaml
