### PR TITLE
Allow OpenShift user update CA bundle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN export CLAIR_VERSION=$(git describe --tag --always --dirty) && \
 FROM alpine:3.8
 COPY --from=build /go/src/github.com/coreos/clair/clair /clair
 RUN apk add --no-cache git rpm xz ca-certificates dumb-init
+
+# change ownership of ssl directory to allow custom cert in OpenShift
+RUN chgrp -R 0 /etc/ssl/certs && \
+    chmod -R g=u /etc/ssl/certs
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/clair"]
 VOLUME /config
 EXPOSE 6060 6061


### PR DESCRIPTION
When users run Clair in OpenShift under arbitrary user and
they want to update CA bundle with their own certificate
they need to run `ca-certificates` which requires access
to /etc/ssl/certs.

This commit updates Dockerfile based on OpenShift guidelines to allow
update CA bundle in a system.

https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines