### PR TITLE
Switch to NVD JSON feed and include CVSSv3

### DIFF
--- a/ext/vulnmdsrc/nvd/json.go
+++ b/ext/vulnmdsrc/nvd/json.go
@@ -74,7 +74,25 @@ type nvdCVSSv3 struct {
 	AvailImpact        string  `json:"availabilityImpact"`
 }
 
-var vectorValuesToLetters map[string]string
+var vectorValuesToLetters = map[string]string{
+	"NETWORK":          "N",
+	"ADJACENT_NETWORK": "A",
+	"LOCAL":            "L",
+	"HIGH":             "H",
+	"MEDIUM":           "M",
+	"LOW":              "L",
+	"NONE":             "N",
+	"SINGLE":           "S",
+	"MULTIPLE":         "M",
+	"PARTIAL":          "P",
+	"COMPLETE":         "C",
+
+	// CVSSv3 only
+	"PHYSICAL":  "P",
+	"REQUIRED":  "R",
+	"CHANGED":   "C",
+	"UNCHANGED": "U",
+}
 
 func init() {
 	vectorValuesToLetters = make(map[string]string)

--- a/ext/vulnmdsrc/nvd/json.go
+++ b/ext/vulnmdsrc/nvd/json.go
@@ -1,4 +1,4 @@
-// Copyright 2017 clair authors
+// Copyright 2018 clair authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/ext/vulnmdsrc/nvd/json.go
+++ b/ext/vulnmdsrc/nvd/json.go
@@ -59,7 +59,9 @@ type nvdCVSSv2 struct {
 }
 
 type nvdBaseMetricV3 struct {
-	CVSSv3 nvdCVSSv3 `json:"cvssV3"`
+	CVSSv3              nvdCVSSv3 `json:"cvssV3"`
+	ExploitabilityScore float64   `json:"exploitabilityScore"`
+	ImpactScore         float64   `json:"impactScore"`
 }
 
 type nvdCVSSv3 struct {
@@ -123,8 +125,10 @@ func (n nvdEntry) Metadata() *NVDMetadata {
 			Score:             n.Impact.BaseMetricV2.CVSSv2.Score,
 		},
 		CVSSv3: NVDmetadataCVSSv3{
-			Vectors: n.Impact.BaseMetricV3.CVSSv3.String(),
-			Score:   n.Impact.BaseMetricV3.CVSSv3.Score,
+			Vectors:             n.Impact.BaseMetricV3.CVSSv3.String(),
+			Score:               n.Impact.BaseMetricV3.CVSSv3.Score,
+			ExploitabilityScore: n.Impact.BaseMetricV3.ExploitabilityScore,
+			ImpactScore:         n.Impact.BaseMetricV3.ImpactScore,
 		},
 	}
 

--- a/ext/vulnmdsrc/nvd/json.go
+++ b/ext/vulnmdsrc/nvd/json.go
@@ -96,27 +96,6 @@ var vectorValuesToLetters = map[string]string{
 	"UNCHANGED": "U",
 }
 
-func init() {
-	vectorValuesToLetters = make(map[string]string)
-	vectorValuesToLetters["NETWORK"] = "N"
-	vectorValuesToLetters["ADJACENT_NETWORK"] = "A"
-	vectorValuesToLetters["LOCAL"] = "L"
-	vectorValuesToLetters["HIGH"] = "H"
-	vectorValuesToLetters["MEDIUM"] = "M"
-	vectorValuesToLetters["LOW"] = "L"
-	vectorValuesToLetters["NONE"] = "N"
-	vectorValuesToLetters["SINGLE"] = "S"
-	vectorValuesToLetters["MULTIPLE"] = "M"
-	vectorValuesToLetters["PARTIAL"] = "P"
-	vectorValuesToLetters["COMPLETE"] = "C"
-
-	// CVSSv3 only
-	vectorValuesToLetters["PHYSICAL"] = "P"
-	vectorValuesToLetters["REQUIRED"] = "R"
-	vectorValuesToLetters["CHANGED"] = "C"
-	vectorValuesToLetters["UNCHANGED"] = "U"
-}
-
 func (n nvdEntry) Metadata() *NVDMetadata {
 	metadata := &NVDMetadata{
 		CVSSv2: NVDmetadataCVSSv2{

--- a/ext/vulnmdsrc/nvd/json.go
+++ b/ext/vulnmdsrc/nvd/json.go
@@ -41,6 +41,7 @@ type nvdCVEMetadata struct {
 
 type nvdImpact struct {
 	BaseMetricV2 nvdBaseMetricV2 `json:"baseMetricV2"`
+	BaseMetricV3 nvdBaseMetricV3 `json:"baseMetricV3"`
 }
 
 type nvdBaseMetricV2 struct {
@@ -55,6 +56,22 @@ type nvdCVSSv2 struct {
 	ConfImpact       string  `json:"confidentialityImpact"`
 	IntegImpact      string  `json:"integrityImpact"`
 	AvailImpact      string  `json:"availabilityImpact"`
+}
+
+type nvdBaseMetricV3 struct {
+	CVSSv3 nvdCVSSv3 `json:"cvssV3"`
+}
+
+type nvdCVSSv3 struct {
+	Score              float64 `json:"baseScore"`
+	AttackVector       string  `json:"attackVector"`
+	AttackComplexity   string  `json:"attackComplexity"`
+	PrivilegesRequired string  `json:"privilegesRequired"`
+	UserInteraction    string  `json:"userInteraction"`
+	Scope              string  `json:"scope"`
+	ConfImpact         string  `json:"confidentialityImpact"`
+	IntegImpact        string  `json:"integrityImpact"`
+	AvailImpact        string  `json:"availabilityImpact"`
 }
 
 var vectorValuesToLetters map[string]string
@@ -72,6 +89,12 @@ func init() {
 	vectorValuesToLetters["MULTIPLE"] = "M"
 	vectorValuesToLetters["PARTIAL"] = "P"
 	vectorValuesToLetters["COMPLETE"] = "C"
+
+	// CVSSv3 only
+	vectorValuesToLetters["PHYSICAL"] = "P"
+	vectorValuesToLetters["REQUIRED"] = "R"
+	vectorValuesToLetters["CHANGED"] = "C"
+	vectorValuesToLetters["UNCHANGED"] = "U"
 }
 
 func (n nvdEntry) Metadata() *NVDMetadata {
@@ -80,6 +103,10 @@ func (n nvdEntry) Metadata() *NVDMetadata {
 			PublishedDateTime: n.PublishedDateTime,
 			Vectors:           n.Impact.BaseMetricV2.CVSSv2.String(),
 			Score:             n.Impact.BaseMetricV2.CVSSv2.Score,
+		},
+		CVSSv3: NVDmetadataCVSSv3{
+			Vectors: n.Impact.BaseMetricV3.CVSSv3.String(),
+			Score:   n.Impact.BaseMetricV3.CVSSv3.Score,
 		},
 	}
 
@@ -103,6 +130,24 @@ func (n nvdCVSSv2) String() string {
 	addVec(&str, "I", n.IntegImpact)
 	addVec(&str, "A", n.AvailImpact)
 	str = strings.TrimSuffix(str, "/")
+	return str
+}
+
+func (n nvdCVSSv3) String() string {
+	var str string
+	addVec(&str, "AV", n.AttackVector)
+	addVec(&str, "AC", n.AttackComplexity)
+	addVec(&str, "PR", n.PrivilegesRequired)
+	addVec(&str, "UI", n.UserInteraction)
+	addVec(&str, "S", n.Scope)
+	addVec(&str, "C", n.ConfImpact)
+	addVec(&str, "I", n.IntegImpact)
+	addVec(&str, "A", n.AvailImpact)
+	str = strings.TrimSuffix(str, "/")
+
+	if len(str) > 0 {
+		return fmt.Sprintf("CVSS:3.0/%s", str)
+	}
 	return str
 }
 

--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -55,12 +55,18 @@ type appender struct {
 
 type NVDMetadata struct {
 	CVSSv2 NVDmetadataCVSSv2
+	CVSSv3 NVDmetadataCVSSv3
 }
 
 type NVDmetadataCVSSv2 struct {
 	PublishedDateTime string
 	Vectors           string
 	Score             float64
+}
+
+type NVDmetadataCVSSv3 struct {
+	Vectors string
+	Score   float64
 }
 
 func init() {

--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -65,8 +65,10 @@ type NVDmetadataCVSSv2 struct {
 }
 
 type NVDmetadataCVSSv3 struct {
-	Vectors string
-	Score   float64
+	Vectors             string
+	Score               float64
+	ExploitabilityScore float64
+	ImpactScore         float64
 }
 
 func init() {

--- a/ext/vulnmdsrc/nvd/nvd_test.go
+++ b/ext/vulnmdsrc/nvd/nvd_test.go
@@ -1,0 +1,93 @@
+// Copyright 2018 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNVDParser(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(filename))
+
+	dataFilePath := filepath.Join(path, "/testdata/nvd_test.json")
+	testData, err := os.Open(dataFilePath)
+	if err != nil {
+		t.Fatalf("Error opening %q: %v", dataFilePath, err)
+	}
+	defer testData.Close()
+
+	a := &appender{}
+	a.metadata = make(map[string]NVDMetadata)
+
+	err = a.parseDataFeed(testData)
+	if err != nil {
+		t.Fatalf("Error parsing %q: %v", dataFilePath, err)
+	}
+
+	var gotMetadata, wantMetadata NVDMetadata
+
+	// Items without CVSSv2 aren't returned.
+	assert.Len(t, a.metadata, 2)
+	gotMetadata, ok := a.metadata["CVE-2002-0001"]
+	assert.False(t, ok)
+
+	// Item with only CVSSv2.
+	gotMetadata, ok = a.metadata["CVE-2012-0001"]
+	assert.True(t, ok)
+	wantMetadata = NVDMetadata{
+		CVSSv2: NVDmetadataCVSSv2{
+			Vectors: "AV:N/AC:L/Au:S/C:P/I:N/A:N",
+			Score:   4.0,
+		},
+	}
+	assert.Equal(t, wantMetadata, gotMetadata)
+
+	// Item with both CVSSv2 and CVSSv3 has CVSSv2 information returned.
+	gotMetadata, ok = a.metadata["CVE-2018-0001"]
+	assert.True(t, ok)
+	wantMetadata = NVDMetadata{
+		CVSSv2: NVDmetadataCVSSv2{
+			Vectors: "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+			Score:   7.5,
+		},
+	}
+	assert.Equal(t, wantMetadata, gotMetadata)
+}
+
+func TestNVDParserErrors(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(filename))
+
+	dataFilePath := filepath.Join(path, "/testdata/nvd_test_incorrect_format.json")
+	testData, err := os.Open(dataFilePath)
+	if err != nil {
+		t.Fatalf("Error opening %q: %v", dataFilePath, err)
+	}
+	defer testData.Close()
+
+	a := &appender{}
+	a.metadata = make(map[string]NVDMetadata)
+
+	err = a.parseDataFeed(testData)
+	if err == nil {
+		t.Fatalf("Expected error parsing NVD data file: %q", dataFilePath)
+	}
+}

--- a/ext/vulnmdsrc/nvd/nvd_test.go
+++ b/ext/vulnmdsrc/nvd/nvd_test.go
@@ -69,8 +69,10 @@ func TestNVDParser(t *testing.T) {
 			Score:   7.5,
 		},
 		CVSSv3: NVDmetadataCVSSv3{
-			Vectors: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-			Score:   9.8,
+			Vectors:             "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			Score:               9.8,
+			ExploitabilityScore: 3.9,
+			ImpactScore:         5.9,
 		},
 	}
 	assert.Equal(t, wantMetadata, gotMetadata)

--- a/ext/vulnmdsrc/nvd/nvd_test.go
+++ b/ext/vulnmdsrc/nvd/nvd_test.go
@@ -68,6 +68,10 @@ func TestNVDParser(t *testing.T) {
 			Vectors: "AV:N/AC:L/Au:N/C:P/I:P/A:P",
 			Score:   7.5,
 		},
+		CVSSv3: NVDmetadataCVSSv3{
+			Vectors: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			Score:   9.8,
+		},
 	}
 	assert.Equal(t, wantMetadata, gotMetadata)
 }

--- a/ext/vulnmdsrc/nvd/testdata/nvd_test.json
+++ b/ext/vulnmdsrc/nvd/testdata/nvd_test.json
@@ -1,0 +1,92 @@
+{
+  "CVE_Items" : [ {
+    "_comment": "A CVE without CVSSv2 or CVSSv3",
+    "cve" : {
+      "data_type" : "CVE",
+      "data_format" : "MITRE",
+      "data_version" : "4.0",
+      "CVE_data_meta" : {
+        "ID" : "CVE-2002-0001"
+      }
+    },
+    "impact" : { },
+    "publishedDate" : "2018-01-10T22:29Z"
+  }, {
+    "_comment": "A CVE with only CVSSv2",
+    "cve" : {
+      "CVE_data_meta" : {
+        "ID" : "CVE-2012-0001"
+      }
+    },
+    "impact" : {
+      "baseMetricV3" : { },
+      "baseMetricV2" : {
+        "cvssV2" : {
+          "version" : "2.0",
+          "vectorString" : "(AV:N/AC:L/Au:S/C:P/I:N/A:N)",
+          "accessVector" : "NETWORK",
+          "accessComplexity" : "LOW",
+          "authentication" : "SINGLE",
+          "confidentialityImpact" : "PARTIAL",
+          "integrityImpact" : "NONE",
+          "availabilityImpact" : "NONE",
+          "baseScore" : 4.0
+        },
+        "severity" : "MEDIUM",
+        "exploitabilityScore" : 8.0,
+        "impactScore" : 2.9,
+        "obtainAllPrivilege" : false,
+        "obtainUserPrivilege" : false,
+        "obtainOtherPrivilege" : false,
+        "userInteractionRequired" : false
+      }
+    }
+  }, {
+    "_comment": "A CVE with standard CVSSv2 and CVSSv3",
+    "cve" : {
+      "CVE_data_meta" : {
+        "ID" : "CVE-2018-0001"
+      }
+    },
+    "impact" : {
+      "baseMetricV3" : {
+        "cvssV3" : {
+          "version" : "3.0",
+          "vectorString" : "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "attackVector" : "NETWORK",
+          "attackComplexity" : "LOW",
+          "privilegesRequired" : "NONE",
+          "userInteraction" : "NONE",
+          "scope" : "UNCHANGED",
+          "confidentialityImpact" : "HIGH",
+          "integrityImpact" : "HIGH",
+          "availabilityImpact" : "HIGH",
+          "baseScore" : 9.8,
+          "baseSeverity" : "CRITICAL"
+        },
+        "exploitabilityScore" : 3.9,
+        "impactScore" : 5.9
+      },
+      "baseMetricV2" : {
+        "cvssV2" : {
+          "version" : "2.0",
+          "vectorString" : "(AV:N/AC:L/Au:N/C:P/I:P/A:P)",
+          "accessVector" : "NETWORK",
+          "accessComplexity" : "LOW",
+          "authentication" : "NONE",
+          "confidentialityImpact" : "PARTIAL",
+          "integrityImpact" : "PARTIAL",
+          "availabilityImpact" : "PARTIAL",
+          "baseScore" : 7.5
+        },
+        "severity" : "HIGH",
+        "exploitabilityScore" : 10.0,
+        "impactScore" : 6.4,
+        "obtainAllPrivilege" : false,
+        "obtainUserPrivilege" : false,
+        "obtainOtherPrivilege" : false,
+        "userInteractionRequired" : false
+      }
+    }
+  } ]
+}

--- a/ext/vulnmdsrc/nvd/testdata/nvd_test_incorrect_format.json
+++ b/ext/vulnmdsrc/nvd/testdata/nvd_test_incorrect_format.json
@@ -1,0 +1,1 @@
+Not a JSON file.


### PR DESCRIPTION
The NVD JSON feed is still "beta". According to the [NVD changlog](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) the last breaking change (a field rename which would not have affected this code) happened 2017-12-18. **CVSSv3 is only in the JSON feed.**

Some things in the feed relevant to Clair have changed:
* The format for `PublishedDateTime` has changed from `2018-01-10T17:29:00.930-05:00` to `2018-01-10T22:29Z`.
* The CVSSv2 and CVSSv3 vector strings are provided directly. If desired, I'm happy to remove the parsing code here or in another PR.

The changes in this PR are meant to be backwards compatible:
* `NVDmetadataCVSSv2` remains unchanged. `PublishedDateTime` is still in `NVDmetadataCVSSv2` even though it isn't specific to CVSSv2.
* As before, `Metadata` returns nil if CVSSv2 isn't available (and this now has a test).