### PR TITLE
Fix incorrect warning message in notifier

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -128,7 +128,7 @@ func findTask(datastore database.Datastore, renotifyInterval time.Duration, whoA
 	for {
 		notification, ok, err := database.FindNewNotification(datastore, time.Now().Add(-renotifyInterval))
 		if err != nil || !ok {
-			if !ok {
+			if err != nil {
 				log.WithError(err).Warning("could not get notification to send")
 			}
 


### PR DESCRIPTION
The warning message was incorrectly printed in case there was no new
notification. This message can confuse users.

Now it only prints warning message when something bad happens with
database query or internal logic.