### PR TITLE
Notification: Add new stomp notifier

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -51,6 +51,7 @@ import (
 	_ "github.com/quay/clair/v3/ext/imagefmt/aci"
 	_ "github.com/quay/clair/v3/ext/imagefmt/docker"
 	_ "github.com/quay/clair/v3/ext/imgpostprocessor/redhatcpe"
+	_ "github.com/quay/clair/v3/ext/notification/stomp"
 	_ "github.com/quay/clair/v3/ext/notification/webhook"
 	_ "github.com/quay/clair/v3/ext/vulnmdsrc/nvd"
 	_ "github.com/quay/clair/v3/ext/vulnsrc/alpine"

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -89,3 +89,17 @@ clair:
 
       # Optional HTTP Proxy: must be a valid URL (including the scheme).
       proxy:
+
+    stomp:
+      # Brokers array/list - with failover support
+      brokers:
+
+      # Virtual topic where a notification is sent
+      destination:
+      # Failover delay in ms
+      FailoverRetryDelay:
+
+      # Path to certificate, key and ca certificate files
+      cafile:
+      keyfile:
+      certfile:

--- a/ext/notification/stomp/stomp.go
+++ b/ext/notification/stomp/stomp.go
@@ -1,0 +1,209 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stomp implements a notification sender using stomp protocol.
+package stomp
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	"github.com/go-stomp/stomp"
+	"github.com/go-stomp/stomp/frame"
+	"gopkg.in/yaml.v2"
+
+	"github.com/quay/clair/v3/ext/notification"
+	log "github.com/sirupsen/logrus"
+)
+
+type Connetion interface {
+	Disconnect() error
+	Send(destination, contentType string, body []byte, opts ...func(*frame.Frame) error) error
+}
+
+type Sender struct {
+	Config    Config
+	StompConn Connetion
+	ConnOpts  []func(*stomp.Conn) error
+}
+
+// Config represents the configuration of a Stomp Sender.
+type Config struct {
+	Brokers            []string
+	Destination        string
+	CertFile           string
+	KeyFile            string
+	CAFile             string
+	FailoverRetryDelay float32
+}
+
+func init() {
+	notification.RegisterSender("stomp", &Sender{})
+}
+
+// Configure verifies stomp config and sets up stomp connection
+func (s *Sender) Configure(config *notification.Config) (bool, error) {
+	// Get configuration
+	var stompConfig Config
+	if config == nil {
+		return false, nil
+	}
+	if _, ok := config.Params["stomp"]; !ok {
+		return false, nil
+	}
+	yamlConfig, err := yaml.Marshal(config.Params["stomp"])
+	if err != nil {
+		return false, errors.New("invalid configuration")
+	}
+	err = yaml.Unmarshal(yamlConfig, &stompConfig)
+	if err != nil {
+		return false, errors.New("invalid configuration")
+	}
+
+	// Verify at least one broker is available
+	if len(stompConfig.Brokers) == 0 {
+		return false, nil
+	}
+	s.Config = stompConfig
+	return true, nil
+}
+
+// Connect - connect to one of a brokers which is currently online
+func (s *Sender) Connect() error {
+	if s.StompConn != nil {
+		return nil
+	}
+	tlsConfig, err := loadTLSClientConfig(&s.Config)
+	if err != nil {
+		return err
+	}
+
+	// try to connect to one of a brokers
+	var conn *tls.Conn
+	for _, broker := range s.Config.Brokers {
+		conn, err = tls.Dial("tcp", broker, tlsConfig)
+		if err == nil {
+			log.WithField("broker", broker).Info("Established TCP connection to broker")
+			break
+		}
+		log.WithField("broker", broker).Warning("Connection to broker failed")
+	}
+	if err != nil {
+		return err
+	}
+
+	// disable heartbeat since it actually just makes us disconnect
+	// see: https://github.com/go-stomp/stomp/issues/32
+	// remove or set to short time to test failover :-)
+	opts := append(s.ConnOpts, stomp.ConnOpt.HeartBeat(0, 0))
+	stompConn, err := stomp.Connect(conn, opts...)
+	if err != nil {
+		return errors.New("Failed stomp connection: " + err.Error())
+	}
+	s.StompConn = stompConn
+	return nil
+}
+
+// Disconnect - disconnect from remote broker
+func (s *Sender) Disconnect() {
+	if s.StompConn != nil {
+		s.StompConn.Disconnect()
+		s.StompConn = nil
+	}
+}
+
+type notificationEnvelope struct {
+	Notification struct {
+		Name string
+	}
+}
+
+// Send - send notification using STOMP in json format
+//
+// Send function has failover feature - in case one broker fails it reconnect
+// to another broker and send message again
+func (s *Sender) Send(notificationName string) error {
+	err := s.Connect()
+	if err != nil {
+		return err
+	}
+	// Marshal notification.
+	jsonNotification, err := json.Marshal(notificationEnvelope{struct{ Name string }{notificationName}})
+	if err != nil {
+		return fmt.Errorf("could not marshal: %s", err)
+	}
+
+	// Send with failover
+	opts := []func(*frame.Frame) error{stomp.SendOpt.NoContentLength}
+	var retryCount int
+	for retryCount = 0; retryCount <= len(s.Config.Brokers); retryCount++ {
+		err = s.StompConn.Send(s.Config.Destination, "application/json", jsonNotification, opts...)
+		if err == nil {
+			break
+		}
+
+		if retryCount > 0 {
+			log.Debug("Failed send over stomp right after reconnecting. Permission problems?")
+		}
+		s.Disconnect()
+
+		time.Sleep(time.Duration(s.Config.FailoverRetryDelay*float32(retryCount)) * time.Second)
+
+		err := s.Connect()
+		if err != nil {
+			log.Error("Failed to connect to any broker during reconnect: " + err.Error())
+			return err
+		}
+	}
+	s.Disconnect()
+
+	return nil
+}
+
+// loadTLSClientConfig initializes a *tls.Config using the given Config.
+//
+// If no certificates are given, (nil, nil) is returned.
+// The CA certificate is optional and falls back to the system default.
+func loadTLSClientConfig(cfg *Config) (*tls.Config, error) {
+	if cfg.CertFile == "" || cfg.KeyFile == "" {
+		return nil, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var caCertPool *x509.CertPool
+	if cfg.CAFile != "" {
+		caCert, err := ioutil.ReadFile(cfg.CAFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool = x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      caCertPool,
+	}
+
+	return tlsConfig, nil
+}

--- a/ext/notification/stomp/stomp_test.go
+++ b/ext/notification/stomp/stomp_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stomp
+
+import (
+	"testing"
+
+	"github.com/go-stomp/stomp/frame"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockConnetion struct {
+}
+
+func (c *MockConnetion) Disconnect() error {
+	return nil
+}
+
+func (c *MockConnetion) Send(destination, contentType string, body []byte, opts ...func(*frame.Frame) error) error {
+	return nil
+}
+
+func TestSend(t *testing.T) {
+	mockConnection := &MockConnetion{}
+
+	sender := Sender{StompConn: mockConnection}
+	err := sender.Send("foo")
+	assert.Equal(t, err, nil)
+	assert.Equal(t, sender.StompConn, nil)
+
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf
 	github.com/deckarep/golang-set v1.7.1
 	github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b
+	github.com/go-stomp/stomp v2.0.4+incompatible
 	github.com/golang/protobuf v1.2.0
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/google/uuid v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/docker/libnetwork v0.8.0-dev.2.0.20190604151032-3c26b4e7495e/go.mod h
 github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b h1:QqmfGmPkAbYcqM0YdHOS8JxqRJqEx+0rxjYZ1OiP6aw=
 github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b/go.mod h1:2H9hjfbpSMHwY503FclkV/lZTBh2YlOmLLSda12uL8c=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-stomp/stomp v2.0.4+incompatible h1:kLDcoPr8Ldoq61kpo6pwwzSacF6UZ+HJAzlHFLz8JCM=
+github.com/go-stomp/stomp v2.0.4+incompatible/go.mod h1:VqCtqNZv1226A1/79yh+rMiFUcfY3R109np+7ke4n0c=
 github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gofrs/flock v0.7.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=


### PR DESCRIPTION
Stomp protocol is capable to send messages/notification to message bus.
https://stomp.github.io/

The code is tested on Activemq messages bus. The code also supports
multiple brokers. In case one of them fails it can recover connection
and send a message to another one.