### PR TITLE
fix an error produced by analyze-local-images remotely

### DIFF
--- a/contrib/analyze-local-images/main.go
+++ b/contrib/analyze-local-images/main.go
@@ -369,8 +369,6 @@ func listenHTTP(path, allowedHost string, ch chan error) {
 		fc := func(w http.ResponseWriter, r *http.Request) {
 			host, _, err := net.SplitHostPort(r.RemoteAddr)
                         allowedIPs, err1 := net.LookupIP(allowedHost)
-                        log.Printf("host: %s; ip: %s", host, allowedIPs[0])
-                        fmt.Println(host,allowedIPs)
 			if err == nil && err1 == nil {
                            allowedIPs = append(allowedIPs, net.ParseIP("172.17.0.1"))
                            for _, a :=range allowedIPs {


### PR DESCRIPTION
scripts: fix an error produced by analyze-local-images remotely

We are getting the error, Could not analyze layer: Got response 400 with message {"Error":{"Message":"could not find layer"}}, because the script only allow endpoint (from -endpoint) to access our local data. However, the logic only match ip address, which mean if you use anlayze-local-images -endpoint http://<dns-name>:6060 xxx, it will fails. The fix is to remove the restriction. 

Fixes #336