### PR TITLE
featurens: Ensure RHEL is correctly identified

### DIFF
--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux Server release) (?P<version>[\d]+)`)
+	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
 	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
 	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release) (?P<version>[\d]+)`)
 )

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -45,6 +45,12 @@ func TestDetector(t *testing.T) {
 		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
 			Files: tarutil.FilesMap{
+				"etc/redhat-release": []byte(`Red Hat Enterprise Linux Server release 7.2 (Maipo)`),
+			},
+		},
+		{
+			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
+			Files: tarutil.FilesMap{
 				"etc/system-release": []byte(`CentOS Linux release 7.1.1503 (Core)`),
 			},
 		},


### PR DESCRIPTION
When trying to identify various RedHat releases, RHEL was not being
picked up as a centos release because the Oracle Linux regex was too
permissive: it would match any release name with '<something> Linux
Server release' in the name. By being more restrictive with the Oracle
regex, RHEL is now properly identified.

I don't know why the Oracle regex used such a permissive matcher for the
name but it still passes all the tests by replacing it with the word
'Oracle'.

Fixes #436