### PR TITLE
api/v3/server: Fix binding in ipv4 only systems

### DIFF
--- a/api/v3/server.go
+++ b/api/v3/server.go
@@ -124,6 +124,9 @@ func newGrpcGatewayServer(ctx context.Context, listenerAddr string, tlsConfig *t
 	jsonOpt := runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{EmitDefaults: true})
 	gwmux := runtime.NewServeMux(jsonOpt)
 
+	// workaround for https://github.com/golang/go/issues/18806
+	listenerAddr = strings.TrimPrefix(listenerAddr, "[::]")
+
 	conn, err := grpc.DialContext(ctx, listenerAddr, gwOpts...)
 	if err != nil {
 		log.WithError(err).Fatal("could not initialize grpc gateway connection")


### PR DESCRIPTION
This workarounds 0.0.0.0 not working in ipv4 only systems.

Fixes #526 #533