### PR TITLE
Vulnsrc: return flag map instead of single value 

### DIFF
--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -67,8 +67,8 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 	}
 
 	// Set the updaterFlag to equal the commit processed.
-	resp.FlagName = updaterFlag
-	resp.FlagValue = commit
+	resp.Flags = make(map[string]string)
+	resp.Flags[updaterFlag] = commit
 	if existingCommit, foundCommit, err = database.FindKeyValueAndRollback(db, updaterFlag); err != nil {
 		return
 	}

--- a/ext/vulnsrc/debian/debian.go
+++ b/ext/vulnsrc/debian/debian.go
@@ -102,8 +102,8 @@ func buildResponse(jsonReader io.Reader, latestKnownHash string) (resp vulnsrc.U
 	// Defer the addition of flag information to the response.
 	defer func() {
 		if err == nil {
-			resp.FlagName = updaterFlag
-			resp.FlagValue = hash
+			resp.Flags = make(map[string]string)
+			resp.Flags[updaterFlag] = hash
 		}
 	}()
 

--- a/ext/vulnsrc/driver.go
+++ b/ext/vulnsrc/driver.go
@@ -33,8 +33,7 @@ var (
 
 // UpdateResponse represents the sum of results of an update.
 type UpdateResponse struct {
-	FlagName        string
-	FlagValue       string
+	Flags           map[string]string
 	Notes           []string
 	Vulnerabilities []database.VulnerabilityWithAffected
 }

--- a/ext/vulnsrc/oracle/oracle.go
+++ b/ext/vulnsrc/oracle/oracle.go
@@ -196,8 +196,8 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 
 	// Set the flag if we found anything.
 	if len(elsaList) > 0 {
-		resp.FlagName = updaterFlag
-		resp.FlagValue = strconv.Itoa(largest(elsaList))
+		resp.Flags = make(map[string]string)
+		resp.Flags[updaterFlag] = strconv.Itoa(largest(elsaList))
 	} else {
 		log.WithField("package", "Oracle Linux").Debug("no update")
 	}

--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -171,8 +171,8 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 
 	// Set the flag if we found anything.
 	if len(rhsaList) > 0 {
-		resp.FlagName = updaterFlag
-		resp.FlagValue = strconv.Itoa(rhsaList[len(rhsaList)-1])
+		resp.Flags = make(map[string]string)
+		resp.Flags[updaterFlag] = strconv.Itoa(rhsaList[len(rhsaList)-1])
 	} else {
 		log.WithField("package", "Red Hat").Debug("no update")
 	}

--- a/ext/vulnsrc/suse/suse.go
+++ b/ext/vulnsrc/suse/suse.go
@@ -215,8 +215,8 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 
 	// Set the flag if we found anything.
 	if len(generationTimes) > 0 {
-		resp.FlagName = u.UpdaterFlag
-		resp.FlagValue = strconv.FormatInt(latest(generationTimes), 10)
+		resp.Flags = make(map[string]string)
+		resp.Flags[u.UpdaterFlag] = strconv.FormatInt(latest(generationTimes), 10)
 	} else {
 		log.WithField("package", u.Name).Debug("no update")
 	}

--- a/ext/vulnsrc/ubuntu/ubuntu.go
+++ b/ext/vulnsrc/ubuntu/ubuntu.go
@@ -105,8 +105,8 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 	}
 
 	// Set the updaterFlag to equal the commit processed.
-	resp.FlagName = updaterFlag
-	resp.FlagValue = commit
+	resp.Flags = make(map[string]string)
+	resp.Flags[updaterFlag] = commit
 
 	// Short-circuit if there have been no updates.
 	if commit == dbCommit {
@@ -130,7 +130,7 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 	// The only notes we take are if we encountered unknown Ubuntu release.
 	// We don't want the commit to be considered as managed in that case.
 	if len(resp.Notes) != 0 {
-		resp.FlagValue = dbCommit
+		resp.Flags[updaterFlag] = dbCommit
 	}
 
 	return

--- a/updater.go
+++ b/updater.go
@@ -308,8 +308,8 @@ func fetchUpdates(ctx context.Context, datastore database.Datastore) (success bo
 			mu.Lock()
 			vulns = append(vulns, namespacedVulns...)
 			notes = append(notes, response.Notes...)
-			if response.FlagName != "" && response.FlagValue != "" {
-				flags[response.FlagName] = response.FlagValue
+			for flagKey, flagValue := range response.Flags {
+				flags[flagKey] = flagValue
 			}
 			mu.Unlock()
 
@@ -363,8 +363,8 @@ func fetch(datastore database.Datastore) (bool, []database.VulnerabilityWithAffe
 		if resp != nil {
 			vulnerabilities = append(vulnerabilities, doVulnerabilitiesNamespacing(resp.Vulnerabilities)...)
 			notes = append(notes, resp.Notes...)
-			if resp.FlagName != "" && resp.FlagValue != "" {
-				flags[resp.FlagName] = resp.FlagValue
+			for flagKey, flagValue := range resp.Flags {
+				flags[flagKey] = flagValue
 			}
 		}
 	}


### PR DESCRIPTION
Updates can return only one value using FlagName and FlagValue. This is
limited in some cases when updaters want to store more than one value.
    
This commit enables to return map with more than one key + value.

This PR also cleans unused code in updater.go
