### PR TITLE
Fix areas only copying namespace names

### DIFF
--- a/database/pgsql/vulnerability.go
+++ b/database/pgsql/vulnerability.go
@@ -241,7 +241,7 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 		if fifv.Feature.Namespace.Name == "" {
 			// As there is no Namespace on that FixedIn FeatureVersion, set it to the Vulnerability's
 			// Namespace.
-			fifv.Feature.Namespace.Name = vulnerability.Namespace.Name
+			fifv.Feature.Namespace = vulnerability.Namespace
 		} else if fifv.Feature.Namespace.Name != vulnerability.Namespace.Name {
 			msg := "could not insert an invalid vulnerability that contains FixedIn FeatureVersion that are not in the same namespace as the Vulnerability"
 			log.Warning(msg)

--- a/updater.go
+++ b/updater.go
@@ -333,12 +333,14 @@ func (lv *lockableVulnerability) appendFunc(metadataKey string, metadata interfa
 	}
 }
 
-// doVulnerabilitiesNamespacing takes Vulnerabilities that don't have a Namespace and split them
-// into multiple vulnerabilities that have a Namespace and only contains the FixedIn
-// FeatureVersions corresponding to their Namespace.
+// doVulnerabilitiesNamespacing takes Vulnerabilities that don't have a
+// Namespace and split them into multiple vulnerabilities that have a Namespace
+// and only contains the FixedIn FeatureVersions corresponding to their
+// Namespace.
 //
-// It helps simplifying the fetchers that share the same metadata about a Vulnerability regardless
-// of their actual namespace (ie. same vulnerability information for every version of a distro).
+// It helps simplifying the fetchers that share the same metadata about a
+// Vulnerability regardless of their actual namespace (ie. same vulnerability
+// information for every version of a distro).
 func doVulnerabilitiesNamespacing(vulnerabilities []database.Vulnerability) []database.Vulnerability {
 	vulnerabilitiesMap := make(map[string]*database.Vulnerability)
 
@@ -351,7 +353,7 @@ func doVulnerabilitiesNamespacing(vulnerabilities []database.Vulnerability) []da
 
 			if vulnerability, ok := vulnerabilitiesMap[index]; !ok {
 				newVulnerability := v
-				newVulnerability.Namespace.Name = fv.Feature.Namespace.Name
+				newVulnerability.Namespace = fv.Feature.Namespace
 				newVulnerability.FixedIn = []database.FeatureVersion{fv}
 
 				vulnerabilitiesMap[index] = &newVulnerability


### PR DESCRIPTION
When performing the first vulnerability update, the namespaces being inserted for all the vulnerabilities are having their version format stripped.

This address this issue by ensuring that the whole namespace is copied when being reassigned.