### PR TITLE
Make source of vulnerability data configurable

### DIFF
--- a/cmd/clair/config.go
+++ b/cmd/clair/config.go
@@ -61,6 +61,7 @@ func DefaultConfig() Config {
 		Updater: &clair.UpdaterConfig{
 			EnabledUpdaters: vulnsrc.ListUpdaters(),
 			Interval:        1 * time.Hour,
+			SourceURLs:      make(map[string]string),
 		},
 		Worker: &clair.WorkerConfig{
 			EnabledDetectors: featurens.ListDetectors(),

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -124,6 +124,8 @@ func configClairVersion(config *Config) {
 	}
 
 	clair.EnabledUpdaters = strutil.CompareStringListsInBoth(config.Updater.EnabledUpdaters, updaters)
+
+	clair.SourceURLs = config.Updater.SourceURLs
 }
 
 // Boot starts Clair instance with the provided config.

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -68,12 +68,21 @@ clair:
     # Frequency the database will be updated with vulnerabilities from the default data sources
     # The value 0 disables the updater entirely.
     interval: 2h
+
     enabledupdaters: 
       - debian
       - ubuntu
       - rhel
       - oracle
       - alpine
+
+    # Vulnerability data sources
+    sourceurls:
+      alpine: "https://git.alpinelinux.org/cgit/alpine-secdb"
+      debian: "https://security-tracker.debian.org/tracker/data/json"
+      oracle: "https://linux.oracle.com/oval/"
+      rhel:   "https://www.redhat.com/security/data/oval/"
+      ubuntu: "https://launchpad.net/ubuntu-cve-tracker"
 
   notifier:
     # Number of attempts before the notification is marked as failed to be sent

--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -34,8 +34,9 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
+var	secdbGitURL = "https://git.alpinelinux.org/cgit/alpine-secdb"
+
 const (
-	secdbGitURL  = "https://git.alpinelinux.org/cgit/alpine-secdb"
 	updaterFlag  = "alpine-secdbUpdater"
 	nvdURLPrefix = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
 )
@@ -113,6 +114,10 @@ func (u *updater) Clean() {
 	if u.repositoryLocalPath != "" {
 		os.RemoveAll(u.repositoryLocalPath)
 	}
+}
+
+func (u *updater) SetSourceUrl(sourceURL string) {
+	secdbGitURL = sourceURL
 }
 
 type lsFilter int

--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -34,7 +34,7 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
-var	secdbGitURL = "https://git.alpinelinux.org/cgit/alpine-secdb"
+var secdbGitURL = "https://git.alpinelinux.org/cgit/alpine-secdb"
 
 const (
 	updaterFlag  = "alpine-secdbUpdater"

--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -34,8 +34,9 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
+var url = "https://security-tracker.debian.org/tracker/data/json"
+
 const (
-	url          = "https://security-tracker.debian.org/tracker/data/json"
 	cveURLPrefix = "https://security-tracker.debian.org/tracker"
 	updaterFlag  = "debianUpdater"
 )
@@ -100,6 +101,10 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 }
 
 func (u *updater) Clean() {}
+
+func (u *updater) SetSourceUrl(sourceURL string) {
+	url = sourceURL
+}
 
 func buildResponse(jsonReader io.Reader, latestKnownHash string) (resp vulnsrc.UpdateResponse, err error) {
 	hash := latestKnownHash

--- a/ext/vulnsrc/driver.go
+++ b/ext/vulnsrc/driver.go
@@ -50,6 +50,9 @@ type Updater interface {
 	// Clean deletes any allocated resources.
 	// It is invoked when Clair stops.
 	Clean()
+
+	// Sets the source of vulnerability data to be used by the updater
+	SetSourceUrl(string)
 }
 
 // RegisterUpdater makes an Updater available by the provided name.

--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -36,9 +36,10 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
+var ovalURI = "https://linux.oracle.com/oval/"
+
 const (
 	firstOracle5ELSA = 20070057
-	ovalURI          = "https://linux.oracle.com/oval/"
 	elsaFilePrefix   = "com.oracle.elsa-"
 	updaterFlag      = "oracleUpdater"
 )
@@ -201,6 +202,10 @@ func largest(list []int) (largest int) {
 }
 
 func (u *updater) Clean() {}
+
+func (u *updater) SetSourceUrl(sourceURL string) {
+	ovalURI = sourceURL
+}
 
 func parseELSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWithAffected, err error) {
 	// Decode the XML.

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -35,12 +35,13 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
+var ovalURI = "https://www.redhat.com/security/data/oval/"
+
 const (
 	// Before this RHSA, it deals only with RHEL <= 4.
 	firstRHEL5RHSA      = 20070044
 	firstConsideredRHEL = 5
 
-	ovalURI        = "https://www.redhat.com/security/data/oval/"
 	rhsaFilePrefix = "com.redhat.rhsa-"
 	updaterFlag    = "rhelUpdater"
 )
@@ -168,6 +169,10 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 }
 
 func (u *updater) Clean() {}
+
+func (u *updater) SetSourceUrl(sourceURL string) {
+	ovalURI = sourceURL
+}
 
 func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWithAffected, err error) {
 	// Decode the XML.

--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -40,9 +40,9 @@ import (
 var trackerRepository = "https://launchpad.net/ubuntu-cve-tracker"
 
 const (
-	trackerURI        = "https://launchpad.net/ubuntu-cve-tracker"
-	updaterFlag       = "ubuntuUpdater"
-	cveURL            = "http://people.ubuntu.com/~ubuntu-security/cve/%s"
+	trackerURI  = "https://launchpad.net/ubuntu-cve-tracker"
+	updaterFlag = "ubuntuUpdater"
+	cveURL      = "http://people.ubuntu.com/~ubuntu-security/cve/%s"
 )
 
 var (

--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -37,9 +37,10 @@ import (
 	"github.com/coreos/clair/pkg/commonerr"
 )
 
+var trackerRepository = "https://launchpad.net/ubuntu-cve-tracker"
+
 const (
 	trackerURI        = "https://launchpad.net/ubuntu-cve-tracker"
-	trackerRepository = "https://launchpad.net/ubuntu-cve-tracker"
 	updaterFlag       = "ubuntuUpdater"
 	cveURL            = "http://people.ubuntu.com/~ubuntu-security/cve/%s"
 )
@@ -173,6 +174,10 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 
 func (u *updater) Clean() {
 	os.RemoveAll(u.repositoryLocalPath)
+}
+
+func (u *updater) SetSourceUrl(sourceURL string) {
+	trackerRepository = sourceURL
 }
 
 func (u *updater) pullRepository() (err error) {

--- a/updater.go
+++ b/updater.go
@@ -57,6 +57,9 @@ var (
 
 	// EnabledUpdaters contains all updaters to be used for update.
 	EnabledUpdaters []string
+
+	// SourceURLs contains any modified vulnerability data sources
+	SourceURLs map[string]string
 )
 
 func init() {
@@ -69,6 +72,7 @@ func init() {
 type UpdaterConfig struct {
 	EnabledUpdaters []string
 	Interval        time.Duration
+	SourceURLs map[string]string
 }
 
 type vulnerabilityChange struct {
@@ -276,6 +280,9 @@ func fetch(datastore database.Datastore) (bool, []database.VulnerabilityWithAffe
 			continue
 		}
 		numUpdaters++
+		if url, ok := SourceURLs[n]; ok {
+			u.SetSourceUrl(url)
+		}
 		go func(name string, u vulnsrc.Updater) {
 			response, err := u.Update(datastore)
 			if err != nil {

--- a/updater.go
+++ b/updater.go
@@ -58,7 +58,7 @@ var (
 	// EnabledUpdaters contains all updaters to be used for update.
 	EnabledUpdaters []string
 
-	// SourceURLs contains any modified vulnerability data sources
+	// SourceURLs contains any alternative vulnerability data sources
 	SourceURLs map[string]string
 )
 

--- a/updater.go
+++ b/updater.go
@@ -72,7 +72,7 @@ func init() {
 type UpdaterConfig struct {
 	EnabledUpdaters []string
 	Interval        time.Duration
-	SourceURLs map[string]string
+	SourceURLs      map[string]string
 }
 
 type vulnerabilityChange struct {


### PR DESCRIPTION
This is a proposal for solving #401. I've added a new method to the Updater interface called SetSourceUrl which is invoked if the config file contains relevant source urls.

I've tried to stick to the conventions but there were a couple of things that I was not sure what to do with:

1. I have added SourceURLs as a var in updater.go. Another option would be to pass the config to fetch and use config.SourceURLs instead of SourceURLs in fetch. This would be more explicit, so I think I would prefer doing it this way, but I tried to stick to the conventions as much as possible...
2. Should I add all default urls to the sample config? I haven't but reading the comments in config.yaml.sample made me consider doing so. 