### PR TITLE
pgsql: Change layer name column data type

### DIFF
--- a/database/pgsql/migrations/00007_expand_column_width.go
+++ b/database/pgsql/migrations/00007_expand_column_width.go
@@ -1,0 +1,31 @@
+// Copyright 2017 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import "github.com/remind101/migrate"
+
+func init() {
+	RegisterMigration(migrate.Migration{
+		ID: 7,
+		Up: migrate.Queries([]string{
+			`ALTER TABLE Namespace ALTER COLUMN version_format SET DATA TYPE varchar(256);`,
+			`ALTER TABLE Layer ALTER COLUMN name SET DATA TYPE varchar(256);`,
+		}),
+		Down: migrate.Queries([]string{
+			`ALTER TABLE Namespace ALTER COLUMN version_format SET DATA TYPE varchar(128);`,
+			`ALTER TABLE Layer ALTER COLUMN name SET DATA TYPE varchar(128);`,
+		}),
+	})
+}


### PR DESCRIPTION
Presently the `layer.name` column has type `varchar(128)`. This works
fine enough when using the sha256 layer digests provided by docker.
However, if one wishes to encode the image name into the layer (eg, to
avoid collisions like in https://github.com/coreos/clair/issues/319),
the limit of 128 bytes becomes a bit cramped.

I've configured my client to name layers using the docker layer digest

    sha256:21a547c3a96a390f700a68bc506a26e5c6e8f129fce41e05485d907d7fc130c1

concatenated with sha256(image.name, image.tag, layer.parent.digest):

    69429e10ce617a247feca82cf50ffc9bd071c1184e6910872f26b5c3d37325d3

This change allows the name column to support such a format.