### PR TITLE
Helm: Fixed a typo in maintainers field.

### DIFF
--- a/contrib/helm/clair/Chart.yaml
+++ b/contrib/helm/clair/Chart.yaml
@@ -8,4 +8,4 @@ sources:
   - https://github.com/coreos/clair
 maintainers:
   - name: Jimmy Zelinskie
-  - email: jimmy.zelinskie@coreos.com
+    email: jimmy.zelinskie@coreos.com


### PR DESCRIPTION
Maintainers field was incorrectly listing email as one item.