### PR TITLE
Make nodePort configurable with helm

### DIFF
--- a/contrib/helm/clair/templates/service.yaml
+++ b/contrib/helm/clair/templates/service.yaml
@@ -14,9 +14,15 @@ spec:
     port: {{ .Values.service.externalApiPort }}
     targetPort: {{ .Values.service.internalApiPort }}
     protocol: TCP
+{{- if and (.Values.service.apiNodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.apiNodePort }}
+{{- end }}
   - name: "{{ .Chart.Name }}-health"
     port: {{ .Values.service.externalHealthPort }}
     targetPort: {{ .Values.service.internalHealthPort }}
     protocol: TCP
+{{- if and (.Values.service.healthNodePort) (eq .Values.service.type "NodePort") }}
+    nodePort: {{ .Values.service.healthNodePort }}
+{{- end }}
   selector:
     app: {{ template "clair.fullname" . }}


### PR DESCRIPTION
This pull request adds option to set the NodePort to desired port. The port can be set with the following values file:

```
service:
   type: "NodePort"
   apiNodePort: 31111
   healthNodePort: 31112
```

Only when `Values.service.type` equals `"NodePort"` and `Values.service.apiNodePort` or `Values.service.healthNodePort` is specified the NodePort port will be set. 