### PR TITLE
added support for detecting multiple namespaces in a layer

### DIFF
--- a/api/v1/models.go
+++ b/api/v1/models.go
@@ -33,7 +33,7 @@ type Error struct {
 
 type Layer struct {
 	Name             string            `json:"Name,omitempty"`
-	NamespaceName    string            `json:"NamespaceName,omitempty"`
+	NamespaceNames   []string          `json:"NamespaceNames,omitempty"`
 	Path             string            `json:"Path,omitempty"`
 	Headers          map[string]string `json:"Headers,omitempty"`
 	ParentName       string            `json:"ParentName,omitempty"`
@@ -52,8 +52,8 @@ func LayerFromDatabaseModel(dbLayer database.Layer, withFeatures, withVulnerabil
 		layer.ParentName = dbLayer.Parent.Name
 	}
 
-	if dbLayer.Namespace != nil {
-		layer.NamespaceName = dbLayer.Namespace.Name
+	for _, ns := range dbLayer.Namespaces {
+		layer.NamespaceNames = append(layer.NamespaceNames, ns.Name)
 	}
 
 	if withFeatures || withVulnerabilities && dbLayer.Features != nil {

--- a/database/models.go
+++ b/database/models.go
@@ -31,7 +31,7 @@ type Layer struct {
 	Name          string
 	EngineVersion int
 	Parent        *Layer
-	Namespace     *Namespace
+	Namespaces    []Namespace
 	Features      []FeatureVersion
 }
 

--- a/database/pgsql/layer.go
+++ b/database/pgsql/layer.go
@@ -52,9 +52,6 @@ func (pgSQL *pgSQL) FindLayer(name string, withFeatures, withVulnerabilities boo
 		&layer.EngineVersion,
 		&parentID,
 		&parentName,
-		&nsID,
-		&nsName,
-		&nsVersionFormat,
 	)
 	observeQueryTime("FindLayer", "searchLayer", t)
 
@@ -68,11 +65,23 @@ func (pgSQL *pgSQL) FindLayer(name string, withFeatures, withVulnerabilities boo
 			Name:  parentName.String,
 		}
 	}
-	if !nsID.IsZero() {
-		layer.Namespace = &database.Namespace{
-			Model:         database.Model{ID: int(nsID.Int64)},
-			Name:          nsName.String,
-			VersionFormat: nsVersionFormat.String,
+
+	rows, err := pgSQL.Query(searchLayerNamespace, layer.ID)
+	defer rows.Close()
+	if err != nil {
+		return layer, handleError("searchLayerNamespace", err)
+	}
+	for rows.Next() {
+		err = rows.Scan(&nsID, &nsName, &nsVersionFormat)
+		if err != nil {
+			return layer, handleError("searchLayerNamespace", err)
+		}
+		if !nsID.IsZero() {
+			layer.Namespaces = append(layer.Namespaces, database.Namespace{
+				Model:         database.Model{ID: int(nsID.Int64)},
+				Name:          nsName.String,
+				VersionFormat: nsVersionFormat.String,
+			})
 		}
 	}
 
@@ -277,18 +286,22 @@ func (pgSQL *pgSQL) InsertLayer(layer database.Layer) error {
 		parentID = zero.IntFrom(int64(layer.Parent.ID))
 	}
 
-	// Find or insert namespace if provided.
-	var namespaceID zero.Int
-	if layer.Namespace != nil {
-		n, err := pgSQL.insertNamespace(*layer.Namespace)
+	// namespaceIDs will contain inherited and new namespaces
+	namespaceIDs := make(map[int]struct{})
+
+	// try to insert the new namespaces
+	for _, ns := range layer.Namespaces {
+		n, err := pgSQL.insertNamespace(ns)
 		if err != nil {
-			return err
+			return handleError("pgSQL.insertNamespace", err)
 		}
-		namespaceID = zero.IntFrom(int64(n))
-	} else if layer.Namespace == nil && layer.Parent != nil {
-		// Import the Namespace from the parent if it has one and this layer doesn't specify one.
-		if layer.Parent.Namespace != nil {
-			namespaceID = zero.IntFrom(int64(layer.Parent.Namespace.ID))
+		namespaceIDs[n] = struct{}{}
+	}
+
+	// inherit namespaces from parent layer
+	if layer.Parent != nil {
+		for _, ns := range layer.Parent.Namespaces {
+			namespaceIDs[ns.ID] = struct{}{}
 		}
 	}
 
@@ -301,7 +314,7 @@ func (pgSQL *pgSQL) InsertLayer(layer database.Layer) error {
 
 	if layer.ID == 0 {
 		// Insert a new layer.
-		err = tx.QueryRow(insertLayer, layer.Name, layer.EngineVersion, parentID, namespaceID).
+		err = tx.QueryRow(insertLayer, layer.Name, layer.EngineVersion, parentID).
 			Scan(&layer.ID)
 		if err != nil {
 			tx.Rollback()
@@ -315,17 +328,47 @@ func (pgSQL *pgSQL) InsertLayer(layer database.Layer) error {
 		}
 	} else {
 		// Update an existing layer.
-		_, err = tx.Exec(updateLayer, layer.ID, layer.EngineVersion, namespaceID)
+		_, err = tx.Exec(updateLayer, layer.ID, layer.EngineVersion)
 		if err != nil {
 			tx.Rollback()
 			return handleError("updateLayer", err)
 		}
 
+		// replace the old namespace in the database
+		_, err := tx.Exec(removeLayerNamespace, layer.ID)
+		if err != nil {
+			tx.Rollback()
+			return handleError("removeLayerNamespace", err)
+		}
 		// Remove all existing Layer_diff_FeatureVersion.
 		_, err = tx.Exec(removeLayerDiffFeatureVersion, layer.ID)
 		if err != nil {
 			tx.Rollback()
 			return handleError("removeLayerDiffFeatureVersion", err)
+		}
+	}
+
+	// insert the layer's namespaces
+	stmt, err := tx.Prepare(insertLayerNamespace)
+
+	if err != nil {
+		tx.Rollback()
+		return handleError("failed to prepare statement", err)
+	}
+
+	defer func() {
+		err = stmt.Close()
+		if err != nil {
+			tx.Rollback()
+			log.WithError(err).Error("failed to close prepared statement")
+		}
+	}()
+
+	for nsid := range namespaceIDs {
+		_, err := stmt.Exec(layer.ID, nsid)
+		if err != nil {
+			tx.Rollback()
+			return handleError("insertLayerNamespace", err)
 		}
 	}
 

--- a/database/pgsql/migrations/00008_add_multiplens.go
+++ b/database/pgsql/migrations/00008_add_multiplens.go
@@ -1,0 +1,44 @@
+// Copyright 2016 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrations
+
+import "github.com/remind101/migrate"
+
+func init() {
+	RegisterMigration(migrate.Migration{
+		ID: 8,
+		Up: migrate.Queries([]string{
+			// set on deletion, remove the corresponding rows in database
+			`CREATE TABLE IF NOT EXISTS Layer_Namespace(
+				id SERIAL PRIMARY KEY,
+				layer_id INT REFERENCES Layer(id) ON DELETE CASCADE,		  
+				namespace_id INT REFERENCES Namespace(id) ON DELETE CASCADE,
+				unique(layer_id, namespace_id)
+			);`,
+			`CREATE INDEX ON Layer_Namespace (namespace_id);`,
+			`CREATE INDEX ON Layer_Namespace (layer_id);`,
+			// move the namespace_id to the table
+			`INSERT INTO Layer_Namespace (layer_id, namespace_id) SELECT id, namespace_id FROM Layer;`,
+			// alter the Layer table to remove the column
+			`ALTER TABLE IF EXISTS Layer DROP namespace_id;`,
+		}),
+		Down: migrate.Queries([]string{
+			`ALTER TABLE IF EXISTS Layer ADD namespace_id INT NULL REFERENCES Namespace;`,
+			`CREATE INDEX ON Layer (namespace_id);`,
+			`UPDATE IF EXISTS Layer SET namespace_id = (SELECT lns.namespace_id FROM Layer_Namespace lns WHERE Layer.id = lns.layer_id LIMIT 1);`,
+			`DROP TABLE IF EXISTS Layer_Namespace;`,
+		}),
+	})
+}

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -77,11 +77,16 @@ const (
 
 	// layer.go
 	searchLayer = `
-		SELECT l.id, l.name, l.engineversion, p.id, p.name, n.id, n.name, n.version_format
-		FROM Layer l
-			LEFT JOIN Layer p ON l.parent_id = p.id
-			LEFT JOIN Namespace n ON l.namespace_id = n.id
+			SELECT l.id, l.name, l.engineversion, p.id, p.name
+			FROM Layer l
+				LEFT JOIN Layer p ON l.parent_id = p.id
 		WHERE l.name = $1;`
+
+	searchLayerNamespace = `
+			SELECT n.id, n.name, n.version_format 
+			FROM Namespace n
+				JOIN Layer_Namespace lns ON lns.namespace_id = n.id 
+			WHERE lns.layer_id = $1`
 
 	searchLayerFeatureVersion = `
 		WITH RECURSIVE layer_tree(id, name, parent_id, depth, path, cycle) AS(
@@ -113,11 +118,14 @@ const (
 						AND v.deleted_at IS NULL`
 
 	insertLayer = `
-		INSERT INTO Layer(name, engineversion, parent_id, namespace_id, created_at)
-    VALUES($1, $2, $3, $4, CURRENT_TIMESTAMP)
-    RETURNING id`
+		INSERT INTO Layer(name, engineversion, parent_id, created_at)
+		VALUES($1, $2, $3, CURRENT_TIMESTAMP)
+		RETURNING id`
 
-	updateLayer = `UPDATE LAYER SET engineversion = $2, namespace_id = $3 WHERE id = $1`
+	insertLayerNamespace = `INSERT INTO Layer_Namespace(layer_id, namespace_id) VALUES($1, $2)`
+	removeLayerNamespace = `DELETE FROM Layer_Namespace WHERE layer_id = $1`
+
+	updateLayer = `UPDATE LAYER SET engineversion = $2 WHERE id = $1`
 
 	removeLayerDiffFeatureVersion = `
 		DELETE FROM Layer_diff_FeatureVersion

--- a/database/pgsql/testdata/data.sql
+++ b/database/pgsql/testdata/data.sql
@@ -36,11 +36,11 @@ INSERT INTO layer (id, name, engineversion, parent_id) VALUES
   (5, 'layer-3b', 1, 3);
 
 INSERT INTO layer_namespace (id, layer_id, namespace_id) VALUES
-(1, 2, 1),
-(2, 3, 1),
-(3, 4, 1),
-(4, 5, 2),
-(5, 5, 1);
+  (1, 2, 1),
+  (2, 3, 1),
+  (3, 4, 1),
+  (4, 5, 2),
+  (5, 5, 1);
 
 INSERT INTO layer_diff_featureversion (id, layer_id, featureversion_id, modification) VALUES
   (1, 2, 1, 'add'),

--- a/database/pgsql/testdata/data.sql
+++ b/database/pgsql/testdata/data.sql
@@ -28,12 +28,19 @@ INSERT INTO featureversion (id, feature_id, version) VALUES
   (3, 2, '2.0'),
   (4, 3, '1.0');
 
-INSERT INTO layer (id, name, engineversion, parent_id, namespace_id) VALUES
-  (1, 'layer-0', 1, NULL, NULL),
-  (2, 'layer-1', 1, 1, 1),
-  (3, 'layer-2', 1, 2, 1),
-  (4, 'layer-3a', 1, 3, 1),
-  (5, 'layer-3b', 1, 3, 2);
+INSERT INTO layer (id, name, engineversion, parent_id) VALUES
+  (1, 'layer-0', 1, NULL),
+  (2, 'layer-1', 1, 1),
+  (3, 'layer-2', 1, 2),
+  (4, 'layer-3a', 1, 3),
+  (5, 'layer-3b', 1, 3);
+
+INSERT INTO layer_namespace (id, layer_id, namespace_id) VALUES
+(1, 2, 1),
+(2, 3, 1),
+(3, 4, 1),
+(4, 5, 2),
+(5, 5, 1);
 
 INSERT INTO layer_diff_featureversion (id, layer_id, featureversion_id, modification) VALUES
   (1, 2, 1, 'add'),
@@ -58,6 +65,7 @@ SELECT pg_catalog.setval(pg_get_serial_sequence('namespace', 'id'), (SELECT MAX(
 SELECT pg_catalog.setval(pg_get_serial_sequence('feature', 'id'), (SELECT MAX(id) FROM feature)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('featureversion', 'id'), (SELECT MAX(id) FROM featureversion)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('layer', 'id'), (SELECT MAX(id) FROM layer)+1);
+SELECT pg_catalog.setval(pg_get_serial_sequence('layer_namespace', 'id'), (SELECT MAX(id) FROM layer_namespace)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('layer_diff_featureversion', 'id'), (SELECT MAX(id) FROM layer_diff_featureversion)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('vulnerability', 'id'), (SELECT MAX(id) FROM vulnerability)+1);
 SELECT pg_catalog.setval(pg_get_serial_sequence('vulnerability_fixedin_feature', 'id'), (SELECT MAX(id) FROM vulnerability_fixedin_feature)+1);

--- a/ext/featurens/driver_test.go
+++ b/ext/featurens/driver_test.go
@@ -1,0 +1,66 @@
+package featurens_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/ext/featurens"
+	"github.com/coreos/clair/pkg/tarutil"
+	
+	_ "github.com/coreos/clair/ext/featurens/alpinerelease"
+	_ "github.com/coreos/clair/ext/featurens/aptsources"
+	_ "github.com/coreos/clair/ext/featurens/lsbrelease"
+	_ "github.com/coreos/clair/ext/featurens/osrelease"
+	_ "github.com/coreos/clair/ext/featurens/redhatrelease"
+)
+
+type MultipleNamespaceTestData struct {
+	Files              tarutil.FilesMap
+	ExpectedNamespaces []database.Namespace
+}
+
+func assertnsNameEqual(t *testing.T, nslist_expected, nslist []database.Namespace) {
+	assert.Equal(t, len(nslist_expected), len(nslist))
+	expected := map[string]struct{}{}
+	input := map[string]struct{}{}
+	// compare the two sets
+	for i := range nslist_expected {
+		expected[nslist_expected[i].Name] = struct{}{}
+		input[nslist[i].Name] = struct{}{}
+	}
+	assert.Equal(t, expected, input)
+}
+
+func testMultipleNamespace(t *testing.T, testData []MultipleNamespaceTestData) {
+	for _, td := range testData {
+		nslist, err := featurens.Detect(td.Files)
+		assert.Nil(t, err)
+		assertnsNameEqual(t, td.ExpectedNamespaces, nslist)
+	}
+}
+
+func TestMultipleNamespaceDetector(t *testing.T) {
+	testData := []MultipleNamespaceTestData{
+		{
+			ExpectedNamespaces: []database.Namespace{
+				database.Namespace{Name: "debian:8", VersionFormat: "dpkg"},
+				database.Namespace{Name: "alpine:v3.3", VersionFormat: "dpkg"},
+			},
+			Files: tarutil.FilesMap{
+				"etc/os-release": []byte(`
+PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
+NAME="Debian GNU/Linux"
+VERSION_ID="8"
+VERSION="8 (jessie)"
+ID=debian
+HOME_URL="http://www.debian.org/"
+SUPPORT_URL="http://www.debian.org/support/"
+BUG_REPORT_URL="https://bugs.debian.org/"`),
+				"etc/alpine-release": []byte(`3.3.4`),
+			},
+		},
+	}
+	testMultipleNamespace(t, testData)
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -85,7 +85,10 @@ func TestProcessWithDistUpgrade(t *testing.T) {
 	// Ensure that the 'wheezy' layer has the expected namespace and features.
 	wheezy, ok := datastore.layers["wheezy"]
 	if assert.True(t, ok, "layer 'wheezy' not processed") {
-		assert.Equal(t, "debian:7", wheezy.Namespace.Name)
+		if !assert.Len(t, wheezy.Namespaces, 1) {
+			return
+		}
+		assert.Equal(t, "debian:7", wheezy.Namespaces[0].Name)
 		assert.Len(t, wheezy.Features, 52)
 
 		for _, nufv := range nonUpgradedFeatureVersions {
@@ -98,7 +101,10 @@ func TestProcessWithDistUpgrade(t *testing.T) {
 	// Ensure that the 'wheezy' layer has the expected namespace and non-upgraded features.
 	jessie, ok := datastore.layers["jessie"]
 	if assert.True(t, ok, "layer 'jessie' not processed") {
-		assert.Equal(t, "debian:8", jessie.Namespace.Name)
+		if !assert.Len(t, jessie.Namespaces, 1) {
+			return
+		}
+		assert.Equal(t, "debian:8", jessie.Namespaces[0].Name)
 		assert.Len(t, jessie.Features, 74)
 
 		for _, nufv := range nonUpgradedFeatureVersions {


### PR DESCRIPTION
created table layer_namespace to store the many to many unique mapping of layers and namespaces
changed v1 api to provide a list of namespaces for each layer
changed namespace detector to use all registered detectors to detect namespaces
updated tests for multiple namespaces

Fixes #150