### PR TITLE
Add Ubuntu Zesty and Artful to UbuntuReleasesMapping

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -41,4 +41,6 @@ var UbuntuReleasesMapping = map[string]string{
 	"wily":    "15.10",
 	"xenial":  "16.04",
 	"yakkety": "16.10",
+	"zesty":   "17.04",
+	"artful":  "17.10",
 }


### PR DESCRIPTION
See also https://wiki.ubuntu.com/Releases :+1: :heart:

(Saw `clair: fetcher note: Ubuntu zesty is not mapped to any version number (eg. trusty->14.04). Please update me.` in some logs, and figured that's something I could do! :smile:)