### PR TITLE
/ext/vulnmdsrc/nvd Switched NVD URLs to https

### DIFF
--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -38,8 +38,8 @@ import (
 )
 
 const (
-	dataFeedURL     string = "http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.xml.gz"
-	dataFeedMetaURL string = "http://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.meta"
+	dataFeedURL     string = "https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.xml.gz"
+	dataFeedMetaURL string = "https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.meta"
 
 	appenderName string = "NVD"
 


### PR DESCRIPTION
NVD Stopped serving traffic on http endpoints.  Updated to https

Fixes #515