### PR TITLE
pkg/grpcutil: use cockroachdb cipher suite

### DIFF
--- a/pkg/grpcutil/muxed_server.go
+++ b/pkg/grpcutil/muxed_server.go
@@ -1,4 +1,4 @@
-// Copyright 2018 clair authors
+// Copyright 2019 clair authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +114,50 @@ func configureCertificate(tlsConfig *tls.Config, certFile, keyFile string) error
 // pivot based on whether the request is gRPC or HTTP.
 func (srv *MuxedGRPCServer) ListenAndServeTLS(certFile, keyFile, caPath string, mw httputil.Middleware) error {
 	if srv.TLSConfig == nil {
-		srv.TLSConfig = &tls.Config{}
+		srv.TLSConfig = &tls.Config{
+			// This is Go's default list of cipher suites (as of go 1.8.3),
+			// with the following differences:
+			//
+			// - 3DES-based cipher suites have been removed. This cipher is
+			//   vulnerable to the Sweet32 attack and is sometimes reported by
+			//   security scanners. (This is arguably a false positive since
+			//   it will never be selected: Any TLS1.2 implementation MUST
+			//   include at least one cipher higher in the priority list, but
+			//   there's also no reason to keep it around)
+			// - AES is always prioritized over ChaCha20. Go makes this decision
+			//   by default based on the presence or absence of hardware AES
+			//   acceleration.
+			//   TODO(bdarnell): do the same detection here. See
+			//   https://github.com/golang/go/issues/21167
+			//
+			// Note that some TLS cipher suite guidance (such as Mozilla's[1])
+			// recommend replacing the CBC_SHA suites below with CBC_SHA384 or
+			// CBC_SHA256 variants. We do not do this because Go does not
+			// currently implement the CBC_SHA384 suites, and its CBC_SHA256
+			// implementation is vulnerable to the Lucky13 attack and is disabled
+			// by default.[2]
+			//
+			// [1]: https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
+			// [2]: https://github.com/golang/go/commit/48d8edb5b21db190f717e035b4d9ab61a077f9d7
+			CipherSuites: []uint16{
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+				tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			},
+
+			MinVersion: tls.VersionTLS12,
+		}
 	}
 	err := configureCA(srv.TLSConfig, caPath)
 	if err != nil {


### PR DESCRIPTION
This resolves any concern around Sweet32.

See the following issues for more details:

https://github.com/golang/go/issues/21167
https://github.com/golang/go/issues/21144