### PR TITLE
ext/vulnsrc/oracle: ensure flag is largest elsa

### DIFF
--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -174,12 +174,21 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 	// Set the flag if we found anything.
 	if len(elsaList) > 0 {
 		resp.FlagName = updaterFlag
-		resp.FlagValue = strconv.Itoa(elsaList[len(elsaList)-1])
+		resp.FlagValue = strconv.Itoa(largest(elsaList))
 	} else {
 		log.Debug("no Oracle Linux update.")
 	}
 
 	return resp, nil
+}
+
+func largest(list []int) (largest int) {
+	for _, element := range list {
+		if element > largest {
+			largest = element
+		}
+	}
+	return
 }
 
 func (u *updater) Clean() {}


### PR DESCRIPTION
If the Oracle Linux directory is ever in the wrong order, this should
ensure that the updaterFlag is always set the latest ELSA value.