### PR TITLE
Proxy for 2.0

### DIFF
--- a/ext/imagefmt/driver.go
+++ b/ext/imagefmt/driver.go
@@ -122,6 +122,7 @@ func Extract(format, path string, headers map[string]string, toExtract []string)
 		// Send the request and handle the response.
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureTLS},
+			Proxy:           http.ProxyFromEnvironment,
 		}
 		client := &http.Client{Transport: tr}
 		r, err := client.Do(request)


### PR DESCRIPTION
Hi,

I see some issues on this repo about running from master, so I've tried deploying v2.0.1.

I get an error when attempting to POST a layer to Clair. Here is an example log of pushing alpine:

```
{"Event":"could not download layer","Level":"warning","Location":"driver.go:129","Time":"2018-03-14 20:36:46.683821","error":"Get https://registry-1.docker.io/v2/library/alpine/blobs/sha256:ff3a5c916c92643ff77519ffa742d3ec61b7f591b6b7504599d95a4a41134e28: dial tcp 52.5.185.86:443: getsockopt: connection timed out"}
{"Event":"failed to extract data from path","Level":"error","Location":"worker.go:122","Time":"2018-03-14 20:36:46.683949","error":"could not find layer","layer":"3fd9065eaf02feaf94d68376da52541925650b81698c53c6824d92ff63f98353ff3a5c916c92643ff77519ffa742d3ec61b7f591b6b7504599d95a4a41134e28","path":"https://registry-1.docker.io/v2/library/alpine/blobs/sha256:ff3a5c916c92643ff77519ffa742d3ec61b7f591b6b7504599d95a4a41134e28"}
```

The request was not configured for the proxy.

Looks like this has been added in master, it would be great if we could get a v2.0.2 release with this change too.