### PR TITLE
Improvements to the helm chart

### DIFF
--- a/contrib/helm/clair/templates/configmap.yaml
+++ b/contrib/helm/clair/templates/configmap.yaml
@@ -14,7 +14,7 @@ data:
           # PostgreSQL Connection string
           # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
           # This should be done using secrets or Vault, but for now this will also work
-          {{- if .Values.config.postgresURI -}}
+          {{- if .Values.config.postgresURI }}
           source: "{{ .Values.config.postgresURI }}"
           {{ else }}
           source: "postgres://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgresql.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}?sslmode=disable"

--- a/contrib/helm/clair/values.yaml
+++ b/contrib/helm/clair/values.yaml
@@ -34,7 +34,7 @@ resources:
     memory: 1Gi
   requests:
     cpu: 100m
-    memory: 128Mi
+    memory: 500Mi
 config:
   # postgresURI: "postgres://user:password@host:5432/postgres?sslmode=disable"
   paginationKey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ="
@@ -59,6 +59,9 @@ config:
 # Configuration values for the postgresql dependency.
 # ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
 postgresql:
+# The dependant Postgres chart can be disabled, to connect to
+# an existing database by defining config.postgresURI
+  enabled: true
   cpu: 1000m
   memory: 1Gi
 # These values are hardcoded until Helm supports secrets.


### PR DESCRIPTION
With this PR I'd like to fix the hurdles I've run into.

These are:
* one bug: the `source: postgresURI ` line was merged the the comment above, because the if statement strips newlines at both ends.
* the memory limits are too low, causing Clair to be scheduled on hosts that doesn't have enough memory available - and eventually OOM the container or machine.
* Switch to the stable release, as the git version doesn't work out of the box.
* Explicitly mention that `postgresql.enabled` can be set to false, because the `requirements.yaml` allows that.

Do you also have plans to move this chart to the official helm chart repositories?