### PR TITLE
Allow multiple namespaces per detector

### DIFF
--- a/ext/featurens/alpinerelease/alpinerelease.go
+++ b/ext/featurens/alpinerelease/alpinerelease.go
@@ -41,7 +41,7 @@ func init() {
 
 type detector struct{}
 
-func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
+func (d detector) Detect(files tarutil.FilesMap) ([]*database.Namespace, error) {
 	file, exists := files[alpineReleasePath]
 	if exists {
 		scanner := bufio.NewScanner(bytes.NewBuffer(file))
@@ -50,9 +50,11 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 			match := versionRegexp.FindStringSubmatch(line)
 			if len(match) > 0 {
 				versionNumbers := strings.Split(match[0], ".")
-				return &database.Namespace{
-					Name:          osName + ":" + "v" + versionNumbers[0] + "." + versionNumbers[1],
-					VersionFormat: dpkg.ParserName,
+				return []*database.Namespace{
+					{
+						Name:          osName + ":" + "v" + versionNumbers[0] + "." + versionNumbers[1],
+						VersionFormat: dpkg.ParserName,
+					},
 				}, nil
 			}
 		}

--- a/ext/featurens/alpinerelease/alpinerelease_test.go
+++ b/ext/featurens/alpinerelease/alpinerelease_test.go
@@ -25,19 +25,19 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
-			ExpectedNamespace: &database.Namespace{Name: "alpine:v3.3"},
+			ExpectedNamespace: []*database.Namespace{{Name: "alpine:v3.3"}},
 			Files:             tarutil.FilesMap{"etc/alpine-release": []byte(`3.3.4`)},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "alpine:v3.4"},
+			ExpectedNamespace: []*database.Namespace{{Name: "alpine:v3.4"}},
 			Files:             tarutil.FilesMap{"etc/alpine-release": []byte(`3.4.0`)},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "alpine:v0.3"},
+			ExpectedNamespace: []*database.Namespace{{Name: "alpine:v0.3"}},
 			Files:             tarutil.FilesMap{"etc/alpine-release": []byte(`0.3.4`)},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "alpine:v0.3"},
+			ExpectedNamespace: []*database.Namespace{{Name: "alpine:v0.3"}},
 			Files: tarutil.FilesMap{"etc/alpine-release": []byte(`
 0.3.4
 `)},

--- a/ext/featurens/aptsources/aptsources.go
+++ b/ext/featurens/aptsources/aptsources.go
@@ -35,7 +35,7 @@ func init() {
 	featurens.RegisterDetector("apt-sources", "1.0", &detector{})
 }
 
-func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
+func (d detector) Detect(files tarutil.FilesMap) ([]*database.Namespace, error) {
 	f, hasFile := files["etc/apt/sources.list"]
 	if !hasFile {
 		return nil, nil
@@ -79,9 +79,11 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{
-			Name:          OS + ":" + version,
-			VersionFormat: dpkg.ParserName,
+		return []*database.Namespace{
+			{
+				Name:          OS + ":" + version,
+				VersionFormat: dpkg.ParserName,
+			},
 		}, nil
 	}
 	return nil, nil

--- a/ext/featurens/aptsources/aptsources_test.go
+++ b/ext/featurens/aptsources/aptsources_test.go
@@ -25,7 +25,7 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
-			ExpectedNamespace: &database.Namespace{Name: "debian:unstable"},
+			ExpectedNamespace: []*database.Namespace{{Name: "debian:unstable"}},
 			Files: tarutil.FilesMap{
 				"etc/os-release": []byte(
 					`PRETTY_NAME="Debian GNU/Linux stretch/sid"

--- a/ext/featurens/lsbrelease/lsbrelease.go
+++ b/ext/featurens/lsbrelease/lsbrelease.go
@@ -41,7 +41,7 @@ func init() {
 	featurens.RegisterDetector("lsb-release", "1.0", &detector{})
 }
 
-func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
+func (d detector) Detect(files tarutil.FilesMap) ([]*database.Namespace, error) {
 	f, hasFile := files["etc/lsb-release"]
 	if !hasFile {
 		return nil, nil
@@ -84,12 +84,13 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{
-			Name:          OS + ":" + version,
-			VersionFormat: versionFormat,
+		return []*database.Namespace{
+			{
+				Name:          OS + ":" + version,
+				VersionFormat: versionFormat,
+			},
 		}, nil
 	}
-
 	return nil, nil
 }
 

--- a/ext/featurens/lsbrelease/lsbrelease_test.go
+++ b/ext/featurens/lsbrelease/lsbrelease_test.go
@@ -25,7 +25,7 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
-			ExpectedNamespace: &database.Namespace{Name: "ubuntu:12.04"},
+			ExpectedNamespace: []*database.Namespace{{Name: "ubuntu:12.04"}},
 			Files: tarutil.FilesMap{
 				"etc/lsb-release": []byte(
 					`DISTRIB_ID=Ubuntu
@@ -35,7 +35,7 @@ DISTRIB_DESCRIPTION="Ubuntu 12.04 LTS"`),
 			},
 		},
 		{ // We don't care about the minor version of Debian
-			ExpectedNamespace: &database.Namespace{Name: "debian:7"},
+			ExpectedNamespace: []*database.Namespace{{Name: "debian:7"}},
 			Files: tarutil.FilesMap{
 				"etc/lsb-release": []byte(
 					`DISTRIB_ID=Debian

--- a/ext/featurens/osrelease/osrelease.go
+++ b/ext/featurens/osrelease/osrelease.go
@@ -48,7 +48,7 @@ func init() {
 	featurens.RegisterDetector("os-release", "1.0", &detector{})
 }
 
-func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
+func (d detector) Detect(files tarutil.FilesMap) ([]*database.Namespace, error) {
 	var OS, version string
 
 	for _, filePath := range blacklistFilenames {
@@ -91,9 +91,11 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 	}
 
 	if OS != "" && version != "" {
-		return &database.Namespace{
-			Name:          OS + ":" + version,
-			VersionFormat: versionFormat,
+		return []*database.Namespace{
+			{
+				Name:          OS + ":" + version,
+				VersionFormat: versionFormat,
+			},
 		}, nil
 	}
 	return nil, nil

--- a/ext/featurens/osrelease/osrelease_test.go
+++ b/ext/featurens/osrelease/osrelease_test.go
@@ -25,7 +25,7 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
-			ExpectedNamespace: &database.Namespace{Name: "debian:8"},
+			ExpectedNamespace: []*database.Namespace{{Name: "debian:8"}},
 			Files: tarutil.FilesMap{
 				"etc/os-release": []byte(
 					`PRETTY_NAME="Debian GNU/Linux 8 (jessie)"
@@ -39,7 +39,7 @@ BUG_REPORT_URL="https://bugs.debian.org/"`),
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "ubuntu:15.10"},
+			ExpectedNamespace: []*database.Namespace{{Name: "ubuntu:15.10"}},
 			Files: tarutil.FilesMap{
 				"etc/os-release": []byte(
 					`NAME="Ubuntu"
@@ -54,7 +54,7 @@ BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"`),
 			},
 		},
 		{ // Doesn't have quotes around VERSION_ID
-			ExpectedNamespace: &database.Namespace{Name: "fedora:20"},
+			ExpectedNamespace: []*database.Namespace{{Name: "fedora:20"}},
 			Files: tarutil.FilesMap{
 				"etc/os-release": []byte(
 					`NAME=Fedora

--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -20,6 +20,7 @@
 package redhatrelease
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -41,7 +42,7 @@ func init() {
 	featurens.RegisterDetector("redhat-release", "1.0", &detector{})
 }
 
-func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
+func (d detector) Detect(files tarutil.FilesMap) ([]*database.Namespace, error) {
 	for _, filePath := range d.RequiredFilenames() {
 		f, hasFile := files[filePath]
 		if !hasFile {
@@ -53,9 +54,12 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 		// Attempt to match Oracle Linux.
 		r = oracleReleaseRegexp.FindStringSubmatch(string(f))
 		if len(r) == 4 {
-			return &database.Namespace{
-				Name:          strings.ToLower(r[1]) + ":" + r[3],
-				VersionFormat: rpm.ParserName,
+			fmt.Println(r)
+			return []*database.Namespace{
+				{
+					Name:          strings.ToLower(r[1]) + ":" + r[3],
+					VersionFormat: rpm.ParserName,
+				},
 			}, nil
 		}
 
@@ -63,18 +67,22 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 		r = redhatReleaseRegexp.FindStringSubmatch(string(f))
 		if len(r) == 4 {
 			// TODO(vbatts): this is a hack until https://github.com/coreos/clair/pull/193
-			return &database.Namespace{
-				Name:          "centos" + ":" + r[3],
-				VersionFormat: rpm.ParserName,
+			return []*database.Namespace{
+				{
+					Name:          "centos" + ":" + r[3],
+					VersionFormat: rpm.ParserName,
+				},
 			}, nil
 		}
 
 		// Atempt to match CentOS.
 		r = centosReleaseRegexp.FindStringSubmatch(string(f))
 		if len(r) == 4 {
-			return &database.Namespace{
-				Name:          strings.ToLower(r[1]) + ":" + r[3],
-				VersionFormat: rpm.ParserName,
+			return []*database.Namespace{
+				{
+					Name:          strings.ToLower(r[1]) + ":" + r[3],
+					VersionFormat: rpm.ParserName,
+				},
 			}, nil
 		}
 	}

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -25,31 +25,31 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
-			ExpectedNamespace: &database.Namespace{Name: "oracle:6"},
+			ExpectedNamespace: []*database.Namespace{{Name: "oracle:6"}},
 			Files: tarutil.FilesMap{
 				"etc/oracle-release": []byte(`Oracle Linux Server release 6.8`),
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "oracle:7"},
+			ExpectedNamespace: []*database.Namespace{{Name: "oracle:7"}},
 			Files: tarutil.FilesMap{
 				"etc/oracle-release": []byte(`Oracle Linux Server release 7.2`),
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "centos:6"},
+			ExpectedNamespace: []*database.Namespace{{Name: "centos:6"}},
 			Files: tarutil.FilesMap{
 				"etc/centos-release": []byte(`CentOS release 6.6 (Final)`),
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
+			ExpectedNamespace: []*database.Namespace{{Name: "centos:7"}},
 			Files: tarutil.FilesMap{
 				"etc/redhat-release": []byte(`Red Hat Enterprise Linux Server release 7.2 (Maipo)`),
 			},
 		},
 		{
-			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
+			ExpectedNamespace: []*database.Namespace{{Name: "centos:7"}},
 			Files: tarutil.FilesMap{
 				"etc/system-release": []byte(`CentOS Linux release 7.1.1503 (Core)`),
 			},


### PR DESCRIPTION
In some cases single detector can return multiple namespaces, based on
what is installed in container - features can come from multiple
products.