### PR TITLE
vulnsrc_rhel: one vulnerability by CVE

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -213,7 +213,6 @@ func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWi
 
 			// Only RHSA is present
 			if len(definition.References) == 1 {
-				vulnerability.Link = definition.References[0].URI
 				vulnerabilities = append(vulnerabilities, vulnerability)
 			} else {
 				for _, reference := range definition.References[1:] {

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -201,6 +201,8 @@ func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWi
 			// Init vulnerability
 			vulnerability := database.VulnerabilityWithAffected{
 				Vulnerability: database.Vulnerability{
+					Name:        rhsaName(definition),
+					Link:        rhsaLink(definition),
 					Severity:    severity(definition),
 					Description: description(definition),
 				},
@@ -211,13 +213,12 @@ func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWi
 
 			// Only RHSA is present
 			if len(definition.References) == 1 {
-				vulnerability.Name = rhsaName(definition)
 				vulnerability.Link = definition.References[0].URI
 				vulnerabilities = append(vulnerabilities, vulnerability)
 			} else {
 				for _, reference := range definition.References[1:] {
-					vulnerability.Name = name(reference)
-					vulnerability.Link = link(reference)
+					vulnerability.Name = reference.ID
+					vulnerability.Link = reference.URI
 					vulnerabilities = append(vulnerabilities, vulnerability)
 				}
 			}
@@ -387,14 +388,13 @@ func severity(def definition) database.Severity {
 	}
 }
 
-func name(ref reference) string {
-	return ref.ID
-}
-
-func link(ref reference) string {
-	return ref.URI
-}
-
 func rhsaName(def definition) string {
 	return strings.TrimSpace(def.Title[:strings.Index(def.Title, ": ")])
+}
+
+func rhsaLink(def definition) (link string) {
+	if len(def.References) > 0 {
+		link = def.References[0].URI
+	}
+	return
 }

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -214,13 +214,16 @@ func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWi
 			// Only RHSA is present
 			if len(definition.References) == 1 {
 				vulnerabilities = append(vulnerabilities, vulnerability)
-			} else {
-				for _, reference := range definition.References[1:] {
-					vulnerability.Name = reference.ID
-					vulnerability.Link = reference.URI
-					vulnerabilities = append(vulnerabilities, vulnerability)
-				}
+				continue
 			}
+
+			// Create one vulnerability by CVE
+			for _, reference := range definition.References[1:] {
+				vulnerability.Name = reference.ID
+				vulnerability.Link = reference.URI
+				vulnerabilities = append(vulnerabilities, vulnerability)
+			}
+
 		}
 	}
 

--- a/ext/vulnsrc/rhel/rhel_test.go
+++ b/ext/vulnsrc/rhel/rhel_test.go
@@ -33,8 +33,8 @@ func TestRHELParser(t *testing.T) {
 	testFile, _ := os.Open(path + "/testdata/fetcher_rhel_test.1.xml")
 	vulnerabilities, err := parseRHSA(testFile)
 	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 1) {
-		assert.Equal(t, "RHSA-2015:1193", vulnerabilities[0].Name)
-		assert.Equal(t, "https://rhn.redhat.com/errata/RHSA-2015-1193.html", vulnerabilities[0].Link)
+		assert.Equal(t, "CVE-2015-0252", vulnerabilities[0].Name)
+		assert.Equal(t, "https://access.redhat.com/security/cve/CVE-2015-0252", vulnerabilities[0].Link)
 		assert.Equal(t, database.MediumSeverity, vulnerabilities[0].Severity)
 		assert.Equal(t, `Xerces-C is a validating XML parser written in a portable subset of C++. A flaw was found in the way the Xerces-C XML parser processed certain XML documents. A remote attacker could provide specially crafted XML input that, when parsed by an application using Xerces-C, would cause that application to crash.`, vulnerabilities[0].Description)
 
@@ -76,9 +76,9 @@ func TestRHELParser(t *testing.T) {
 	// Test parsing testdata/fetcher_rhel_test.2.xml
 	testFile, _ = os.Open(path + "/testdata/fetcher_rhel_test.2.xml")
 	vulnerabilities, err = parseRHSA(testFile)
-	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 1) {
-		assert.Equal(t, "RHSA-2015:1207", vulnerabilities[0].Name)
-		assert.Equal(t, "https://rhn.redhat.com/errata/RHSA-2015-1207.html", vulnerabilities[0].Link)
+	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 17) {
+		assert.Equal(t, "CVE-2015-2722", vulnerabilities[0].Name)
+		assert.Equal(t, "https://access.redhat.com/security/cve/CVE-2015-2722", vulnerabilities[0].Link)
 		assert.Equal(t, database.CriticalSeverity, vulnerabilities[0].Severity)
 		assert.Equal(t, `Mozilla Firefox is an open source web browser. XULRunner provides the XUL Runtime environment for Mozilla Firefox. Several flaws were found in the processing of malformed web content. A web page containing malicious content could cause Firefox to crash or, potentially, execute arbitrary code with the privileges of the user running Firefox.`, vulnerabilities[0].Description)
 

--- a/ext/vulnsrc/rhel/rhel_test.go
+++ b/ext/vulnsrc/rhel/rhel_test.go
@@ -39,6 +39,11 @@ func TestRHELParserMultipleCVE(t *testing.T) {
 		"CVE-2015-2729", "CVE-2015-2731", "CVE-2015-2733", "CVE-2015-2734", "CVE-2015-2735", "CVE-2015-2736",
 		"CVE-2015-2737", "CVE-2015-2738", "CVE-2015-2739", "CVE-2015-2740", "CVE-2015-2741", "CVE-2015-2743",
 	}
+	expectedSeverity := []database.Severity{database.CriticalSeverity, database.HighSeverity, database.HighSeverity,
+		database.MediumSeverity, database.MediumSeverity, database.MediumSeverity, database.CriticalSeverity,
+		database.CriticalSeverity, database.CriticalSeverity, database.CriticalSeverity, database.CriticalSeverity,
+		database.CriticalSeverity, database.CriticalSeverity, database.CriticalSeverity, database.CriticalSeverity,
+		database.MediumSeverity, database.MediumSeverity}
 	expectedFeatures := []database.AffectedFeature{
 		{
 			Namespace: database.Namespace{
@@ -65,7 +70,7 @@ func TestRHELParserMultipleCVE(t *testing.T) {
 		for i, vulnerability := range vulnerabilities {
 			assert.Equal(t, expectedCve[i], vulnerability.Name)
 			assert.Equal(t, fmt.Sprintf("https://access.redhat.com/security/cve/%s", expectedCve[i]), vulnerability.Link)
-			assert.Equal(t, database.CriticalSeverity, vulnerability.Severity)
+			assert.Equal(t, expectedSeverity[i], vulnerability.Severity)
 			assert.Equal(t, `Mozilla Firefox is an open source web browser. XULRunner provides the XUL Runtime environment for Mozilla Firefox. Several flaws were found in the processing of malformed web content. A web page containing malicious content could cause Firefox to crash or, potentially, execute arbitrary code with the privileges of the user running Firefox.`, vulnerability.Description)
 
 			for _, expectedFeature := range expectedFeatures {

--- a/ext/vulnsrc/rhel/rhel_test.go
+++ b/ext/vulnsrc/rhel/rhel_test.go
@@ -15,6 +15,7 @@
 package rhel
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,7 +26,55 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRHELParser(t *testing.T) {
+func TestRHELParserMultipleCVE(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(filename))
+
+	// Test parsing testdata/fetcher_rhel_test.2.xml
+	testFile, _ := os.Open(path + "/testdata/fetcher_rhel_test.2.xml")
+	vulnerabilities, err := parseRHSA(testFile)
+
+	// Expected
+	expectedCve := []string{"CVE-2015-2722", "CVE-2015-2724", "CVE-2015-2725", "CVE-2015-2727", "CVE-2015-2728",
+		"CVE-2015-2729", "CVE-2015-2731", "CVE-2015-2733", "CVE-2015-2734", "CVE-2015-2735", "CVE-2015-2736",
+		"CVE-2015-2737", "CVE-2015-2738", "CVE-2015-2739", "CVE-2015-2740", "CVE-2015-2741", "CVE-2015-2743",
+	}
+	expectedFeatures := []database.AffectedFeature{
+		{
+			Namespace: database.Namespace{
+				Name:          "centos:6",
+				VersionFormat: rpm.ParserName,
+			},
+			FeatureName:     "firefox",
+			FixedInVersion:  "0:38.1.0-1.el6_6",
+			AffectedVersion: "0:38.1.0-1.el6_6",
+		},
+		{
+			Namespace: database.Namespace{
+				Name:          "centos:7",
+				VersionFormat: rpm.ParserName,
+			},
+			FeatureName:     "firefox",
+			FixedInVersion:  "0:38.1.0-1.el7_1",
+			AffectedVersion: "0:38.1.0-1.el7_1",
+		},
+	}
+
+	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, len(expectedCve)) {
+
+		for i, vulnerability := range vulnerabilities {
+			assert.Equal(t, expectedCve[i], vulnerability.Name)
+			assert.Equal(t, fmt.Sprintf("https://access.redhat.com/security/cve/%s", expectedCve[i]), vulnerability.Link)
+			assert.Equal(t, database.CriticalSeverity, vulnerability.Severity)
+			assert.Equal(t, `Mozilla Firefox is an open source web browser. XULRunner provides the XUL Runtime environment for Mozilla Firefox. Several flaws were found in the processing of malformed web content. A web page containing malicious content could cause Firefox to crash or, potentially, execute arbitrary code with the privileges of the user running Firefox.`, vulnerability.Description)
+
+			for _, expectedFeature := range expectedFeatures {
+				assert.Contains(t, vulnerability.Affected, expectedFeature)
+			}
+		}
+	}
+}
+func TestRHELParserOneCVE(t *testing.T) {
 	_, filename, _, _ := runtime.Caller(0)
 	path := filepath.Join(filepath.Dir(filename))
 
@@ -65,41 +114,6 @@ func TestRHELParser(t *testing.T) {
 				FeatureName:     "xerces-c-doc",
 				AffectedVersion: "0:3.1.1-7.el7_1",
 				FixedInVersion:  "0:3.1.1-7.el7_1",
-			},
-		}
-
-		for _, expectedFeature := range expectedFeatures {
-			assert.Contains(t, vulnerabilities[0].Affected, expectedFeature)
-		}
-	}
-
-	// Test parsing testdata/fetcher_rhel_test.2.xml
-	testFile, _ = os.Open(path + "/testdata/fetcher_rhel_test.2.xml")
-	vulnerabilities, err = parseRHSA(testFile)
-	if assert.Nil(t, err) && assert.Len(t, vulnerabilities, 17) {
-		assert.Equal(t, "CVE-2015-2722", vulnerabilities[0].Name)
-		assert.Equal(t, "https://access.redhat.com/security/cve/CVE-2015-2722", vulnerabilities[0].Link)
-		assert.Equal(t, database.CriticalSeverity, vulnerabilities[0].Severity)
-		assert.Equal(t, `Mozilla Firefox is an open source web browser. XULRunner provides the XUL Runtime environment for Mozilla Firefox. Several flaws were found in the processing of malformed web content. A web page containing malicious content could cause Firefox to crash or, potentially, execute arbitrary code with the privileges of the user running Firefox.`, vulnerabilities[0].Description)
-
-		expectedFeatures := []database.AffectedFeature{
-			{
-				Namespace: database.Namespace{
-					Name:          "centos:6",
-					VersionFormat: rpm.ParserName,
-				},
-				FeatureName:     "firefox",
-				FixedInVersion:  "0:38.1.0-1.el6_6",
-				AffectedVersion: "0:38.1.0-1.el6_6",
-			},
-			{
-				Namespace: database.Namespace{
-					Name:          "centos:7",
-					VersionFormat: rpm.ParserName,
-				},
-				FeatureName:     "firefox",
-				FixedInVersion:  "0:38.1.0-1.el7_1",
-				AffectedVersion: "0:38.1.0-1.el7_1",
 			},
 		}
 

--- a/ext/vulnsrc/rhel/testdata/fetcher_rhel_test.2.xml
+++ b/ext/vulnsrc/rhel/testdata/fetcher_rhel_test.2.xml
@@ -50,23 +50,23 @@ Firefox.</description>
         <rights>Copyright 2015 Red Hat, Inc.</rights>
         <issued date="2015-07-02"/>
         <updated date="2015-07-02"/>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2722">CVE-2015-2722</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2724">CVE-2015-2724</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2725">CVE-2015-2725</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2727">CVE-2015-2727</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2728">CVE-2015-2728</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2729">CVE-2015-2729</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2731">CVE-2015-2731</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2733">CVE-2015-2733</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2734">CVE-2015-2734</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2735">CVE-2015-2735</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2736">CVE-2015-2736</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2737">CVE-2015-2737</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2738">CVE-2015-2738</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2739">CVE-2015-2739</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2740">CVE-2015-2740</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2741">CVE-2015-2741</cve>
-        <cve href="https://access.redhat.com/security/cve/CVE-2015-2743">CVE-2015-2743</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" cwe="CWE-416" href="https://access.redhat.com/security/cve/CVE-2015-2722" public="20150702">CVE-2015-2722</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2724" impact="important" public="20150702">CVE-2015-2724</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2725" impact="important" public="20150702">CVE-2015-2725</cve>
+        <cve cvss2="5.1/AV:N/AC:H/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2727" impact="moderate" public="20150702">CVE-2015-2727</cve>
+        <cve cvss2="5.1/AV:N/AC:H/Au:N/C:P/I:P/A:P" cwe="CWE-843" href="https://access.redhat.com/security/cve/CVE-2015-2728" impact="moderate" public="20150702">CVE-2015-2728</cve>
+        <cve cvss2="5.1/AV:N/AC:H/Au:N/C:P/I:P/A:P" cwe="CWE-125" href="https://access.redhat.com/security/cve/CVE-2015-2729" impact="moderate" public="20150702">CVE-2015-2729</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" cwe="CWE-416" href="https://access.redhat.com/security/cve/CVE-2015-2731" public="20150702">CVE-2015-2731</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" cwe="CWE-416" href="https://access.redhat.com/security/cve/CVE-2015-2733" public="20150702">CVE-2015-2733</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2734" public="20150702">CVE-2015-2734</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2735" public="20150702">CVE-2015-2735</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2736" public="20150702">CVE-2015-2736</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2737" public="20150702">CVE-2015-2737</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2738" public="20150702">CVE-2015-2738</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2739" public="20150702">CVE-2015-2739</cve>
+        <cve cvss2="6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P" href="https://access.redhat.com/security/cve/CVE-2015-2740" public="20150702">CVE-2015-2740</cve>
+        <cve cvss2="4.3/AV:N/AC:M/Au:N/C:P/I:N/A:N" href="https://access.redhat.com/security/cve/CVE-2015-2741" impact="moderate" public="20150702">CVE-2015-2741</cve>
+        <cve cvss2="5.1/AV:N/AC:H/Au:N/C:P/I:P/A:P" cwe="CWE-250" href="https://access.redhat.com/security/cve/CVE-2015-2743" impact="moderate" public="20150702">CVE-2015-2743</cve>
         <bugzilla href="https://bugzilla.redhat.com/1236947" id="1236947">CVE-2015-2724 CVE-2015-2725 Mozilla: Miscellaneous memory safety hazards (rv:31.8 / rv:38.1) (MFSA 2015-59)</bugzilla>
         <bugzilla href="https://bugzilla.redhat.com/1236950" id="1236950">CVE-2015-2727 Mozilla: Local files or privileged URLs in pages can be opened into new tabs (MFSA 2015-60)</bugzilla>
         <bugzilla href="https://bugzilla.redhat.com/1236951" id="1236951">CVE-2015-2728 Mozilla: Type confusion in Indexed Database Manager (MFSA 2015-61)</bugzilla>


### PR DESCRIPTION
Get one vulnerability by CVE_ID for RHEL instead of one by RHSA_ID so we can have NVD metadata added to the vulnerabilities.

Fixes #495