### PR TITLE
Update the Ingress to use apiVersion: networking.k8s.io/v1beta1

### DIFF
--- a/local-dev/helm/clair/Chart.yaml
+++ b/local-dev/helm/clair/Chart.yaml
@@ -1,6 +1,6 @@
 name: clair
 home: https://coreos.com/clair
-version: 0.1.1
+version: 0.1.2
 appVersion: 3.0.0-pre
 description: Clair is an open source project for the static analysis of vulnerabilities in application containers.
 icon: https://cloud.githubusercontent.com/assets/343539/21630811/c5081e5c-d202-11e6-92eb-919d5999c77a.png

--- a/local-dev/helm/clair/templates/ingress.yaml
+++ b/local-dev/helm/clair/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $serviceName := include "clair.fullname" . -}}
 {{- $servicePort := .Values.service.externalApiPort -}}
 {{- $path := .Values.ingress.path | default "/" -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "clair.fullname" . }}


### PR DESCRIPTION
This PR updates the `Ingress` so that it is Kubernetes 1.16 compatible.