### PR TITLE
Check http code when downloading vulnerabilities data

### DIFF
--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -90,6 +90,11 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		return resp, commonerr.ErrCouldNotDownload
 	}
 
+	if r.StatusCode != http.StatusOK {
+		log.WithField("StatusCode", r.StatusCode).Error("could not download Debian's update")
+		return resp, commonerr.ErrCouldNotDownload
+	}
+
 	// Parse the JSON.
 	resp, err = buildResponse(r.Body, latestHash)
 	if err != nil {

--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -144,6 +144,10 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		log.WithError(err).Error("could not download Oracle's update list")
 		return resp, commonerr.ErrCouldNotDownload
 	}
+	if r.StatusCode != http.StatusOK {
+		log.WithField("StatusCode", r.StatusCode).Error("could not download Oracle's update list")
+		return resp, commonerr.ErrCouldNotDownload
+	}
 	defer r.Body.Close()
 
 	// Get the list of ELSAs that we have to process.
@@ -166,6 +170,13 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		if err != nil {
 			log.WithError(err).Error("could not download Oracle's update list")
 			return resp, commonerr.ErrCouldNotDownload
+		}
+		if r.StatusCode != http.StatusOK {
+			log.WithFields(log.Fields{
+				"Elsa":       elsaFilePrefix + strconv.Itoa(elsa),
+				"StatusCode": r.StatusCode,
+			}).Debug("could not download Oracle's elsa")
+			continue
 		}
 
 		// Parse the XML.


### PR DESCRIPTION
When http requests to Red Hat's oval data doesn't return StatusOK it
returns empty vulnerability list with no error. This should not happen.

This commits check the return code of http request to Red Hat's oval data.

This is also related to #596