### PR TITLE
Vulnsrc rhel: handle "none" CVE impact

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -221,7 +221,7 @@ func parseRHSA(ovalReader io.Reader) (vulnerabilities []database.VulnerabilityWi
 			for _, currentCve := range definition.Cves {
 				vulnerability.Name = currentCve.ID
 				vulnerability.Link = currentCve.Href
-				if currentCve.Impact != "" {
+				if currentCve.Impact != "" && currentCve.Impact != "none" {
 					vulnerability.Severity = severity(currentCve.Impact)
 				} else {
 					vulnerability.Severity = severity(definition.Severity)


### PR DESCRIPTION
Some RHEL CVEs [1] contains "none" string in impact field. This is throwing
warning message when fetching vulnerabilities. The new code handles this
case and it uses advisory severity instead.

[1] https://www.redhat.com/security/data/oval/com.redhat.rhsa-20080038.xml