### PR TITLE
vulnmdsrc: update NVD URLs

### DIFF
--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	dataFeedURL     string = "https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.xml.gz"
-	dataFeedMetaURL string = "https://static.nvd.nist.gov/feeds/xml/cve/nvdcve-2.0-%s.meta"
+	dataFeedURL     string = "https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%s.xml.gz"
+	dataFeedMetaURL string = "https://nvd.nist.gov/feeds/xml/cve/2.0/nvdcve-2.0-%s.meta"
 
 	appenderName string = "NVD"
 


### PR DESCRIPTION
This connects us via a domain hosted on AWS which should provide
performance benefits for users running Clair on AWS and alleviate load
from the NIST campus network.

Fixes #575.