### PR TITLE
Source binary mapping

### DIFF
--- a/database/feature.go
+++ b/database/feature.go
@@ -25,6 +25,8 @@ type Feature struct {
 	Version       string      `json:"version"`
 	VersionFormat string      `json:"versionFormat"`
 	Type          FeatureType `json:"type"`
+	// if the feature has a source affiliated with it bind it here
+	Source *Feature `json:"source"`
 }
 
 // NamespacedFeature is a feature with determined namespace and can be affected
@@ -79,15 +81,15 @@ type NullableAffectedNamespacedFeature struct {
 }
 
 func NewFeature(name string, version string, versionFormat string, featureType FeatureType) *Feature {
-	return &Feature{name, version, versionFormat, featureType}
+	return &Feature{name, version, versionFormat, featureType, nil}
 }
 
 func NewBinaryPackage(name string, version string, versionFormat string) *Feature {
-	return &Feature{name, version, versionFormat, BinaryPackage}
+	return &Feature{name, version, versionFormat, BinaryPackage, nil}
 }
 
 func NewSourcePackage(name string, version string, versionFormat string) *Feature {
-	return &Feature{name, version, versionFormat, SourcePackage}
+	return &Feature{name, version, versionFormat, SourcePackage, nil}
 }
 
 func NewNamespacedFeature(namespace *Namespace, feature *Feature) *NamespacedFeature {

--- a/ext/featurefmt/dpkg/dpkg.go
+++ b/ext/featurefmt/dpkg/dpkg.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/coreos/clair/database"
@@ -123,7 +123,7 @@ func parseDpkgDB(scanner *bufio.Scanner) (binaryPackage *database.Feature, sourc
 		if err := versionfmt.Valid(dpkg.ParserName, version); err != nil {
 			log.WithError(err).WithFields(log.Fields{"name": name, "version": version}).Warning("skipped unparseable package")
 		} else {
-			binaryPackage = &database.Feature{name, version, dpkg.ParserName, database.BinaryPackage}
+			binaryPackage = &database.Feature{name, version, dpkg.ParserName, database.BinaryPackage, nil}
 		}
 	}
 
@@ -145,7 +145,12 @@ func parseDpkgDB(scanner *bufio.Scanner) (binaryPackage *database.Feature, sourc
 		if err := versionfmt.Valid(dpkg.ParserName, version); err != nil {
 			log.WithError(err).WithFields(log.Fields{"name": name, "version": version}).Warning("skipped unparseable package")
 		} else {
-			sourcePackage = &database.Feature{sourceName, sourceVersion, dpkg.ParserName, database.SourcePackage}
+			sourcePackage = &database.Feature{sourceName, sourceVersion, dpkg.ParserName, database.SourcePackage, nil}
+			// associate this binary package with the source package. we will use this for mapping when
+			// persisting to the database
+			if binaryPackage != nil {
+				binaryPackage.Source = sourcePackage
+			}
 		}
 	}
 

--- a/ext/featurefmt/rpm/rpm.go
+++ b/ext/featurefmt/rpm/rpm.go
@@ -93,14 +93,14 @@ func (l lister) ListFeatures(files tarutil.FilesMap) ([]database.LayerFeature, e
 	for scanner.Scan() {
 		rpmPackage, srpmPackage := parseRPMOutput(scanner.Text())
 		if rpmPackage != nil {
+			if srpmPackage != nil {
+				rpmPackage.Source = srpmPackage
+			}
 			packages.Add(*rpmPackage)
 		}
 
 		if srpmPackage != nil {
 			packages.Add(*srpmPackage)
-			if rpmPackage != nil {
-				rpmPackage.Source = srpmPackage
-			}
 		}
 	}
 

--- a/ext/featurefmt/rpm/rpm.go
+++ b/ext/featurefmt/rpm/rpm.go
@@ -23,7 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/coreos/clair/database"
@@ -98,6 +98,9 @@ func (l lister) ListFeatures(files tarutil.FilesMap) ([]database.LayerFeature, e
 
 		if srpmPackage != nil {
 			packages.Add(*srpmPackage)
+			if rpmPackage != nil {
+				rpmPackage.Source = srpmPackage
+			}
 		}
 	}
 
@@ -122,7 +125,7 @@ func parseRPMOutput(raw string) (rpmPackage *database.Feature, srpmPackage *data
 		return
 	}
 
-	rpmPackage = &database.Feature{name, version, rpm.ParserName, database.BinaryPackage}
+	rpmPackage = &database.Feature{name, version, rpm.ParserName, database.BinaryPackage, nil}
 	srpmName, srpmVersion, srpmRelease, _, err := parseSourceRPM(srpm)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{"name": name, "sourcerpm": srpm}).Warning("skipped unparseable package")
@@ -134,7 +137,7 @@ func parseRPMOutput(raw string) (rpmPackage *database.Feature, srpmPackage *data
 		return
 	}
 
-	srpmPackage = &database.Feature{srpmName, srpmVersion, rpm.ParserName, database.SourcePackage}
+	srpmPackage = &database.Feature{srpmName, srpmVersion, rpm.ParserName, database.SourcePackage, nil}
 	return
 }
 


### PR DESCRIPTION
@KeyboardNerd @jzelinskie 

This is the start of closing the source->binary mapping task. I have successfully mapped the source packages to their binary packages with this code, however I seem to be hitting a brick wall when saving layer features. 

To test you can add this table to your ClairV3 database:
```
CREATE TABLE source_binary_mapping (
	id SERIAL PRIMARY KEY,
	source_feature int REFERENCES feature(id),
	binary_feature int REFERENCES feature(id),
	unique(source_feature, binary_feature)
);
```

However we begin to face this issue: `{"Event":"failed to store layer change","Level":"error","Location":"analyzer.go:106","Time":"2019-08-26 20:19:49.353730","error":"associated immutable entities are missing in the database","layer.Hash":"f59d6d019dd5b8398eb8d794e3fafe31f9411cc99a71dabfa587bf732b4a7385"}` 

I troubleshot for awhile but every time I make small change locally, I break something in another database file. Any ideas why we get this issue? I'll continue to look tomorrow. 