### PR TITLE
Updating the ubuntu vulnsrc to use the new git repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ EXPOSE 6060 6061
 ADD .   /go/src/github.com/coreos/clair/
 WORKDIR /go/src/github.com/coreos/clair/
 
-RUN apk add --no-cache git bzr rpm xz && \
+RUN apk add --no-cache git rpm xz && \
     go install -v github.com/coreos/clair/cmd/clair && \
     mv /go/bin/clair /clair && \
     rm -rf /go /usr/local/go

--- a/README.md
+++ b/README.md
@@ -119,14 +119,12 @@ To build Clair, you need to latest stable version of [Go] and a working [Go envi
 In addition, Clair requires some additional binaries be installed on the system [$PATH] as runtime dependencies:
 
 * [git]
-* [bzr]
 * [rpm]
 * [xz]
 
 [Go]: https://github.com/golang/go/releases
 [Go environment]: https://golang.org/doc/code.html
 [git]: https://git-scm.com
-[bzr]: http://bazaar.canonical.com/en
 [rpm]: http://www.rpm.org
 [xz]: http://tukaani.org/xz
 [$PATH]: https://en.wikipedia.org/wiki/PATH_(variable)

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -127,7 +127,7 @@ func main() {
 	flag.Parse()
 
 	// Check for dependencies.
-	for _, bin := range []string{"git", "bzr", "rpm", "xz"} {
+	for _, bin := range []string{"git", "rpm", "xz"} {
 		_, err := exec.LookPath(bin)
 		if err != nil {
 			log.WithError(err).WithField("dependency", bin).Fatal("failed to find dependency")


### PR DESCRIPTION
Hi,
Since ubuntu has officially moved their cve-tracker to use git instead of bzr. I've updated the vulnsrc for ubuntu to use git. A lot of the code was copied from Alpine.

I've built and tested locally and it all runs fine.

Cheers,