### PR TITLE
Use PotentialNamespace in ancestry

### DIFF
--- a/ancestry.go
+++ b/ancestry.go
@@ -211,9 +211,20 @@ func (b *AncestryBuilder) createLayerIndexedFeature(namespace *layerIndexedNames
 
 func (b *AncestryBuilder) lookupNamespace(feature *database.LayerFeature) (*layerIndexedNamespace, bool) {
 	matchedNamespaces := []*layerIndexedNamespace{}
-	for i, namespace := range b.namespaces {
-		if namespace.Namespace.VersionFormat == feature.VersionFormat {
-			matchedNamespaces = append(matchedNamespaces, &b.namespaces[i])
+	if feature.PotentialNamespace.Name != "" {
+		a := &layerIndexedNamespace{
+			Namespace: database.LayerNamespace{
+				Namespace: feature.PotentialNamespace,
+			},
+			IntroducedIn: b.layerIndex,
+		}
+		matchedNamespaces = append(matchedNamespaces, a)
+	} else {
+
+		for i, namespace := range b.namespaces {
+			if namespace.Namespace.VersionFormat == feature.VersionFormat {
+				matchedNamespaces = append(matchedNamespaces, &b.namespaces[i])
+			}
 		}
 	}
 

--- a/api/v3/clairpb/convert.go
+++ b/api/v3/clairpb/convert.go
@@ -153,6 +153,9 @@ func NamespacedFeatureFromDatabaseModel(feature database.AncestryFeature) *Featu
 
 // DetectorFromDatabaseModel converts database detector to api detector.
 func DetectorFromDatabaseModel(detector database.Detector) *Detector {
+	if !detector.Valid() {
+		return nil
+	}
 	return &Detector{
 		Name:    detector.Name,
 		Version: detector.Version,

--- a/database/pgsql/migrations/00001_initial_schema.go
+++ b/database/pgsql/migrations/00001_initial_schema.go
@@ -127,7 +127,7 @@ var (
 				ancestry_layer_id INT NOT NULL REFERENCES ancestry_layer ON DELETE CASCADE,
 				namespaced_feature_id INT NOT NULL REFERENCES namespaced_feature ON DELETE CASCADE,
 				feature_detector_id INT NOT NULL REFERENCES detector ON DELETE CASCADE,
-				namespace_detector_id INT NOT NULL REFERENCES detector ON DELETE CASCADE,
+				namespace_detector_id INT REFERENCES detector ON DELETE CASCADE,
 				UNIQUE (ancestry_layer_id, namespaced_feature_id));`,
 
 			`CREATE TABLE IF NOT EXISTS ancestry_detector(


### PR DESCRIPTION
If PotentialNamespace is available for a given feature it is used instead
of detector namespace. A detector is empty in such a case.

Resolves: https://github.com/coreos/clair/issues/734