### PR TITLE
update first instructions for k8s with helm

### DIFF
--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -44,7 +44,7 @@ A [PostgreSQL 9.4+] database instance is required for all instructions.
 #### Kubernetes (Helm)
 
 If you don't have a local Kubernetes cluster already, check out [minikube].
-This assumes you've already ran helm init and you have access to a currently running instance of Tiller.
+This assumes you've already ran `helm init` and you have access to a currently running instance of Tiller.
 
 [minikube]: https://github.com/kubernetes/minikube
 

--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -41,18 +41,19 @@ A [PostgreSQL 9.4+] database instance is required for all instructions.
 
 ### Cluster
 
-#### Kubernetes
+#### Kubernetes (Helm)
 
 If you don't have a local Kubernetes cluster already, check out [minikube].
-This also requires [helm].
+This assumes you've already ran helm init and you have access to a currently running instance of Tiller.
 
 [minikube]: https://github.com/kubernetes/minikube
-[helm]: https://github.com/kubernetes/helm
 
 ```
 git clone https://github.com/coreos/clair
 cd clair/contrib/helm
-helm install clair
+cp values.yaml ~/my_custom_values.yaml
+vi ~/my_custom_values.yaml
+helm install clair -f ~/my_custom_values.yaml
 ```
 
 ### Local

--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -44,14 +44,15 @@ A [PostgreSQL 9.4+] database instance is required for all instructions.
 #### Kubernetes
 
 If you don't have a local Kubernetes cluster already, check out [minikube].
+This also requires [helm].
 
 [minikube]: https://github.com/kubernetes/minikube
+[helm]: https://github.com/kubernetes/helm
 
 ```
 git clone https://github.com/coreos/clair
-cd clair/contrib/k8s
-kubectl create secret generic clairsecret --from-file=./config.yaml
-kubectl create -f clair-kubernetes.yaml
+cd clair/contrib/helm
+helm install clair
 ```
 
 ### Local


### PR DESCRIPTION
It appears the preferred method of installation for kubernetes is to use helm.
I updated documentation to reflect that.