### PR TITLE
Clair only support 1.9.1 docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Clair currently supports and tests against:
 * [Postgres] 9.4
 * [Postgres] 9.5
 * [Postgres] 9.6
+* [Docker] 1.9.1
 
 [Postgres]: https://www.postgresql.org
 


### PR DESCRIPTION
Clair only support 1.9.1 docker