### PR TITLE
fix whitespace remove in postgresql configmap helm chart

### DIFF
--- a/contrib/helm/clair/templates/configmap.yaml
+++ b/contrib/helm/clair/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
           # PostgreSQL Connection string
           # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
           # This should be done using secrets or Vault, but for now this will also work
-          {{- if .Values.config.postgresURI -}}
+          {{- if .Values.config.postgresURI }}
           source: "{{ .Values.config.postgresURI }}"
           {{ else }}
           source: "postgres://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgresql.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}?sslmode=disable"


### PR DESCRIPTION
When setting a dedicated postgresql instance with the config.postgresURI value, there is no entry for clair.database.options.source in the configmap after helm deploy.

The if statement in configmap.yaml has two dashes "-". It turns out that the newline between source and the comment above is removed by the ending "-".

```
# PostgreSQL Connection string
# https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
# This should be done using secrets or Vault, but for now this will also work
{{- if .Values.config.postgresURI -}}
source: "{{ .Values.config.postgresURI }}"
```

Generated yaml:
```
# PostgreSQL Connection string
# https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
# This should be done using secrets or Vault, but for now this will also worksource: "postgres://clair:*********@psql.cloudsql.svc.cluster.local:5432/postgres?sslmode=disable"
```

The [helm documentation](https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/control_structures.md) says:
> {{- (with the dash and space added) indicates that whitespace should be chomped left, while -}} means whitespace to the right should be consumed. Be careful! Newlines are whitespace!