### PR TITLE
database: Handle FindAncestryAndRollback datastore.Begin() error

### DIFF
--- a/database/dbutil.go
+++ b/database/dbutil.go
@@ -140,11 +140,10 @@ func PersistNamespacesAndCommit(datastore Datastore, namespaces []Namespace) err
 // rollback.
 func FindAncestryAndRollback(datastore Datastore, name string) (Ancestry, bool, error) {
 	tx, err := datastore.Begin()
-	defer tx.Rollback()
-
 	if err != nil {
 		return Ancestry{}, false, err
 	}
+	defer tx.Rollback()
 
 	return tx.FindAncestry(name)
 }

--- a/database/dbutil_test.go
+++ b/database/dbutil_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxCreationFailure(t *testing.T) {
+	mdb := &MockDatastore{}
+
+	mdb.FctBegin = func() (Session, error) {
+		return nil, errors.New("Deliberately failed Begin")
+	}
+
+	_, _, err := FindAncestryAndRollback(mdb, "mockAncestry")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Do not call rollback() if transaction is not created.

Fixes #828