### PR TITLE
fix crash on database error

### DIFF
--- a/database/pgsql/feature.go
+++ b/database/pgsql/feature.go
@@ -112,7 +112,9 @@ func (pgSQL *pgSQL) insertFeatureVersion(fv database.FeatureVersion) (id int, er
 	// Begin transaction.
 	tx, err := pgSQL.Begin()
 	if err != nil {
-		tx.Rollback()
+		if tx != nil {
+			tx.Rollback()
+		}
 		return 0, handleError("insertFeatureVersion.Begin()", err)
 	}
 

--- a/database/pgsql/layer.go
+++ b/database/pgsql/layer.go
@@ -87,6 +87,9 @@ func (pgSQL *pgSQL) FindLayer(name string, withFeatures, withVulnerabilities boo
 		// preferred to use a nested loop.
 		tx, err := pgSQL.Begin()
 		if err != nil {
+			if tx != nil {
+				tx.Rollback()
+			}
 			return layer, handleError("FindLayer.Begin()", err)
 		}
 		defer tx.Commit()
@@ -295,7 +298,9 @@ func (pgSQL *pgSQL) InsertLayer(layer database.Layer) error {
 	// Begin transaction.
 	tx, err := pgSQL.Begin()
 	if err != nil {
-		tx.Rollback()
+		if tx != nil {
+			tx.Rollback()
+		}
 		return handleError("InsertLayer.Begin()", err)
 	}
 

--- a/database/pgsql/notification.go
+++ b/database/pgsql/notification.go
@@ -173,6 +173,9 @@ func (pgSQL *pgSQL) loadLayerIntroducingVulnerability(vulnerability *database.Vu
 	// allowing a small nested loop join instead.
 	tx, err := pgSQL.Begin()
 	if err != nil {
+		if tx != nil {
+			tx.Rollback()
+		}
 		return -1, handleError("searchNotificationLayerIntroducingVulnerability.Begin()", err)
 	}
 	defer tx.Commit()

--- a/database/pgsql/vulnerability.go
+++ b/database/pgsql/vulnerability.go
@@ -257,7 +257,9 @@ func (pgSQL *pgSQL) insertVulnerability(vulnerability database.Vulnerability, on
 	// Begin transaction.
 	tx, err := pgSQL.Begin()
 	if err != nil {
-		tx.Rollback()
+		if tx != nil {
+			tx.Rollback()
+		}
 		return handleError("insertVulnerability.Begin()", err)
 	}
 
@@ -588,7 +590,9 @@ func (pgSQL *pgSQL) DeleteVulnerability(namespaceName, name string) error {
 	// Begin transaction.
 	tx, err := pgSQL.Begin()
 	if err != nil {
-		tx.Rollback()
+		if tx != nil {
+			tx.Rollback()
+		}
 		return handleError("DeleteVulnerability.Begin()", err)
 	}
 


### PR DESCRIPTION
database/pgsql/*.go was not checking that `tx` was non-null before calling `tx.Rollback()` after `pgSQL.Begin()` returned an error.

Fixes #231, which appears to be fixed on `master` by other changes.