### PR TITLE
features: Store source package to database

### DIFF
--- a/database/models.go
+++ b/database/models.go
@@ -169,6 +169,20 @@ type Feature struct {
 	VersionFormat string
 }
 
+// Valid checks if the Feature Layer is compliant to the spec.
+func (f *Feature) Valid() bool {
+	if f == nil {
+		return false
+	}
+
+	if f.Name == "" || f.Version == "" || f.SourceName == "" ||
+		f.SourceVersion == "" || f.VersionFormat == "" {
+		return false
+	}
+
+	return true
+}
+
 // NamespacedFeature is a feature with determined namespace and can be affected
 // by vulnerabilities.
 //

--- a/database/pgsql/ancestry.go
+++ b/database/pgsql/ancestry.go
@@ -23,8 +23,9 @@ const (
 
 	findAncestryFeatures = `
 		SELECT namespace.name, namespace.version_format, feature.name, 
-			feature.version, feature.version_format, ancestry_layer.ancestry_index, 
-			ancestry_feature.feature_detector_id, ancestry_feature.namespace_detector_id
+			feature.version, feature.source_name, feature.source_version, feature.version_format,
+			ancestry_layer.ancestry_index, ancestry_feature.feature_detector_id,
+			ancestry_feature.namespace_detector_id
 		FROM namespace, feature, namespaced_feature, ancestry_layer, ancestry_feature
 		WHERE ancestry_layer.ancestry_id = $1
 			AND ancestry_feature.ancestry_layer_id = ancestry_layer.id
@@ -255,6 +256,8 @@ func (tx *pgSession) findAncestryFeatures(ancestryID int64, detectors detectorMa
 			&feature.Namespace.VersionFormat,
 			&feature.Feature.Name,
 			&feature.Feature.Version,
+			&feature.Feature.SourceName,
+			&feature.Feature.SourceVersion,
 			&feature.Feature.VersionFormat,
 			&index,
 			&featureDetectorID,

--- a/database/pgsql/feature.go
+++ b/database/pgsql/feature.go
@@ -76,11 +76,9 @@ func (tx *pgSession) PersistFeatures(features []database.Feature) error {
 	})
 
 	// TODO(Sida): A better interface for bulk insertion is needed.
-	keys := make([]interface{}, len(features)*3)
-	for i, f := range features {
-		keys[i*3] = f.Name
-		keys[i*3+1] = f.Version
-		keys[i*3+2] = f.VersionFormat
+	keys := make([]interface{}, 0, len(features)*3)
+	for _, f := range features {
+		keys = append(keys, f.Name, f.Version, f.VersionFormat)
 		if f.Name == "" || f.Version == "" || f.VersionFormat == "" {
 			return commonerr.NewBadRequestError("Empty feature name, version or version format is not allowed")
 		}
@@ -160,11 +158,9 @@ func (tx *pgSession) CacheAffectedNamespacedFeatures(features []database.Namespa
 
 	cache, err := tx.searchAffectingVulnerabilities(features)
 
-	keys := make([]interface{}, len(cache)*3)
-	for i, c := range cache {
-		keys[i*3] = c.vulnID
-		keys[i*3+1] = c.nsFeatureID
-		keys[i*3+2] = c.vulnAffectingID
+	keys := make([]interface{}, 0, len(cache)*3)
+	for _, c := range cache {
+		keys = append(keys, c.vulnID, c.nsFeatureID, c.vulnAffectingID)
 	}
 
 	if len(cache) == 0 {
@@ -231,10 +227,9 @@ func (tx *pgSession) PersistNamespacedFeatures(features []database.NamespacedFea
 		return err
 	}
 
-	keys := make([]interface{}, len(features)*2)
-	for i, f := range features {
-		keys[i*2] = fIDs[f.Feature]
-		keys[i*2+1] = nsIDs[f.Namespace]
+	keys := make([]interface{}, 0, len(features)*2)
+	for _, f := range features {
+		keys = append(keys, fIDs[f.Feature], nsIDs[f.Namespace])
 	}
 
 	_, err := tx.Exec(queryPersistNamespacedFeature(len(features)), keys...)
@@ -329,12 +324,9 @@ func (tx *pgSession) findNamespacedFeatureIDs(nfs []database.NamespacedFeature) 
 	}
 
 	nfsMap := map[database.NamespacedFeature]sql.NullInt64{}
-	keys := make([]interface{}, len(nfs)*4)
-	for i, nf := range nfs {
-		keys[i*4] = nfs[i].Name
-		keys[i*4+1] = nfs[i].Version
-		keys[i*4+2] = nfs[i].VersionFormat
-		keys[i*4+3] = nfs[i].Namespace.Name
+	keys := make([]interface{}, 0, len(nfs)*4)
+	for _, nf := range nfs {
+		keys = append(keys, nf.Name, nf.Version, nf.VersionFormat, nf.Namespace.Name)
 		nfsMap[nf] = sql.NullInt64{}
 	}
 
@@ -373,11 +365,9 @@ func (tx *pgSession) findFeatureIDs(fs []database.Feature) ([]sql.NullInt64, err
 
 	fMap := map[database.Feature]sql.NullInt64{}
 
-	keys := make([]interface{}, len(fs)*3)
-	for i, f := range fs {
-		keys[i*3] = f.Name
-		keys[i*3+1] = f.Version
-		keys[i*3+2] = f.VersionFormat
+	keys := make([]interface{}, 0, len(fs)*3)
+	for _, f := range fs {
+		keys = append(keys, f.Name, f.Version, f.VersionFormat)
 		fMap[f] = sql.NullInt64{}
 	}
 

--- a/database/pgsql/feature_test.go
+++ b/database/pgsql/feature_test.go
@@ -30,7 +30,7 @@ func TestPersistFeatures(t *testing.T) {
 	defer closeTest(t, datastore, tx)
 
 	f1 := database.Feature{}
-	f2 := database.Feature{Name: "n", Version: "v", VersionFormat: "vf"}
+	f2 := database.Feature{Name: "n", Version: "v", SourceName: "sn", SourceVersion: "sv", VersionFormat: "vf"}
 
 	// empty
 	assert.Nil(t, tx.PersistFeatures([]database.Feature{}))

--- a/database/pgsql/layer.go
+++ b/database/pgsql/layer.go
@@ -235,12 +235,9 @@ func (tx *pgSession) persistLayerFeatures(features []dbLayerFeature) error {
 	sort.Slice(features, func(i, j int) bool {
 		return features[i].featureID < features[j].featureID
 	})
-
-	keys := make([]interface{}, len(features)*3)
-	for i, feature := range features {
-		keys[i*3] = feature.layerID
-		keys[i*3+1] = feature.featureID
-		keys[i*3+2] = feature.detectorID
+	keys := make([]interface{}, 0, len(features)*3)
+	for _, f := range features {
+		keys = append(keys, f.layerID, f.featureID, f.detectorID)
 	}
 
 	_, err := tx.Exec(queryPersistLayerFeature(len(features)), keys...)
@@ -260,12 +257,9 @@ func (tx *pgSession) persistLayerNamespaces(namespaces []dbLayerNamespace) error
 		return namespaces[i].namespaceID < namespaces[j].namespaceID
 	})
 
-	elementSize := 3
-	keys := make([]interface{}, len(namespaces)*elementSize)
-	for i, row := range namespaces {
-		keys[i*3] = row.layerID
-		keys[i*3+1] = row.namespaceID
-		keys[i*3+2] = row.detectorID
+	keys := make([]interface{}, 0, len(namespaces)*3)
+	for _, row := range namespaces {
+		keys = append(keys, row.layerID, row.namespaceID, row.detectorID)
 	}
 
 	_, err := tx.Exec(queryPersistLayerNamespace(len(namespaces)), keys...)

--- a/database/pgsql/layer.go
+++ b/database/pgsql/layer.go
@@ -37,7 +37,7 @@ const (
 		SELECT id FROM layer WHERE hash = $1`
 
 	findLayerFeatures = `
-		SELECT f.name, f.version, f.version_format, lf.detector_id
+		SELECT f.name, f.version, f.source_name, f.source_version, f.version_format, lf.detector_id
 			FROM layer_feature AS lf, feature AS f
 			WHERE lf.feature_id = f.id
 				AND lf.layer_id = $1`
@@ -307,7 +307,8 @@ func (tx *pgSession) findLayerFeatures(layerID int64, detectors detectorMap) ([]
 			detectorID int64
 			feature    database.LayerFeature
 		)
-		if err := rows.Scan(&feature.Name, &feature.Version, &feature.VersionFormat, &detectorID); err != nil {
+		if err := rows.Scan(&feature.Name, &feature.Version, &feature.SourceName, &feature.SourceVersion,
+			&feature.VersionFormat, &detectorID); err != nil {
 			return nil, handleError("findLayerFeatures", err)
 		}
 

--- a/database/pgsql/migrations/00001_initial_schema.go
+++ b/database/pgsql/migrations/00001_initial_schema.go
@@ -32,8 +32,10 @@ var (
 				id SERIAL PRIMARY KEY,
 				name TEXT NOT NULL,
 				version TEXT NOT NULL,
+				source_name  TEXT NOT NULL,
+				source_version TEXT NOT NULL,
 				version_format TEXT NOT NULL,
-				UNIQUE (name, version, version_format));`,
+				UNIQUE (name, version, source_name, source_version, version_format));`,
 			`CREATE INDEX ON feature(name);`,
 
 			`CREATE TABLE IF NOT EXISTS namespaced_feature (

--- a/database/pgsql/queries.go
+++ b/database/pgsql/queries.go
@@ -52,7 +52,7 @@ func querySearchNotDeletedVulnerabilityID(count int) string {
 
 func querySearchFeatureID(featureCount int) string {
 	return fmt.Sprintf(`
-		SELECT id, name, version, version_format 
+		SELECT id, name, version, source_name, source_version, version_format
 		FROM Feature WHERE (name, version, version_format) IN (%s)`,
 		queryString(3, featureCount),
 	)
@@ -60,13 +60,14 @@ func querySearchFeatureID(featureCount int) string {
 
 func querySearchNamespacedFeature(nsfCount int) string {
 	return fmt.Sprintf(`
-	SELECT nf.id, f.name, f.version, f.version_format, n.name
+	SELECT nf.id, f.name, f.version, f.source_name, f.source_version, f.version_format, n.name
 		FROM namespaced_feature AS nf, feature AS f, namespace AS n
 		WHERE nf.feature_id = f.id
 			AND nf.namespace_id = n.id
 			AND n.version_format = f.version_format 
-			AND (f.name, f.version, f.version_format, n.name) IN (%s)`,
-		queryString(4, nsfCount),
+			AND (f.name, f.version, f.source_name, f.source_version,
+				f.version_format, n.name) IN (%s)`,
+		queryString(6, nsfCount),
 	)
 }
 
@@ -110,9 +111,11 @@ func queryInsertNotifications(count int) string {
 func queryPersistFeature(count int) string {
 	return queryPersist(count,
 		"feature",
-		"feature_name_version_version_format_key",
+		"feature_name_version_source_name_source_version_version_for_key",
 		"name",
 		"version",
+		"source_name",
+		"source_version",
 		"version_format")
 }
 

--- a/database/pgsql/testdata/data.sql
+++ b/database/pgsql/testdata/data.sql
@@ -4,11 +4,11 @@ INSERT INTO namespace (id, name, version_format) VALUES
   (2, 'debian:8', 'dpkg'),
   (3, 'fake:1.0', 'rpm');
 
-INSERT INTO feature (id, name, version, version_format) VALUES
-  (1, 'ourchat', '0.5', 'dpkg'),
-  (2, 'openssl', '1.0', 'dpkg'),
-  (3, 'openssl', '2.0', 'dpkg'),
-  (4, 'fake', '2.0', 'rpm');
+INSERT INTO feature (id, name, version, source_name, source_version, version_format) VALUES
+  (1, 'ourchat', '0.5', 'ourchat', '0.5', 'dpkg'),
+  (2, 'openssl', '1.0', 'openssl', '1.0', 'dpkg'),
+  (3, 'openssl', '2.0', 'openssl', '2.0', 'dpkg'),
+  (4, 'fake', '2.0', 'fake-src', '2.0', 'rpm');
 
 INSERT INTO namespaced_feature(id, feature_id, namespace_id) VALUES
   (1, 1, 1), -- ourchat 0.5, debian:7

--- a/worker_test.go
+++ b/worker_test.go
@@ -276,14 +276,14 @@ func TestProcessAncestryWithDistUpgrade(t *testing.T) {
 	// TODO(sidac): Change to use table driven tests.
 	// Create the list of Features that should not been upgraded from one layer to another.
 	nonUpgradedFeatures := []database.Feature{
-		{Name: "libtext-wrapi18n-perl", Version: "0.06-7"},
-		{Name: "libtext-charwidth-perl", Version: "0.04-7"},
-		{Name: "libtext-iconv-perl", Version: "1.7-5"},
-		{Name: "mawk", Version: "1.3.3-17"},
-		{Name: "insserv", Version: "1.14.0-5"},
-		{Name: "db", Version: "5.1.29-5"},
-		{Name: "ustr", Version: "1.0.4-3"},
-		{Name: "xz-utils", Version: "5.1.1alpha+20120614-2"},
+		{Name: "libtext-wrapi18n-perl", Version: "0.06-7", SourceName: "libtext", SourceVersion: "0.06-7"},
+		{Name: "libtext-charwidth-perl", Version: "0.04-7", SourceName: "libtext", SourceVersion: "0.04-7"},
+		{Name: "libtext-iconv-perl", Version: "1.7-5", SourceName: "libtext", SourceVersion: "1.7-5"},
+		{Name: "mawk", Version: "1.3.3-17", SourceName: "mawk", SourceVersion: "1.3.3-17"},
+		{Name: "insserv", Version: "1.14.0-5", SourceName: "insserv", SourceVersion: "1.14.0-5"},
+		{Name: "db", Version: "5.1.29-5", SourceName: "db", SourceVersion: "5.1.29-5"},
+		{Name: "ustr", Version: "1.0.4-3", SourceName: "ustr", SourceVersion: "1.0.4-3"},
+		{Name: "xz-utils", Version: "5.1.1alpha+20120614-2", SourceName: "xz", SourceVersion: "5.1.1alpha+20120614-2"},
 	}
 
 	nonUpgradedMap := map[database.Feature]struct{}{}
@@ -318,7 +318,7 @@ func TestProcessAncestryWithDistUpgrade(t *testing.T) {
 		features = append(features, l.Features...)
 	}
 
-	assert.Len(t, features, 74)
+	assert.Len(t, features, 117)
 	for _, f := range features {
 		if _, ok := nonUpgradedMap[f.Feature]; ok {
 			assert.Equal(t, "debian:7", f.Namespace.Name)
@@ -352,8 +352,8 @@ func TestProcessLayers(t *testing.T) {
 	assert.Len(t, LayerWithContents[1].Namespaces, 1)
 	assert.Len(t, LayerWithContents[2].Namespaces, 1)
 	assert.Len(t, LayerWithContents[0].Features, 0)
-	assert.Len(t, LayerWithContents[1].Features, 52)
-	assert.Len(t, LayerWithContents[2].Features, 74)
+	assert.Len(t, LayerWithContents[1].Features, 80)
+	assert.Len(t, LayerWithContents[2].Features, 117)
 
 	// Ensure each layer has expected namespaces and features detected
 	if blank, ok := datastore.layers["blank"]; ok {
@@ -371,7 +371,7 @@ func TestProcessLayers(t *testing.T) {
 			{database.Namespace{"debian:7", dpkg.ParserName}, database.NewNamespaceDetector("os-release", "1.0")},
 		}, wheezy.Namespaces)
 
-		assert.Len(t, wheezy.Features, 52)
+		assert.Len(t, wheezy.Features, 80)
 	} else {
 		assert.Fail(t, "wheezy is not stored")
 		return
@@ -382,7 +382,7 @@ func TestProcessLayers(t *testing.T) {
 		assert.Equal(t, []database.LayerNamespace{
 			{database.Namespace{"debian:8", dpkg.ParserName}, database.NewNamespaceDetector("os-release", "1.0")},
 		}, jessie.Namespaces)
-		assert.Len(t, jessie.Features, 74)
+		assert.Len(t, jessie.Features, 117)
 	} else {
 		assert.Fail(t, "jessie is not stored")
 		return


### PR DESCRIPTION
Recent commit extracted source packages from images, but it didn't store
the new metadata to the database. This caused inconsistent data model in
several places and the current master branch was broken.

This commit store source package name and version to feature DB table.