### PR TITLE
Update to correct repo

### DIFF
--- a/contrib/compose/docker-compose.yml
+++ b/contrib/compose/docker-compose.yml
@@ -9,7 +9,10 @@ services:
 
   clair:
     container_name: clair_clair
-    image: quay.io/coreos/clair-git:latest
+    image: quay.io/coreos/clair:latest
+    environment:
+      #  - HTTP_PROXY=http://yourproxy.com:port
+      #  - HTTPS_PROXY=http://yourproxy.com:port
     restart: unless-stopped
     depends_on:
       - postgres


### PR DESCRIPTION
  clair:latest is the stable one
  clair-git:latest is buggy to use
  add proxy setting if clair runs behind proxy