### PR TITLE
database: add mapping for Ubuntu Eoan (19.10)

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -49,4 +49,5 @@ var UbuntuReleasesMapping = map[string]string{
 	"bionic":  "18.04",
 	"cosmic":  "18.10",
 	"disco":   "19.04",
+	"eoan":    "19.10",
 }


### PR DESCRIPTION
This is required for Clair to support Ubuntu Eoan (19.10)