### PR TITLE
api: fix 404 error logging

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -52,7 +52,7 @@ func (rtr router) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("%s %d %s %s", http.StatusNotFound, r.Method, r.RequestURI, r.RemoteAddr)
+	log.Infof("%d %s %s %s", http.StatusNotFound, r.Method, r.RequestURI, r.RemoteAddr)
 	http.NotFound(w, r)
 }
 


### PR DESCRIPTION
The first value is an integer and the second value is a string and the
format string has these backwards, leading to %!s(int=404) appearing
in the logs instead of "404".