### PR TITLE
ext/vulnsrc/ubuntu: updated tracker src

### DIFF
--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	trackerURI        = "https://launchpad.net/ubuntu-cve-tracker"
-	trackerRepository = "https://launchpad.net/ubuntu-cve-tracker"
+	trackerURI        = "https://launchpad.net/~ubuntu-security/ubuntu-cve-tracker/master"
+	trackerRepository = "https://launchpad.net/~ubuntu-security/ubuntu-cve-tracker/master"
 	updaterFlag       = "ubuntuUpdater"
 	cveURL            = "http://people.ubuntu.com/~ubuntu-security/cve/%s"
 )


### PR DESCRIPTION
The existing address had been switched from bzr to git. Changed address to location of current bzr master

Fixes #524