### PR TITLE
KeyValue: allow records with empty value

### DIFF
--- a/database/pgsql/keyvalue/keyvalue.go
+++ b/database/pgsql/keyvalue/keyvalue.go
@@ -35,9 +35,9 @@ const (
 )
 
 func UpdateKeyValue(tx *sql.Tx, key, value string) (err error) {
-	if key == "" || value == "" {
-		log.Warning("could not insert a flag which has an empty name or value")
-		return commonerr.NewBadRequestError("could not insert a flag which has an empty name or value")
+	if key == "" {
+		log.Warning("could not insert a flag which has an empty name")
+		return commonerr.NewBadRequestError("could not insert a flag which has an empty name")
 	}
 
 	defer monitoring.ObserveQueryTime("PersistKeyValue", "all", time.Now())

--- a/database/pgsql/keyvalue/keyvalue_test.go
+++ b/database/pgsql/keyvalue/keyvalue_test.go
@@ -31,7 +31,6 @@ func TestKeyValue(t *testing.T) {
 	assert.False(t, ok)
 
 	// Try to insert invalid key/value.
-	assert.Error(t, UpdateKeyValue(tx, "test", ""))
 	assert.Error(t, UpdateKeyValue(tx, "", "test"))
 	assert.Error(t, UpdateKeyValue(tx, "", ""))
 
@@ -48,4 +47,11 @@ func TestKeyValue(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, ok)
 	assert.Equal(t, "test2", f)
+
+	// Insert empty value
+	assert.Nil(t, UpdateKeyValue(tx, "testEmpty", ""))
+	f, ok, err = FindKeyValue(tx, "testEmpty")
+	assert.Nil(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, "", f)
 }


### PR DESCRIPTION
Upcoming change in Red Hat updater requires to store additional
key-value records in database which can contain empty value.