### PR TITLE
ext/vulnsrc/rhel: fix logging namespace

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -54,7 +54,7 @@ var (
 
 	rhsaRegexp = regexp.MustCompile(`com.redhat.rhsa-(\d+).xml`)
 
-	log = capnslog.NewPackageLogger("github.com/coreos/clair", "updater/fetchers/rhel")
+	log = capnslog.NewPackageLogger("github.com/coreos/clair", "ext/vulnsrc/rhel")
 )
 
 type oval struct {


### PR DESCRIPTION
meh.

```
2017-02-22 18:44:37.671405 I | ext/vulnsrc/ubuntu: fetching Ubuntu vulnerabilities
2017-02-22 18:44:37.671638 I | ext/vulnsrc/debian: fetching Debian vulnerabilities
2017-02-22 18:44:37.672353 I | ext/vulnsrc/alpine: fetching Alpine vulnerabilities
2017-02-22 18:44:37.673842 I | ext/vulnsrc/oracle: fetching Oracle Linux vulnerabilities
2017-02-22 18:44:37.676817 I | updater/fetchers/rhel: fetching RHEL vulnerabilities
```