### PR TITLE
nvd: fix conversion of r.StatusCode to string

### DIFF
--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -239,7 +239,7 @@ func getHashFromMetaURL(metaURL string) (string, error) {
 	defer r.Body.Close()
 
 	if !httputil.Status2xx(r) {
-		return "", errors.New(metaURL + " failed status code: " + string(r.StatusCode))
+		return "", fmt.Errorf("%v failed status code: %d", metaURL, r.StatusCode)
 	}
 
 	scanner := bufio.NewScanner(r.Body)


### PR DESCRIPTION
string(404) == "Ɣ"
fmt.Sprintf("%d", 404) == "404"

See https://play.golang.org/p/_avQPvVyLJ4