### PR TITLE
Move Hyperclair link to Clairctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,6 @@ To expose the new behavior, unqualified imports to the package must be added in 
 
 - [Quay](https://quay.io): the first container registry to integrate with Clair
 - [Dockyard](https://github.com/containerops/dockyard): an open source container registry with Clair integration
-- [Hyperclair](https://github.com/wemanity-belgium/hyperclair): a lightweight command-line tool for working locally with Clair
+- [Clairctl](https://github.com/jgsqware/clairctl): a lightweight command-line tool for working locally with Clair and generate HTML report
 - [Clair w/ SQS](https://github.com/zalando/clair-sqs): a container containing Clair and additional processes that integrate Clair with [Amazon SQS](https://aws.amazon.com/sqs)
 - [Klar](https://github.com/optiopay/klar): a simple command-line integration of Clair and Docker registry, designed to be used in scripts and CI


### PR DESCRIPTION
github.com/wemanity-belgium/hyperclair is deprecated.
the new tool is located there: github.com/jgsqware/clairctl and the development continue there too