### PR TITLE
set / as default path but allow for individual configuration in values.yml

### DIFF
--- a/contrib/helm/clair/templates/ingress.yaml
+++ b/contrib/helm/clair/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := include "clair.fullname" . -}}
 {{- $servicePort := .Values.service.externalApiPort -}}
+{{- $path := .Values.ingress.path | default "/" -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -20,7 +21,7 @@ spec:
     - host: {{ $host }}
       http:
         paths:
-          - path: /
+          - path: {{ $path }}
             backend:
               serviceName: {{ $serviceName }}
               servicePort: {{ $servicePort }}


### PR DESCRIPTION
The current hardcoded path `/` in the ingress template of the Helm charts does not work in the context of AWS ALBs.  The listener is explicit in its routing, and the path needs to be set to `/*` in order for any of the requests to Clair endpoints to succeed.  This is a fix that sets `/` as a default but allows for others using the same system to set a custom configuration without having to maintain their own copy of the Helm charts.

Viz:
(with default `/` path)
![Screenshot 2019-03-19 10 33 19](https://user-images.githubusercontent.com/1719123/54704171-a0bfe000-4b10-11e9-9b07-39a51698f702.png)
![Screenshot 2019-03-19 10 34 25](https://user-images.githubusercontent.com/1719123/54704184-a74e5780-4b10-11e9-88d1-3dc5249dde08.png)

(with path configured to `/*` in a local, customized clone of the helm charts)
![Screenshot 2019-03-19 10 28 17](https://user-images.githubusercontent.com/1719123/54704307-d9f85000-4b10-11e9-8f4c-a0ba167eb1a9.png)
![Screenshot 2019-03-19 10 35 46](https://user-images.githubusercontent.com/1719123/54704319-dfee3100-4b10-11e9-8d47-70c289f8afeb.png)
![Screenshot 2019-03-19 10 35 56](https://user-images.githubusercontent.com/1719123/54704329-e41a4e80-4b10-11e9-9833-e02f75e74d4a.png)
