### PR TITLE
Usage of running clair via docker is wrongly written.

### DIFF
--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -77,7 +77,7 @@ If this error is raised, manually execute `docker-compose start clair`.
 $ mkdir $PWD/clair_config
 $ curl -L https://raw.githubusercontent.com/coreos/clair/master/config.yaml.sample -o $PWD/clair_config/config.yaml
 $ docker run -d -e POSTGRES_PASSWORD="" -p 5432:5432 postgres:9.6
-$ docker run -d -p 6060-6061:6060-6061 -v $PWD/clair_config:/config quay.io/coreos/clair-git:latest -config=/config/config.yaml
+$ docker run --net=host -d -p 6060-6061:6060-6061 -v $PWD/clair_config:/config quay.io/coreos/clair-git:latest -config=/config/config.yaml
 ```
 
 #### Source


### PR DESCRIPTION
Command line needs --net=host when docker is used to run clair.