### PR TITLE
Adding httputil and version packages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-.*
+.dockerignore
+.travis.yml
 *.md
 DCO
 LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ ADD .   /go/src/github.com/coreos/clair/
 WORKDIR /go/src/github.com/coreos/clair/
 
 RUN apk add --no-cache git rpm xz && \
-    go install -v github.com/coreos/clair/cmd/clair && \
+    export CLAIR_VERSION=$(git describe --always --tags --dirty) && \
+    go install -ldflags "-X github.com/coreos/clair/pkg/version.Version=$CLAIR_VERSION" -v github.com/coreos/clair/cmd/clair && \
     mv /go/bin/clair /clair && \
     rm -rf /go /usr/local/go
 

--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -32,6 +31,7 @@ import (
 	"github.com/coreos/clair/ext/versionfmt/dpkg"
 	"github.com/coreos/clair/ext/vulnsrc"
 	"github.com/coreos/clair/pkg/commonerr"
+	"github.com/coreos/clair/pkg/httputil"
 )
 
 const (
@@ -63,9 +63,15 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 	log.WithField("package", "Debian").Info("Start fetching vulnerabilities")
 
 	// Download JSON.
-	r, err := http.Get(url)
+	r, err := httputil.GetWithUserAgent(url)
 	if err != nil {
 		log.WithError(err).Error("could not download Debian's update")
+		return resp, commonerr.ErrCouldNotDownload
+	}
+	defer r.Body.Close()
+
+	if !httputil.Status2xx(r) {
+		log.WithField("StatusCode", r.StatusCode).Error("Failed to update Debian")
 		return resp, commonerr.ErrCouldNotDownload
 	}
 

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -1,0 +1,65 @@
+// Copyright 2017 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httputil implements common HTTP functionality used throughout the Clair codebase.
+package httputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/coreos/clair/pkg/version"
+)
+
+// GetWithUserAgent performs an HTTP GET with the proper Clair User-Agent.
+func GetWithUserAgent(url string) (*http.Response, error) {
+	client := &http.Client{}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "Clair/"+version.Version+" (https://github.com/coreos/clair)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// GetClientAddr returns the first value in X-Forwarded-For if it exists
+// otherwise fall back to use RemoteAddr
+func GetClientAddr(r *http.Request) string {
+	addr := r.RemoteAddr
+	if s := r.Header.Get("X-Forwarded-For"); s != "" {
+		ips := strings.Split(s, ",")
+		// assume the first one is the client address
+		if len(ips) != 0 {
+			// validate the ip
+			if realIP := net.ParseIP(ips[0]); realIP != nil {
+				addr = strings.TrimSpace(ips[0])
+			}
+		}
+	}
+	return addr
+}
+
+// Status2xx returns true if the response's status code is success (2xx)
+func Status2xx(resp *http.Response) bool {
+	return resp.StatusCode/100 == 2
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,18 @@
+// Copyright 2017 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+// Version is set at build time by the latest tag
+var Version string


### PR DESCRIPTION
- Debian/RHEL/Oracle now use httpclient
- httpclient sets the User-Agent to the requests as Clair/<version> (https://github.com/coreos/clair/)
- httpclient insures the request return http.StatusOK
- the version string is set at build time from the git tag
- the .git directory was removed from .dockerignore so that we can use the git tag to set the version