### PR TITLE
Helm: change postgresql connection string format in configmap template

### DIFF
--- a/contrib/helm/clair/templates/_config.yaml.tpl
+++ b/contrib/helm/clair/templates/_config.yaml.tpl
@@ -8,7 +8,7 @@ clair:
       {{- if .Values.config.postgresURI }}
       source: "{{ .Values.config.postgresURI }}"
       {{ else }}
-      source: "postgres://{{ .Values.postgresql.postgresUser }}:{{ .Values.postgresql.postgresPassword }}@{{ template "postgresql.fullname" . }}:5432/{{ .Values.postgresql.postgresDatabase }}?sslmode=disable"
+      source: "host={{ template "postgresql.fullname" . }} port=5432 user={{ .Values.postgresql.postgresUser }} password={{ .Values.postgresql.postgresPassword }} dbname={{ .Values.postgresql.postgresDatabase }} sslmode=disable statement_timeout=60000"
       {{ end }}
 
       # Number of elements kept in the cache.


### PR DESCRIPTION
The PostgreSQL connection string in the configmap template for helm was
changed to a key-value format to reflect the currently used format in
the sample config file

Fixes #561