### PR TITLE
Fix broken links in CONTRIBUTING file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ This document outlines some of the conventions on development workflow, commit m
 
 # Certificate of Origin
 
-By contributing to this project you agree to the Developer Certificate of Origin (DCO).
+By contributing to this project you agree to the Developer Certificate of Origin [DCO](../DCO).
 This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution.
 See the [DCO](DCO) file for details.
 
@@ -22,7 +22,7 @@ They are very busy and read the mailing lists.
 ## Getting Started
 
 - Fork the repository on GitHub
-- Read the [README](README.md) for build and test instructions
+- Read the [README](../README.md) for build and test instructions
 - Play with the project, submit bugs, submit patches!
 
 ## Contribution Flow


### PR DESCRIPTION
When CONTRIBUTING was moved to .github/ the links to files in repo
root broke, adding parent dir to relative links.