### PR TITLE
base image version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,10 @@ FROM alpine:3.10
 COPY --from=build /go/src/github.com/coreos/clair/clair /clair
 RUN apk add --no-cache git rpm xz ca-certificates dumb-init
 
-
 # change ownership of ssl directory to allow custom cert in OpenShift
 RUN chgrp -R 0 /etc/ssl/certs && \
     chmod -R g=u /etc/ssl/certs
-
+    
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/clair"]
 VOLUME /config
 EXPOSE 6060 6061

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ WORKDIR /go/src/github.com/coreos/clair/
 RUN export CLAIR_VERSION=$(git describe --tag --always --dirty) && \
 	go build -ldflags "-X github.com/coreos/clair/pkg/version.Version=$CLAIR_VERSION" github.com/coreos/clair/cmd/clair
 
-FROM alpine:3.8
+FROM alpine:3.10
 COPY --from=build /go/src/github.com/coreos/clair/clair /clair
 RUN apk add --no-cache git rpm xz ca-certificates dumb-init
+USER nobody
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/clair"]
 VOLUME /config
 EXPOSE 6060 6061


### PR DESCRIPTION
Dockerfile base image version bump to fix multiple CVE.

https://github.com/gliderlabs/docker-alpine/issues/430

#567 