### PR TITLE
Use golang:1.10-alpine with v2.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.8-alpine
+FROM golang:1.10-alpine
 
 VOLUME /config
 EXPOSE 6060 6061


### PR DESCRIPTION
This is the v2 version of https://github.com/coreos/clair/pull/551.
This will fix [CVE-2017-14166](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14166) in libarchive.

Please also create a new docker image build (probably v2.0.3).