### PR TITLE
Enable runtime fetcher disable/enable

### DIFF
--- a/cmd/clair/config.go
+++ b/cmd/clair/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/clair"
 	"github.com/coreos/clair/api"
 	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/ext/vulnsrc"
 	"github.com/coreos/clair/ext/notification"
 	"github.com/fernet/fernet-go"
 )
@@ -43,6 +44,7 @@ type File struct {
 type Config struct {
 	Database database.RegistrableComponentConfig
 	Updater  *clair.UpdaterConfig
+	Fetcher  *vulnsrc.Config
 	Notifier *notification.Config
 	API      *api.Config
 }
@@ -61,6 +63,7 @@ func DefaultConfig() Config {
 			HealthPort: 6061,
 			Timeout:    900 * time.Second,
 		},
+		Fetcher: &vulnsrc.Config {},
 		Notifier: &notification.Config{
 			Attempts:         5,
 			RenotifyInterval: 2 * time.Hour,

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -110,7 +110,7 @@ func Boot(config *Config) {
 
 	// Start updater
 	st.Begin()
-	go clair.RunUpdater(config.Updater, db, st)
+	go clair.RunUpdater(config.Updater, config.Fetcher, db, st)
 
 	// Wait for interruption and shutdown gracefully.
 	waitForSignals(syscall.SIGINT, syscall.SIGTERM)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,6 +56,22 @@ clair:
     # The value 0 disables the updater entirely.
     interval: 2h
 
+  fetcher:
+    # You can enable or disable individual fetchers in this section. This is useful for reducing
+    # overall update times by disabling the distributions you will never scan
+    # The default if a distribution is unspecified/unconfigured is true/enabled.
+    alpine:
+      enabled: true
+    debian:
+      enabled: true
+    oracle:
+      enabled: true
+    rhel:
+      enabled: true
+    ubuntu:
+      enabled: true
+
+
   notifier:
     # Number of attempts before the notification is marked as failed to be sent
     attempts: 3

--- a/ext/vulnsrc/driver.go
+++ b/ext/vulnsrc/driver.go
@@ -42,9 +42,16 @@ type UpdateResponse struct {
 	Vulnerabilities []database.Vulnerability
 }
 
+type Config struct {
+	Params   map[string]interface{} `yaml:",inline"`
+}
+
 // Updater represents anything that can fetch vulnerabilities and insert them
 // into a Clair datastore.
 type Updater interface {
+	// Check configuration for Updater
+	Configure(*Config) (bool, error)
+
 	// Update gets vulnerability updates.
 	Update(database.Datastore) (UpdateResponse, error)
 
@@ -74,6 +81,13 @@ func RegisterUpdater(name string, u Updater) {
 	}
 
 	updaters[name] = u
+}
+
+func UnregisterUpdater(name string) {
+	updatersM.Lock()
+	defer updatersM.Unlock()
+
+	delete(updaters, name)
 }
 
 // Updaters returns the list of the registered Updaters.


### PR DESCRIPTION
Implements #221 

This adds a configuration section to config.yaml which allows users
to enable/disable each fetcher at runtime.

I used the same mechanism being used by the notifications so that future fetchers can add additional configuration items without too much work.

Signed-off-by: Avi Miller <avi.miller@oracle.com>