### PR TITLE
api,database: updated version_format documentation.

### DIFF
--- a/api/v3/clairpb/clair.pb.go
+++ b/api/v3/clairpb/clair.pb.go
@@ -158,9 +158,11 @@ func (m *ClairStatus) GetLastUpdateTime() *google_protobuf2.Timestamp {
 }
 
 type Feature struct {
-	Name            string           `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
-	NamespaceName   string           `protobuf:"bytes,2,opt,name=namespace_name,json=namespaceName" json:"namespace_name,omitempty"`
-	Version         string           `protobuf:"bytes,3,opt,name=version" json:"version,omitempty"`
+	Name          string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
+	NamespaceName string `protobuf:"bytes,2,opt,name=namespace_name,json=namespaceName" json:"namespace_name,omitempty"`
+	Version       string `protobuf:"bytes,3,opt,name=version" json:"version,omitempty"`
+	// version_format is the format used by installer package manager to store
+	// package versions.
 	VersionFormat   string           `protobuf:"bytes,4,opt,name=version_format,json=versionFormat" json:"version_format,omitempty"`
 	Vulnerabilities []*Vulnerability `protobuf:"bytes,5,rep,name=vulnerabilities" json:"vulnerabilities,omitempty"`
 }

--- a/api/v3/clairpb/clair.proto
+++ b/api/v3/clairpb/clair.proto
@@ -45,6 +45,9 @@ message Feature{
 	string name = 1;
 	string namespace_name = 2;
 	string version = 3;
+
+	// version_format is the format used by installer package manager to store
+	// package versions.
 	string version_format = 4;
 	repeated Vulnerability vulnerabilities = 5;
 }

--- a/api/v3/clairpb/clair.swagger.json
+++ b/api/v3/clairpb/clair.swagger.json
@@ -232,7 +232,8 @@
           "type": "string"
         },
         "version_format": {
-          "type": "string"
+          "type": "string",
+          "description": "version_format is the format used by installer package manager to store\npackage versions."
         },
         "vulnerabilities": {
           "type": "array",

--- a/database/models.go
+++ b/database/models.go
@@ -71,8 +71,8 @@ type Namespace struct {
 // determined.
 //
 // e.g. Name: OpenSSL, Version: 1.0, VersionFormat: dpkg.
-// dpkg implies the installer package manager but the namespace (might be
-// debian:7, debian:8, ...) could not be determined.
+// dpkg is the version format of the installer package manager, which in this
+// case could be dpkg or apk.
 type Feature struct {
 	Name          string
 	Version       string


### PR DESCRIPTION
Version format documentation is updated in the example of feature
struct and created in clair.proto along with accordingly generated
swagger and protobuf files.

Fixes #514