### PR TITLE
Upgrade to go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go: 
-  - 1.8
+  - "1.10"
 
 sudo: required
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.8-alpine
+FROM golang:1.10-alpine
 
 VOLUME /config
 EXPOSE 6060 6061


### PR DESCRIPTION
Also upgrading to golang:1.10-alpine docker base image.
This also fixes https://github.com/coreos/clair/issues/546