### PR TITLE
Extend the sleep duration if update fails

### DIFF
--- a/pkg/timeutil/timeutil.go
+++ b/pkg/timeutil/timeutil.go
@@ -1,0 +1,33 @@
+// Copyright 2018 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package timeutil provides time utility functions.
+package timeutil
+
+import (
+	"time"
+)
+
+// ExpBackoff doubles the backoff time, if the result is longer than the parameter max,
+// max will be returned.
+func ExpBackoff(prev, max time.Duration) time.Duration {
+	t := 2 * prev
+	if t > max {
+		t = max
+	}
+	if t == 0 {
+		return time.Second
+	}
+	return t
+}

--- a/pkg/timeutil/timeutil_test.go
+++ b/pkg/timeutil/timeutil_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timeutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpBackoff(t *testing.T) {
+	prev := 5 * time.Second
+	max := 8 * time.Second
+	assert.Equal(t, time.Second, ExpBackoff(prev, 0))
+	assert.Equal(t, time.Second, ExpBackoff(0, max))
+	assert.Equal(t, max, ExpBackoff(prev, max))
+	assert.Equal(t, 2*prev, ExpBackoff(prev, time.Hour))
+}


### PR DESCRIPTION
If one of the updaters failed in the first update.  It will sleep for 1
minute and rerun all the updaters again.  This will generate redundant
requestss to the remote sites.
This commit mitigate such issue by extending the sleep duration after
each failure in update.

Signed-off-by: Daniel Jiang <jiangd@vmware.com>