### PR TITLE
WIP: Feature indicated namespace

### DIFF
--- a/database/pgsql/migrations/00001_initial_schema.go
+++ b/database/pgsql/migrations/00001_initial_schema.go
@@ -90,6 +90,11 @@ var (
 				UNIQUE (layer_id, feature_id));`,
 			`CREATE INDEX ON layer_feature(layer_id);`,
 
+			`CREATE TABLE IF NOT EXISTS layer_feature_context (
+				id SERIAL PRIMARY KEY,
+				layer_feature_id INT REFERENCES layer_feature ON DELETE CASCADE,
+				context TEXT NOT NULL);`,
+
 			`CREATE TABLE IF NOT EXISTS layer_namespace (
 				id SERIAL PRIMARY KEY,
 				layer_id INT REFERENCES layer ON DELETE CASCADE,


### PR DESCRIPTION
The table is to track raw potential contextual information about a
Feature. It's useful for helping Clair to determine the namespace of a
feature.

Work in progress, the raw contextual data will be stored in the database, and interpreted by the Clair logic to relate the feature with some namespace in the layer or not.

This will result in better scanning result for multiple namespaces feature by reducing the number of wrong namespaces of feature.

For example:

CentOS:7 may install a RHEL package, which is compatible, using RPM. Since the package is compiled for the RHEL system, it should be considered a package with RHEL namespace, and affected by RHEL vulnerabilities.
We can extract this information by looking at the version string: e.g. curl-7.29.0-51.el7.x86_64
From the version string, we can understand that it's packaged for RHEL7 X86_64 (el7). We store this information in the database, so that the namespace can be determined correctly.