### PR TITLE
Vulnsrc: Use VMaaS as Red Hat's security data

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -57,7 +57,7 @@ import (
 	_ "github.com/coreos/clair/ext/vulnsrc/alpine"
 	_ "github.com/coreos/clair/ext/vulnsrc/debian"
 	_ "github.com/coreos/clair/ext/vulnsrc/oracle"
-	_ "github.com/coreos/clair/ext/vulnsrc/rhel"
+	_ "github.com/coreos/clair/ext/vulnsrc/redhat"
 	_ "github.com/coreos/clair/ext/vulnsrc/suse"
 	_ "github.com/coreos/clair/ext/vulnsrc/ubuntu"
 )

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -64,7 +64,7 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 		if len(r) == 4 {
 			// TODO(vbatts): this is a hack until https://github.com/coreos/clair/pull/193
 			return &database.Namespace{
-				Name:          "centos" + ":" + r[3],
+				Name:          "rhel" + ":" + r[3],
 				VersionFormat: rpm.ParserName,
 			}, nil
 		}

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -43,7 +43,7 @@ func TestDetector(t *testing.T) {
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
+			ExpectedNamespace: &database.Namespace{Name: "rhel:7"},
 			Files: tarutil.FilesMap{
 				"etc/redhat-release": []byte(`Red Hat Enterprise Linux Server release 7.2 (Maipo)`),
 			},

--- a/ext/vulnsrc/redhat/redhat.go
+++ b/ext/vulnsrc/redhat/redhat.go
@@ -1,0 +1,221 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redhat implements a vulnerability source updater using the
+// Red Hat Vmaas API.
+// https://github.com/RedHatInsights/vmaas
+package redhat
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/ext/versionfmt/rpm"
+	"github.com/coreos/clair/ext/vulnsrc"
+	"github.com/coreos/clair/pkg/commonerr"
+	"github.com/coreos/clair/pkg/httputil"
+)
+
+const (
+	rhsaFirstTime = "2000-01-001T01:01:01+02:00"
+	vmaasURL      = "https://webapp-vmaas-stable.1b13.insights.openshiftapps.com/api/v1"
+	cveURL        = "https://access.redhat.com/security/cve/"
+	updaterFlag   = "redHatUpdater"
+	affectedType  = database.AffectBinaryPackage
+)
+
+type Advisory struct {
+	Name          string    `json:"name"`
+	Synopsis      string    `json:"synopsis"`
+	Summary       string    `json:"summary"`
+	Type          string    `json:"type"`
+	Severity      string    `json:"severity"`
+	Description   string    `json:"description"`
+	Solution      string    `json:"solution"`
+	Issued        time.Time `json:"issued"`
+	Updated       time.Time `json:"updated"`
+	CveList       []string  `json:"cve_list"`
+	PackageList   []string  `json:"package_list"`
+	BugzillaList  []string  `json:"bugzilla_list"`
+	ReferenceList []string  `json:"reference_list"`
+	URL           string    `json:"url"`
+}
+
+type RHSAdata struct {
+	ErrataList    map[string]Advisory `json:"errata_list"`
+	Page          int                 `json:"page"`
+	PageSize      int                 `json:"page_size"`
+	Pages         int                 `json:"pages"`
+	ModifiedSince string              `json:"modified_since"`
+}
+
+type NVRA struct {
+	Name    string
+	Version string
+	Release string
+	Arch    string
+}
+
+type VmaasPostRequest struct {
+	ErrataList    []string `json:"errata_list"`
+	ModifiedSince string   `json:"modified_since"`
+	Page          int      `json:"page"`
+}
+
+type updater struct{}
+
+func init() {
+	vulnsrc.RegisterUpdater("redhat", &updater{})
+}
+
+func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
+	log.WithField("package", "RedHat").Info("Start fetching vulnerabilities")
+
+	// Get the timestamp from last scan
+	flagValue, ok, err := database.FindKeyValueAndRollback(datastore, updaterFlag)
+	if err != nil {
+		return resp, err
+	}
+	timeNow := time.Now()
+	newTime := timeNow.Format(time.RFC3339)
+	rhsaSince := rhsaFirstTime
+	if ok {
+		rhsaSince = flagValue
+	}
+	currentPage := 1
+	var advisories []Advisory
+
+	for {
+		requestParames := VmaasPostRequest{
+			ErrataList:    []string{"RHSA-.*"},
+			ModifiedSince: rhsaSince,
+			Page:          currentPage,
+		}
+		// Fetch the update list.
+		advisoriesURL := vmaasURL + "/errata/"
+		r, err := httputil.PostWithUserAgent(advisoriesURL, requestParames)
+		if err != nil {
+			log.WithError(err).Error("Could not download RedHat's update list")
+			return resp, commonerr.ErrCouldNotDownload
+		}
+		defer r.Body.Close()
+
+		if !httputil.Status2xx(r) {
+			log.WithField("StatusCode", r.StatusCode).Error("Failed to update RedHat")
+			return resp, commonerr.ErrCouldNotDownload
+		}
+
+		var rhsaData RHSAdata
+		if err := json.NewDecoder(r.Body).Decode(&rhsaData); err != nil {
+			return resp, err
+		}
+		for _, advisory := range rhsaData.ErrataList {
+			advisories = append(advisories, advisory)
+		}
+		currentPage++
+		if rhsaData.Page == rhsaData.Pages || rhsaData.Pages == 0 {
+			// last page
+			break
+		}
+	}
+
+	for _, advisory := range advisories {
+		vulnerabilities := parseAdvisory(advisory)
+		resp.Vulnerabilities = append(resp.Vulnerabilities, vulnerabilities...)
+
+	}
+	if len(resp.Vulnerabilities) > 0 {
+		log.WithFields(log.Fields{
+			"items":   len(resp.Vulnerabilities),
+			"updater": "RedHat",
+		}).Debug("Found new vulnerabilities")
+	}
+
+	// save new timestamp to database
+	resp.FlagName = updaterFlag
+	resp.FlagValue = newTime
+	return resp, nil
+
+}
+
+// parseAdvisory - parse advisory metadata and create new Vulnerabilities objects
+func parseAdvisory(advisory Advisory) (vulnerabilities []database.VulnerabilityWithAffected) {
+	for _, cve := range advisory.CveList {
+		vulnerability := database.VulnerabilityWithAffected{
+			Vulnerability: database.Vulnerability{
+				Name:        cve,
+				Link:        cveURL + cve,
+				Severity:    severity(advisory.Severity),
+				Description: advisory.Description,
+			},
+		}
+		for _, nvra := range advisory.PackageList {
+			parsedNVRA := parseNVRA(nvra)
+			p := database.AffectedFeature{
+				FeatureName:     parsedNVRA.Name,
+				AffectedVersion: parsedNVRA.Version + "-" + parsedNVRA.Release,
+				FixedInVersion:  parsedNVRA.Version + "-" + parsedNVRA.Release,
+				AffectedType:    affectedType,
+				Namespace: database.Namespace{
+					// Not sure what namespace should I use here (can we use CPE here?)
+					// TODO: fix it
+					Name:          "redhat",
+					VersionFormat: rpm.ParserName,
+				},
+			}
+			vulnerability.Affected = append(vulnerability.Affected, p)
+		}
+		vulnerabilities = append(vulnerabilities, vulnerability)
+	}
+	return
+}
+
+// parseNVRA - parse {name}-{version}-{release}.{arch}
+func parseNVRA(nvra string) NVRA {
+	var parsedNVRA NVRA
+	archIndex := strings.LastIndex(nvra, ".")
+	parsedNVRA.Arch = nvra[archIndex+1:]
+
+	releaseIndex := strings.LastIndex(nvra[:archIndex], "-")
+	parsedNVRA.Release = nvra[releaseIndex+1 : archIndex]
+
+	versionIndex := strings.LastIndex(nvra[:releaseIndex], "-")
+	parsedNVRA.Version = nvra[versionIndex+1 : releaseIndex]
+
+	parsedNVRA.Name = nvra[:versionIndex]
+
+	return parsedNVRA
+}
+
+func severity(sev string) database.Severity {
+	switch strings.Title(sev) {
+	case "Low":
+		return database.LowSeverity
+	case "Moderate":
+		return database.MediumSeverity
+	case "Important":
+		return database.HighSeverity
+	case "Critical":
+		return database.CriticalSeverity
+	default:
+		log.Warningf("could not determine vulnerability severity from: %s.", sev)
+		return database.UnknownSeverity
+	}
+}
+
+func (u *updater) Clean() {}

--- a/ext/vulnsrc/redhat/redhat_test.go
+++ b/ext/vulnsrc/redhat/redhat_test.go
@@ -1,0 +1,71 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redhat
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/coreos/clair/database"
+	"github.com/coreos/clair/ext/versionfmt/rpm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRHELParserOneCVE(t *testing.T) {
+	_, filename, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(filename))
+
+	// Test parsing testdata/advisory.json
+	testFile, _ := os.Open(filepath.Join(path, "/testdata/advisory.json"))
+	var rhsaData RHSAdata
+	if err := json.NewDecoder(testFile).Decode(&rhsaData); err != nil {
+		panic(err)
+	}
+	vulnerabilities := parseAdvisory(rhsaData.ErrataList["RHSA-2019:0139"])
+	assert.Equal(t, "CVE-2017-2582", vulnerabilities[0].Name)
+	assert.Equal(t, "https://access.redhat.com/security/cve/CVE-2017-2582", vulnerabilities[0].Link)
+	assert.Equal(t, database.MediumSeverity, vulnerabilities[0].Severity)
+	assert.Equal(t, "Red Hat JBoss Enterprise Application Platform is a platform for Java applications based on the JBoss Application Server.\n\nThis release serves as a replacement for Red Hat JBoss Enterprise Application Platform 7.1, and includes bug fixes and enhancements. Refer to the Red Hat JBoss Enterprise Application Platform 7.2.0 Release Notes for information on the most significant bug fixes and enhancements included in this release.\n\nSecurity Fix(es):\n\n* picketlink: SAML request parser replaces special strings with system properties (CVE-2017-2582)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, and other related information, refer to the CVE page(s) listed in\nthe References section.\n\nThe CVE-2017-2582 issue was discovered by Hynek Mlnarik (Red Hat).", vulnerabilities[0].Description)
+
+	expectedFeatures := []database.AffectedFeature{
+		{
+			AffectedType: affectedType,
+			Namespace: database.Namespace{
+				Name:          "redhat",
+				VersionFormat: rpm.ParserName,
+			},
+			FeatureName:     "tomcat7-docs-webapp",
+			AffectedVersion: "7.0.70-31.ep7.el6",
+			FixedInVersion:  "7.0.70-31.ep7.el6",
+		},
+		{
+			AffectedType: affectedType,
+			Namespace: database.Namespace{
+				Name:          "redhat",
+				VersionFormat: rpm.ParserName,
+			},
+			FeatureName:     "tomcat7-selinux",
+			AffectedVersion: "7.0.70-31.ep7.el6",
+			FixedInVersion:  "7.0.70-31.ep7.el6",
+		},
+	}
+
+	for _, expectedFeature := range expectedFeatures {
+		assert.Contains(t, vulnerabilities[0].Affected, expectedFeature)
+	}
+}

--- a/ext/vulnsrc/redhat/testdata/advisory.json
+++ b/ext/vulnsrc/redhat/testdata/advisory.json
@@ -1,0 +1,35 @@
+{
+    "errata_list": {
+        "RHSA-2019:0139": {
+            "bugzilla_list": [
+                "1410481"
+            ],
+            "cve_list": [
+                "CVE-2017-2582"
+            ],
+            "description": "Red Hat JBoss Enterprise Application Platform is a platform for Java applications based on the JBoss Application Server.\n\nThis release serves as a replacement for Red Hat JBoss Enterprise Application Platform 7.1, and includes bug fixes and enhancements. Refer to the Red Hat JBoss Enterprise Application Platform 7.2.0 Release Notes for information on the most significant bug fixes and enhancements included in this release.\n\nSecurity Fix(es):\n\n* picketlink: SAML request parser replaces special strings with system properties (CVE-2017-2582)\n\nFor more details about the security issue(s), including the impact, a CVSS\nscore, and other related information, refer to the CVE page(s) listed in\nthe References section.\n\nThe CVE-2017-2582 issue was discovered by Hynek Mlnarik (Red Hat).",
+            "issued": "2019-01-22T16:22:20+00:00",
+            "package_list": [
+                "tomcat7-docs-webapp-7.0.70-31.ep7.el6.noarch",
+                "tomcat7-selinux-7.0.70-31.ep7.el6.noarch"
+            ],
+            "reference_list": [
+                "classification-RHSA-2019:0139",
+                "ref_0-RHSA-2019:0139",
+                "ref_1-RHSA-2019:0139",
+                "ref_2-RHSA-2019:0139"
+            ],
+            "severity": "Moderate",
+            "solution": "Before applying this update, back up your existing Red Hat JBoss Enterprise Application Platform installation and deployed applications.\n\nThe References section of this erratum contains a download link (you must log in to download the update).\n\nThe JBoss server process must be restarted for the update to take effect.",
+            "summary": "Red Hat JBoss Enterprise Application Platform 7.2.0 is now available.\n\nRed Hat Product Security has rated this update as having a security impact of Moderate. A Common Vulnerability Scoring System (CVSS) base score, which gives a detailed severity rating, is available for each vulnerability from the CVE link(s) in the References section.",
+            "synopsis": "Moderate: Red Hat JBoss Enterprise Application Platform 7.2.0 security update",
+            "type": "security",
+            "updated": "2019-01-22T16:22:20+00:00",
+            "url": "https://access.redhat.com/errata/RHSA-2019:0139"
+        }
+    },
+    "modified_since": "2019-01-22T16:01:41+01:00",
+    "page": 1,
+    "page_size": 1,
+    "pages": 1
+}

--- a/ext/vulnsrc/redhat/testdata/cvemap.xml
+++ b/ext/vulnsrc/redhat/testdata/cvemap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<cvemap updated="2019-01-29T12:15:39">
+    <Vulnerability name="CVE-2017-2582">
+        <PublicDate>2000-04-13T00:00:00</PublicDate>
+        <Bugzilla id="1616471" url="https://bugzilla.redhat.com/show_bug.cgi?id=1616471" xml:lang="en:us">
+    CVE-2000-0336 security flaw
+        </Bugzilla>
+        <Details xml:lang="en:us" source="Mitre">
+    Linux OpenLDAP server allows local users to modify arbitrary files via a symlink attack.
+        </Details>
+        <AffectedRelease cpe="cpe:/o:redhat:enterprise_linux:6.1">
+            <ProductName>Red Hat Linux 6.1</ProductName>
+            <ReleaseDate>2000-04-21T00:00:00</ReleaseDate>
+            <Advisory type="RHSA" url="https://access.redhat.com/errata/RHSA-2019:0139">RHSA-2019:0139</Advisory>
+            <Package name="kernel">tomcat7-docs-webapp-7.0.70-31.ep7.el6</Package>
+        </AffectedRelease>
+        <AffectedRelease cpe="cpe:/o:redhat:enterprise_linux:7">
+            <ProductName>Red Hat Linux 6.2</ProductName>
+            <ReleaseDate>2000-04-21T00:00:00</ReleaseDate>
+            <Advisory type="RHSA" url="https://access.redhat.com/errata/RHSA-2019:0139">RHSA-2019:0139</Advisory>
+            <Package name="kernel">tomcat7-selinux-7.0.70-31.ep7.el6</Package>
+        </AffectedRelease>
+    </Vulnerability>
+</cvemap>

--- a/pkg/httputil/httputil.go
+++ b/pkg/httputil/httputil.go
@@ -16,6 +16,8 @@
 package httputil
 
 import (
+	"bytes"
+	"encoding/json"
 	"net"
 	"net/http"
 	"strings"
@@ -35,6 +37,29 @@ func GetWithUserAgent(url string) (*http.Response, error) {
 		return nil, err
 	}
 
+	req.Header.Set("User-Agent", "Clair/"+version.Version+" (https://github.com/coreos/clair)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// PostWithUserAgent performs an HTTP POST with the proper Clair User-Agent.
+func PostWithUserAgent(url string, data interface{}) (*http.Response, error) {
+	client := &http.Client{}
+	postData, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(postData))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("User-Agent", "Clair/"+version.Version+" (https://github.com/coreos/clair)")
 
 	resp, err := client.Do(req)


### PR DESCRIPTION
Oval data which were used before doesn't cover whole portfolio.
VMaaS provides security data about all Red Hat's products.

Only vulnerability delta is downloaded (only new vulnerabilities since
last scan)

https://github.com/coreos/clair/issues/632
