### PR TITLE
Driver: Add proxy support

### DIFF
--- a/ext/imagefmt/driver.go
+++ b/ext/imagefmt/driver.go
@@ -122,6 +122,7 @@ func Extract(format, path string, headers map[string]string, toExtract []string)
 		// Send the request and handle the response.
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
+			Proxy:           http.ProxyFromEnvironment,
 		}
 		client := &http.Client{Transport: tr}
 		r, err := client.Do(request)


### PR DESCRIPTION
I have to use a proxy on my servers running Clair.

Setting HTTP_PROXY variable works fine for the updater since http.Get and then DefaultTransport is used.

```
var DefaultTransport RoundTripper = &Transport{
        Proxy: ProxyFromEnvironment,
        ...
}
```

On the other hand, as the imagefmt driver declares a custom http.Transport to enable/disable certificate verification, it does not support HTTP_PROXY. I modified it to have the same behavior as the updater. 