### PR TITLE
Adding 'clair-scanner' cli tool as one of integration tools

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -22,6 +22,6 @@ This document tracks projects that integrate with Clair. [Join the community](ht
 
 [Portus](http://port.us.org/features/6_security_scanning.html#coreos-clair): an authorization service and frontend for Docker registry (v2).
 
-[clair-scanner](https://github.com/arminc/clair-scanner): a spin-off from 'analyze-local-images' who blocks on vulnerabilities with whitelist possibility
+[clair-scanner](https://github.com/arminc/clair-scanner): a project similar to 'analyze-local-images' with a whitelisting feature
 
 [sqs]: https://aws.amazon.com/sqs/

--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -22,4 +22,6 @@ This document tracks projects that integrate with Clair. [Join the community](ht
 
 [Portus](http://port.us.org/features/6_security_scanning.html#coreos-clair): an authorization service and frontend for Docker registry (v2).
 
+[clair-scanner](https://github.com/arminc/clair-scanner): a spin-off from 'analyze-local-images' who blocks on vulnerabilities with whitelist possibility
+
 [sqs]: https://aws.amazon.com/sqs/


### PR DESCRIPTION
I have created a spin-off from 'analyze-local-images' before it got deprecated, called clair-scanner. Clair-scanner uses Clair to check for vulnerabilities and blocks when there is one. But it also has an option to whitelist vulnerabilities which allows Clair to be used in a straight trough process as part of CI/CD pipeline. 

Although clair-scanner is derived from 'analyze-local-images' the code is different and is maintained.