### PR TITLE
remove MAINTAINER from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@
 
 FROM golang:1.8-alpine
 
-MAINTAINER Quentin Machu <quentin.machu@coreos.com>
-
 VOLUME /config
 EXPOSE 6060 6061
 


### PR DESCRIPTION
Remove MAINTAINER from Dockerfile, as it has been deprecated in [Docker PR #25466](https://github.com/docker/docker/pull/25466)