### PR TITLE
contrib/helm/clair: fix the ingress template

### DIFF
--- a/contrib/helm/clair/templates/ingress.yaml
+++ b/contrib/helm/clair/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "fullname" . -}}
-{{- $servicePort := .Values.service.externalPort -}}
+{{- $servicePort := .Values.service.externalApiPort -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:


### PR DESCRIPTION
Make `servicePort` reference `externalApiPort` instead of `externalPort`.