### PR TITLE
Pinning helm postgres dep to the working 1.0.0

### DIFF
--- a/contrib/helm/clair/requirements.yaml
+++ b/contrib/helm/clair/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: "*"
+    version: "1.0.0"
     condition: postgresql.enabled
     repository: "alias:stable"


### PR DESCRIPTION
It looks like the postgres chart just had a huge shakeup, image, maintainer change:
https://github.com/helm/charts/commit/7f1e47c5a8b10f24547aa385d782294622f8f439#diff-fb61f7f926e5bfb00f3b15a715d90302

The new chart isn't playing nice with clair (even after updating the postgres args to account for new format on user, password, db) so I pinned the old one for now.