### PR TITLE
database: remove LayerWithContent from interface

### DIFF
--- a/api/v3/clairpb/convert.go
+++ b/api/v3/clairpb/convert.go
@@ -123,7 +123,7 @@ func VulnerabilityWithFixedInFromDatabaseModel(dbVuln database.VulnerabilityWith
 }
 
 // LayerFromDatabaseModel converts database layer to api layer.
-func LayerFromDatabaseModel(dbLayer database.Layer) *Layer {
+func LayerFromDatabaseModel(dbLayer database.LayerMetadata) *Layer {
 	layer := Layer{Hash: dbLayer.Hash}
 	return &layer
 }

--- a/database/database.go
+++ b/database/database.go
@@ -120,22 +120,16 @@ type Session interface {
 	// PersistNamespaces inserts a set of namespaces if not in the database.
 	PersistNamespaces([]Namespace) error
 
-	// PersistLayer creates a layer using the blob Sum hash.
-	PersistLayer(hash string) error
-
-	// PersistLayerContent persists a layer's content in the database. The given
+	// PersistLayer persists a layer's content in the database. The given
 	// namespaces and features can be partial content of this layer.
 	//
 	// The layer, namespaces and features are expected to be already existing
 	// in the database.
-	PersistLayerContent(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error
+	PersistLayer(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error
 
-	// FindLayer retrieves the metadata of a layer.
-	FindLayer(hash string) (layer Layer, found bool, err error)
-
-	// FindLayerWithContent returns a layer with all detected features and
+	// FindLayer returns a layer with all detected features and
 	// namespaces.
-	FindLayerWithContent(hash string) (layer LayerWithContent, found bool, err error)
+	FindLayer(hash string) (layer Layer, found bool, err error)
 
 	// InsertVulnerabilities inserts a set of UNIQUE vulnerabilities with
 	// affected features into database, assuming that all vulnerabilities

--- a/database/database.go
+++ b/database/database.go
@@ -167,9 +167,9 @@ type Session interface {
 	// always considered first page.
 	FindVulnerabilityNotification(name string, limit int, oldVulnerabilityPage pagination.Token, newVulnerabilityPage pagination.Token) (noti VulnerabilityNotificationWithVulnerable, found bool, err error)
 
-	// MarkNotificationNotified marks a Notification as notified now, assuming
+	// MarkNotificationAsRead marks a Notification as notified now, assuming
 	// the requested notification is in the database.
-	MarkNotificationNotified(name string) error
+	MarkNotificationAsRead(name string) error
 
 	// DeleteNotification removes a Notification in the database.
 	DeleteNotification(name string) error

--- a/database/mock.go
+++ b/database/mock.go
@@ -43,13 +43,13 @@ type MockSession struct {
 	FctFindNewNotification              func(lastNotified time.Time) (NotificationHook, bool, error)
 	FctFindVulnerabilityNotification    func(name string, limit int, oldPage pagination.Token, newPage pagination.Token) (
 		vuln VulnerabilityNotificationWithVulnerable, ok bool, err error)
-	FctMarkNotificationNotified func(name string) error
-	FctDeleteNotification       func(name string) error
-	FctUpdateKeyValue           func(key, value string) error
-	FctFindKeyValue             func(key string) (string, bool, error)
-	FctLock                     func(name string, owner string, duration time.Duration, renew bool) (bool, time.Time, error)
-	FctUnlock                   func(name, owner string) error
-	FctFindLock                 func(name string) (string, time.Time, bool, error)
+	FctMarkNotificationAsRead func(name string) error
+	FctDeleteNotification     func(name string) error
+	FctUpdateKeyValue         func(key, value string) error
+	FctFindKeyValue           func(key string) (string, bool, error)
+	FctLock                   func(name string, owner string, duration time.Duration, renew bool) (bool, time.Time, error)
+	FctUnlock                 func(name, owner string) error
+	FctFindLock               func(name string) (string, time.Time, bool, error)
 }
 
 func (ms *MockSession) Commit() error {
@@ -186,9 +186,9 @@ func (ms *MockSession) FindVulnerabilityNotification(name string, limit int, old
 	panic("required mock function not implemented")
 }
 
-func (ms *MockSession) MarkNotificationNotified(name string) error {
-	if ms.FctMarkNotificationNotified != nil {
-		return ms.FctMarkNotificationNotified(name)
+func (ms *MockSession) MarkNotificationAsRead(name string) error {
+	if ms.FctMarkNotificationAsRead != nil {
+		return ms.FctMarkNotificationAsRead(name)
 	}
 	panic("required mock function not implemented")
 }

--- a/database/mock.go
+++ b/database/mock.go
@@ -32,10 +32,8 @@ type MockSession struct {
 	FctPersistFeatures                  func([]Feature) error
 	FctPersistNamespacedFeatures        func([]NamespacedFeature) error
 	FctCacheAffectedNamespacedFeatures  func([]NamespacedFeature) error
-	FctPersistLayer                     func(hash string) error
-	FctPersistLayerContent              func(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error
+	FctPersistLayer                     func(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error
 	FctFindLayer                        func(name string) (Layer, bool, error)
-	FctFindLayerWithContent             func(name string) (LayerWithContent, bool, error)
 	FctInsertVulnerabilities            func([]VulnerabilityWithAffected) error
 	FctFindVulnerabilities              func([]VulnerabilityID) ([]NullableVulnerability, error)
 	FctDeleteVulnerabilities            func([]VulnerabilityID) error
@@ -115,16 +113,9 @@ func (ms *MockSession) CacheAffectedNamespacedFeatures(namespacedFeatures []Name
 	panic("required mock function not implemented")
 }
 
-func (ms *MockSession) PersistLayer(layer string) error {
+func (ms *MockSession) PersistLayer(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error {
 	if ms.FctPersistLayer != nil {
-		return ms.FctPersistLayer(layer)
-	}
-	panic("required mock function not implemented")
-}
-
-func (ms *MockSession) PersistLayerContent(hash string, namespaces []Namespace, features []Feature, processedBy Processors) error {
-	if ms.FctPersistLayerContent != nil {
-		return ms.FctPersistLayerContent(hash, namespaces, features, processedBy)
+		return ms.FctPersistLayer(hash, namespaces, features, processedBy)
 	}
 	panic("required mock function not implemented")
 }
@@ -132,13 +123,6 @@ func (ms *MockSession) PersistLayerContent(hash string, namespaces []Namespace, 
 func (ms *MockSession) FindLayer(name string) (Layer, bool, error) {
 	if ms.FctFindLayer != nil {
 		return ms.FctFindLayer(name)
-	}
-	panic("required mock function not implemented")
-}
-
-func (ms *MockSession) FindLayerWithContent(name string) (LayerWithContent, bool, error) {
-	if ms.FctFindLayerWithContent != nil {
-		return ms.FctFindLayerWithContent(name)
 	}
 	panic("required mock function not implemented")
 }

--- a/database/models.go
+++ b/database/models.go
@@ -41,25 +41,25 @@ type Ancestry struct {
 
 // AncestryLayer is a layer with all detected namespaced features.
 type AncestryLayer struct {
-	Layer
+	LayerMetadata
 
 	// DetectedFeatures are the features introduced by this layer when it was
 	// processed.
 	DetectedFeatures []NamespacedFeature
 }
 
-// Layer contains the metadata of a layer.
-type Layer struct {
+// LayerMetadata contains the metadata of a layer.
+type LayerMetadata struct {
 	// Hash is content hash of the layer.
 	Hash string
 	// ProcessedBy contains the processors that processed this layer.
 	ProcessedBy Processors
 }
 
-// LayerWithContent is a layer with its detected namespaces and features by
+// Layer is a layer with its detected namespaces and features by
 // ProcessedBy.
-type LayerWithContent struct {
-	Layer
+type Layer struct {
+	LayerMetadata
 
 	Namespaces []Namespace
 	Features   []Feature

--- a/database/pgsql/ancestry.go
+++ b/database/pgsql/ancestry.go
@@ -170,7 +170,7 @@ func (tx *pgSession) findAncestryLayers(id int64) ([]database.AncestryLayer, err
 		}
 
 		if !index.Valid || !id.Valid {
-			return nil, commonerr.ErrNotFound
+			panic("null ancestry ID or ancestry index violates database constraints")
 		}
 
 		if _, ok := layers[index.Int64]; ok {

--- a/database/pgsql/ancestry_test.go
+++ b/database/pgsql/ancestry_test.go
@@ -30,7 +30,7 @@ func TestUpsertAncestry(t *testing.T) {
 		Name: "a1",
 		Layers: []database.AncestryLayer{
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-N",
 				},
 			},
@@ -43,7 +43,7 @@ func TestUpsertAncestry(t *testing.T) {
 		Name: "a",
 		Layers: []database.AncestryLayer{
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-0",
 				},
 			},
@@ -54,7 +54,7 @@ func TestUpsertAncestry(t *testing.T) {
 		Name: "a",
 		Layers: []database.AncestryLayer{
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-1",
 				},
 			},
@@ -137,7 +137,7 @@ func assertAncestryEqual(t *testing.T, expected database.Ancestry, actual databa
 }
 
 func assertAncestryLayerEqual(t *testing.T, expected database.AncestryLayer, actual database.AncestryLayer) bool {
-	return assertLayerEqual(t, expected.Layer, actual.Layer) &&
+	return assertLayerEqual(t, expected.LayerMetadata, actual.LayerMetadata) &&
 		assertNamespacedFeatureEqual(t, expected.DetectedFeatures, actual.DetectedFeatures)
 }
 
@@ -159,7 +159,7 @@ func TestFindAncestry(t *testing.T) {
 		},
 		Layers: []database.AncestryLayer{
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-0",
 				},
 				DetectedFeatures: []database.NamespacedFeature{
@@ -188,17 +188,17 @@ func TestFindAncestry(t *testing.T) {
 				},
 			},
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-1",
 				},
 			},
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-2",
 				},
 			},
 			{
-				Layer: database.Layer{
+				LayerMetadata: database.LayerMetadata{
 					Hash: "layer-3b",
 				},
 			},

--- a/database/pgsql/notification.go
+++ b/database/pgsql/notification.go
@@ -289,23 +289,23 @@ func (tx *pgSession) FindVulnerabilityNotification(name string, limit int, oldPa
 	return noti, true, nil
 }
 
-func (tx *pgSession) MarkNotificationNotified(name string) error {
+func (tx *pgSession) MarkNotificationAsRead(name string) error {
 	if name == "" {
 		return commonerr.NewBadRequestError("Empty notification name is not allowed")
 	}
 
-	r, err := tx.Exec(updatedNotificationNotified, name)
+	r, err := tx.Exec(updatedNotificationAsRead, name)
 	if err != nil {
-		return handleError("updatedNotificationNotified", err)
+		return handleError("updatedNotificationAsRead", err)
 	}
 
 	affected, err := r.RowsAffected()
 	if err != nil {
-		return handleError("updatedNotificationNotified", err)
+		return handleError("updatedNotificationAsRead", err)
 	}
 
 	if affected <= 0 {
-		return handleError("updatedNotificationNotified", errNotificationNotFound)
+		return handleError("updatedNotificationAsRead", errNotificationNotFound)
 	}
 	return nil
 }

--- a/database/pgsql/notification_test.go
+++ b/database/pgsql/notification_test.go
@@ -200,7 +200,7 @@ func TestFindNewNotification(t *testing.T) {
 	}
 
 	// can't find the notified
-	assert.Nil(t, tx.MarkNotificationNotified("test"))
+	assert.Nil(t, tx.MarkNotificationAsRead("test"))
 	// if the notified time is before
 	noti, ok, err = tx.FindNewNotification(time.Now().Add(-time.Duration(10 * time.Second)))
 	assert.Nil(t, err)
@@ -225,16 +225,16 @@ func TestFindNewNotification(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestMarkNotificationNotified(t *testing.T) {
-	datastore, tx := openSessionForTest(t, "MarkNotificationNotified", true)
+func TestMarkNotificationAsRead(t *testing.T) {
+	datastore, tx := openSessionForTest(t, "MarkNotificationAsRead", true)
 	defer closeTest(t, datastore, tx)
 
 	// invalid case: notification doesn't exist
-	assert.NotNil(t, tx.MarkNotificationNotified("non-existing"))
+	assert.NotNil(t, tx.MarkNotificationAsRead("non-existing"))
 	// valid case
-	assert.Nil(t, tx.MarkNotificationNotified("test"))
+	assert.Nil(t, tx.MarkNotificationAsRead("test"))
 	// valid case
-	assert.Nil(t, tx.MarkNotificationNotified("test"))
+	assert.Nil(t, tx.MarkNotificationAsRead("test"))
 }
 
 func TestDeleteNotification(t *testing.T) {

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -73,7 +73,16 @@ const (
 			AND v.deleted_at IS NULL`
 
 	// layer.go
-	searchLayerIDs = `SELECT id, hash FROM layer WHERE hash = ANY($1);`
+	soiLayer = `
+		WITH new_layer AS (
+			INSERT INTO layer (hash)
+			SELECT CAST ($1 AS VARCHAR)
+			WHERE NOT EXISTS (SELECT id FROM layer WHERE hash = $1)
+			RETURNING id
+		)
+		SELECT id FROM new_Layer
+		UNION
+		SELECT id FROM layer WHERE hash = $1`
 
 	searchLayerFeatures = `
 		SELECT feature.Name, feature.Version, feature.version_format 

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -168,7 +168,7 @@ const (
 		INSERT INTO Vulnerability_Notification(name, created_at, old_vulnerability_id, new_vulnerability_id)
 		VALUES ($1, $2, $3, $4)`
 
-	updatedNotificationNotified = `
+	updatedNotificationAsRead = `
 		UPDATE Vulnerability_Notification
 		SET notified_at = CURRENT_TIMESTAMP
 		WHERE name = $1`

--- a/database/pgsql/vulnerability.go
+++ b/database/pgsql/vulnerability.go
@@ -16,7 +16,6 @@ package pgsql
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"time"
 
@@ -218,17 +217,6 @@ func (tx *pgSession) insertVulnerabilities(vulnerabilities []database.Vulnerabil
 	}
 
 	return vulnIDs, nil
-}
-
-// castMetadata marshals the given database.MetadataMap and unmarshals it again to make sure that
-// everything has the interface{} type.
-// It is required when comparing crafted MetadataMap against MetadataMap that we get from the
-// database.
-func castMetadata(m database.MetadataMap) database.MetadataMap {
-	c := make(database.MetadataMap)
-	j, _ := json.Marshal(m)
-	json.Unmarshal(j, &c)
-	return c
 }
 
 func (tx *pgSession) lockFeatureVulnerabilityCache() error {

--- a/notifier.go
+++ b/notifier.go
@@ -93,7 +93,7 @@ func RunNotifier(config *notification.Config, datastore database.Datastore, stop
 		go func() {
 			success, interrupted := handleTask(*notification, stopper, config.Attempts)
 			if success {
-				err := markNotificationNotified(datastore, notification.Name)
+				err := markNotificationAsRead(datastore, notification.Name)
 				if err != nil {
 					log.WithError(err).Error("Failed to mark notification notified")
 				}
@@ -196,14 +196,14 @@ func findNewNotification(datastore database.Datastore, renotifyInterval time.Dur
 	return tx.FindNewNotification(time.Now().Add(-renotifyInterval))
 }
 
-func markNotificationNotified(datastore database.Datastore, name string) error {
+func markNotificationAsRead(datastore database.Datastore, name string) error {
 	tx, err := datastore.Begin()
 	if err != nil {
 		log.WithError(err).Error("an error happens when beginning database transaction")
 	}
 	defer tx.Rollback()
 
-	if err := tx.MarkNotificationNotified(name); err != nil {
+	if err := tx.MarkNotificationAsRead(name); err != nil {
 		return err
 	}
 	return tx.Commit()


### PR DESCRIPTION
- Layer is renamed to LayerMetadata
- LayerWithContent is renamed to Layer
- Remove redundant interfaces to pertain layer's metadata
