### PR TITLE
helm: add mapping for postgres ssl certs

### DIFF
--- a/contrib/helm/clair/templates/secret.yaml
+++ b/contrib/helm/clair/templates/secret.yaml
@@ -9,5 +9,6 @@ metadata:
     app: {{ template "clair.fullname" . }}
 type: Opaque
 data:
+  postgresql-ca-cert: {{ default "" .Values.config.postgresCaCert | b64enc | quote }}
   config.yaml: |-
 {{ include (print .Template.BasePath "/_config.yaml.tpl") . | b64enc | indent 4 }}


### PR DESCRIPTION
This allows for easy inclusion of an SSL certificate for Clair's connection to its Postgres database, e.g., by storing it locally and referencing it during a helm install/upgrade with the `--set-file` flag.