### PR TITLE
nvd: fix the name of a field

### DIFF
--- a/ext/vulnmdsrc/nvd/xml.go
+++ b/ext/vulnmdsrc/nvd/xml.go
@@ -41,7 +41,7 @@ type nvdCVSSBaseMetrics struct {
 	Authentication   string  `xml:"authentication"`
 	ConfImpact       string  `xml:"confidentiality-impact"`
 	IntegImpact      string  `xml:"integrity-impact"`
-	AvailImpact      string  `xml:"avaibility-impact"`
+	AvailImpact      string  `xml:"availability-impact"`
 }
 
 var vectorValuesToLetters map[string]string


### PR DESCRIPTION
The xml field "availability-impact" wasn't collected due to a typo.

Before: 
{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C"}}}

After:
{"NVD":{"CVSSv2":{"Score":9.3,"Vectors":"AV:N/AC:M/Au:N/C:C/I:C/**A:C**"}}}