### PR TITLE
[Helm] Do not set resources per default, leave suggested values in comments

### DIFF
--- a/contrib/helm/clair/Chart.yaml
+++ b/contrib/helm/clair/Chart.yaml
@@ -1,6 +1,6 @@
 name: clair
 home: https://coreos.com/clair
-version: 0.1.1
+version: 0.1.2
 appVersion: 3.0.0-pre
 description: Clair is an open source project for the static analysis of vulnerabilities in application containers.
 icon: https://cloud.githubusercontent.com/assets/343539/21630811/c5081e5c-d202-11e6-92eb-919d5999c77a.png

--- a/contrib/helm/clair/values.yaml
+++ b/contrib/helm/clair/values.yaml
@@ -27,13 +27,13 @@ ingress:
     # - secretName: chart-example-tls
     #   hosts:
     #     - chart-example.local
-resources:
-  limits:
-    cpu: 200m
-    memory: 1500Mi
-  requests:
-    cpu: 100m
-    memory: 500Mi
+resources: {}
+# limits:
+#   cpu: 200m
+#   memory: 1500Mi
+# requests:
+#   cpu: 100m
+#   memory: 500Mi
 config:
   # postgresURI: "postgres://user:password@host:5432/postgres?sslmode=disable"
   paginationKey: "XxoPtCUzrUv4JV5dS+yQ+MdW7yLEJnRMwigVY/bpgtQ="


### PR DESCRIPTION
I commented the `resources` values in the helm Chart and added an empty object instead. As described in #730 I stumbled upon this issue, as the default values were very much insufficient.

According to the output of `helm create`:

```
We usually recommend not to specify default resources and to leave this as a conscious
choice for the user. This also increases chances charts run on environments with little
resources, such as Minikube. If you do want to specify resources, uncomment the following
lines, adjust them as necessary, and remove the curly braces after 'resources:'.
```

The setting of resource limits should be a conscious user choice instead of a default.