### PR TITLE
Clair only support docker 1.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Clair currently supports and tests against:
 * [Postgres] 9.4
 * [Postgres] 9.5
 * [Postgres] 9.6
+* [Docker] 1.9.1
 
 [Postgres]: https://www.postgresql.org
 


### PR DESCRIPTION
Clair only support docker 1.9.1

It will go wrong if docker run on 1.13.1 or 1.12

Clair is broken because of the content addressability inconsistencies in docker 1.10 (clair works fine till docker version 1.9.1); "docker history" command gives SHA256 layer IDs, while "docker save" command saves the layers.tar files in plain layer-UID directories.
Not sure if clair is going to fix the issue or will it be taken care of when docker/distribution#727 feature is supported by Docker.

https://github.com/coreos/clair/issues/372

https://github.com/coreos/clair/issues/69