### PR TITLE
ext/vulnsrc/oracle: fix ELSA version comparison

### DIFF
--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -85,6 +85,36 @@ func init() {
 	vulnsrc.RegisterUpdater("oracle", &updater{})
 }
 
+func compareELSA(left, right int) int {
+	// Fast path equals.
+	if right == left {
+		return 0
+	}
+
+	lstr := strconv.Itoa(left)
+	rstr := strconv.Itoa(right)
+
+	for i := range lstr {
+		// If right is too short to be indexed, left is greater.
+		if i >= len(rstr) {
+			return 1
+		}
+
+		ldigit, _ := strconv.Atoi(string(lstr[i]))
+		rdigit, _ := strconv.Atoi(string(rstr[i]))
+
+		if ldigit > rdigit {
+			return 1
+		} else if ldigit < rdigit {
+			return -1
+		}
+		continue
+	}
+
+	// Everything the length of left is the same.
+	return len(lstr) - len(rstr)
+}
+
 func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
 	log.Info("fetching Oracle Linux vulnerabilities")
 
@@ -115,7 +145,7 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		r := elsaRegexp.FindStringSubmatch(line)
 		if len(r) == 2 {
 			elsaNo, _ := strconv.Atoi(r[1])
-			if elsaNo > firstELSA {
+			if compareELSA(elsaNo, firstELSA) > 0 {
 				elsaList = append(elsaList, elsaNo)
 			}
 		}

--- a/ext/vulnsrc/oracle/oracle_test.go
+++ b/ext/vulnsrc/oracle/oracle_test.go
@@ -115,3 +115,23 @@ func TestOracleParser(t *testing.T) {
 		}
 	}
 }
+
+func TestELSAComparison(t *testing.T) {
+	var table = []struct {
+		left     int
+		right    int
+		expected int
+	}{
+		{20170935, 20170935, 0},
+		{20170934, 20170935, -1},
+		{20170936, 20170935, 1},
+
+		{20170935, 201709331, 1},
+		{201709351, 20170935, 1},
+		{201709331, 20170935, -1},
+	}
+
+	for _, tt := range table {
+		assert.Equal(t, tt.expected, compareELSA(tt.left, tt.right))
+	}
+}


### PR DESCRIPTION
Previously we naively compared integers. However, not all versions have
the same length.