### PR TITLE
Option to provide namespace'name when posting layer

### DIFF
--- a/Documentation/api_v1.md
+++ b/Documentation/api_v1.md
@@ -66,6 +66,7 @@ In order to analyze a container image, this route has to be called for each laye
 This request blocks for the entire duration of the downloading and indexing of the layer and displays the provided Layer with an updated `IndexByVersion` property.
 The Name field must be unique globally. Consequently, using the Blob digest describing the Layer content is not sufficient as Clair won't be able to differentiate two empty filesystem diffs that belong to two different image trees.
 The Authorization field is an optional value whose contents will fill the Authorization HTTP Header when requesting the layer via HTTP.
+The NamespaceName field is an optional value used when the namespace can't be determined by Clair.
 
 #### Example Request
 
@@ -82,7 +83,8 @@ POST http://localhost:6060/v1/layers HTTP/1.1
       "Authorization": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.EkN-DOsnsuRjRO6BxXemmJDm3HbxrbRzXglbN2S4sOkopdU4IsDxTI8jO19W_A4K8ZPJijNLis4EZsHeY559a4DFOd50_OqgHGuERTqYZyuhtF39yxJPAjUESwxk2J5k_4zM3O-vtd1Ghyo4IbqKKSy6J9mTniYJPenn5-HIirE"
     },
     "ParentName": "140f9bdfeb9784cf8730e9dab5dd12fbd704151cf555ac8cae650451794e5ac2",
-    "Format": "Docker"
+    "Format": "Docker",
+    "NamespaceName": "debian:7"
   }
 }
 ```

--- a/api/v1/routes.go
+++ b/api/v1/routes.go
@@ -109,7 +109,7 @@ func postLayer(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx 
 		return postLayerRoute, http.StatusBadRequest
 	}
 
-	err = clair.ProcessLayer(ctx.Store, request.Layer.Format, request.Layer.Name, request.Layer.ParentName, request.Layer.Path, request.Layer.Headers)
+	err = clair.ProcessLayer(ctx.Store, request.Layer.Format, request.Layer.Name, request.Layer.ParentName, request.Layer.Path, request.Layer.Headers, request.Layer.NamespaceName)
 	if err != nil {
 		if err == tarutil.ErrCouldNotExtract ||
 			err == tarutil.ErrExtractedFileTooBig ||

--- a/database/database.go
+++ b/database/database.go
@@ -76,6 +76,9 @@ type Datastore interface {
 	// ListNamespaces returns the entire list of known Namespaces.
 	ListNamespaces() ([]Namespace, error)
 
+	//GetNamespace returns the namespace with name namespaceName
+	GetNamespace(namespaceName string) (*Namespace, error)
+
 	// InsertLayer stores a Layer in the database.
 	//
 	// A Layer is uniquely identified by its Name.

--- a/database/mock.go
+++ b/database/mock.go
@@ -20,6 +20,7 @@ import "time"
 // The default behavior of each method is to simply panic.
 type MockDatastore struct {
 	FctListNamespaces           func() ([]Namespace, error)
+	FctGetNamespace             func(namespaceName string) (*Namespace, error)
 	FctInsertLayer              func(Layer) error
 	FctFindLayer                func(name string, withFeatures, withVulnerabilities bool) (Layer, error)
 	FctDeleteLayer              func(name string) error
@@ -45,6 +46,13 @@ type MockDatastore struct {
 func (mds *MockDatastore) ListNamespaces() ([]Namespace, error) {
 	if mds.FctListNamespaces != nil {
 		return mds.FctListNamespaces()
+	}
+	panic("required mock function not implemented")
+}
+
+func (mds *MockDatastore) GetNamespace(namespaceName string) (*Namespace, error) {
+	if mds.FctGetNamespace != nil {
+		return mds.FctGetNamespace(namespaceName)
 	}
 	panic("required mock function not implemented")
 }

--- a/database/pgsql/namespace.go
+++ b/database/pgsql/namespace.go
@@ -73,3 +73,12 @@ func (pgSQL *pgSQL) ListNamespaces() (namespaces []database.Namespace, err error
 
 	return namespaces, err
 }
+
+func (pgSQL *pgSQL) GetNamespace(namespaceName string) (*database.Namespace, error) {
+	var ns database.Namespace
+	err := pgSQL.QueryRow(getNamespace, namespaceName).Scan(&ns.ID, &ns.Name, &ns.VersionFormat)
+	if err != nil {
+		return nil, handleError("getNamespace", err)
+	}
+	return &ns, nil
+}

--- a/database/pgsql/namespace_test.go
+++ b/database/pgsql/namespace_test.go
@@ -72,3 +72,22 @@ func TestListNamespace(t *testing.T) {
 		}
 	}
 }
+
+func TestGetNamespace(t *testing.T) {
+	datastore, err := openDatabaseForTest("GetNamespace", true)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer datastore.Close()
+
+	// Invalid Namespace.
+	ns0, err := datastore.GetNamespace("Not present")
+	assert.NotNil(t, err)
+	assert.Nil(t, ns0)
+
+	// Valid Namespace.
+	ns1, err := datastore.GetNamespace("debian:7")
+	assert.Nil(t, err)
+	assert.Equal(t, ns1.Name, "debian:7")
+}

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -40,6 +40,7 @@ const (
 
 	searchNamespace = `SELECT id FROM Namespace WHERE name = $1`
 	listNamespace   = `SELECT id, name, version_format FROM Namespace`
+	getNamespace    = `SELECT id, name, version_format FROM Namespace WHERE name = $1`
 
 	// feature.go
 	soiFeature = `


### PR DESCRIPTION
This adds an optional field "NamespaceName" to the json provided when posting a Layer.
If during the analyse, Clair can't find the namespace associated to the Layer, we use the namespace provided by the user (only if it exists in the database).
I use this option to resolve the http 422 error I had when uploading some of my base images.

I made the change on the release-2.0 branch because it's the one I use at work and I know you are working on supporting multiple namespaces on the master branch. If it is in stable state, I can adapt the changes to that branch.