### PR TITLE
Fix: lock updater - return correct bool value

### DIFF
--- a/database/dbutil.go
+++ b/database/dbutil.go
@@ -360,7 +360,7 @@ func AcquireLock(datastore Datastore, name, owner string, duration time.Duration
 
 // ExtendLock extends the duration of an existing global lock for the given
 // duration.
-func ExtendLock(ds Datastore, name, whoami string, desiredLockDuration time.Duration) (extended bool, expiration time.Time) {
+func ExtendLock(ds Datastore, name, whoami string, desiredLockDuration time.Duration) (bool, time.Time) {
 	tx, err := ds.Begin()
 	if err != nil {
 		return false, time.Time{}
@@ -374,7 +374,7 @@ func ExtendLock(ds Datastore, name, whoami string, desiredLockDuration time.Dura
 
 	if locked {
 		if err := tx.Commit(); err == nil {
-			return
+			return locked, expiration
 		}
 	}
 


### PR DESCRIPTION
The function which extends lock duration in DB returns incorrect bool
value (return default false value). This cause that context is canceled
when extending lock duration and the whole update process fails.

This commit fixes the bug and returns a correct bool value.