### PR TITLE
Add Debian Buster (10) and update "*stable" aliases

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -21,13 +21,15 @@ var DebianReleasesMapping = map[string]string{
 	"wheezy":  "7",
 	"jessie":  "8",
 	"stretch": "9",
+	"buster":  "10",
 	"sid":     "unstable",
 
 	// Class names
-	"oldstable": "7",
-	"stable":    "8",
-	"testing":   "9",
-	"unstable":  "unstable",
+	"oldoldstable": "7",
+	"oldstable":    "8",
+	"stable":       "9",
+	"testing":      "10",
+	"unstable":     "unstable",
 }
 
 // UbuntuReleasesMapping translates Ubuntu code names to version numbers


### PR DESCRIPTION
See https://lists.debian.org/debian-announce/2017/msg00003.html for the
official release announcement for Debian Stretch.

Saw the following in a log file and figured it was time for another easy contribution! :smile: :tada:

```
{"Event":"Debian buster is not mapped to any version number (eg. Jessie-\u003e8). Please update me.","Level":"warning","Location":"debian.go:128","Time":"2017-06-19 14:51:43.259746"}
```