### PR TITLE
Added Portus integration

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -20,5 +20,6 @@ This document tracks projects that integrate with Clair. [Join the community](ht
 
 [check_openvz_mirror_with_clair](https://github.com/FastVPSEestiOu/check_openvz_mirror_with_clair): a tool to use Clair to analyze OpenVZ templates
 
+[Portus](http://port.us.org/features/6_security_scanning.html#coreos-clair): an authorization service and frontend for Docker registry (v2).
 
 [sqs]: https://aws.amazon.com/sqs/


### PR DESCRIPTION
Since SUSE/Portus#1289 got merged, Portus now integrates security
scanners in order to fetch vulnerabilities for the images stored in the
on-premise Docker registry. CoreOS Clair is a supported backend, so you
can now use Clair for this. This is all explained in the documentation:

  http://port.us.org/features/6_security_scanning.html

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>