### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Clair is an open source project for the [static analysis] of vulnerabilities in 
 1. In regular intervals, Clair ingests vulnerability metadata from a configured set of sources and stores it in the database.
 2. Clients use the Clair API to index their container images; this creates a list of _features_ present in the image and stores them in the database.
 3. Clients use the Clair API to query the database for vulnerabilities of a particular image; correlating vulnerabilities and features is done for each request, avoiding the need to rescan images.
-4. When updates to vulnerability metadata occur, a notification can be sent to alert systems that a change has occured.
+4. When updates to vulnerability metadata occur, a notification can be sent to alert systems that a change has occurred.
 
 Our goal is to enable a more transparent view of the security of container-based infrastructure.
 Thus, the project was named `Clair` after the French term which translates to *clear*, *bright*, *transparent*.


### PR DESCRIPTION
Fix small typo in README.

Signed-off-by: Martin Vrachev mvrachev@vmware.com