### PR TITLE
Allow limiting pgsql database connections in configuration

### DIFF
--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -29,7 +29,11 @@ clair:
       # 32-bit URL-safe base64 key used to encrypt pagination tokens
       # If one is not provided, it will be generated.
       # Multiple clair instances in the same cluster need the same value.
-      paginationkey: 
+      paginationkey:
+
+      # Maximum number of open connections allowed to database
+      # If unspecified or <= 0 then no limit is enforced in Clair
+      maxopenconnections: 10
 
   api:
     # v3 grpc/RESTful API server address
@@ -55,7 +59,7 @@ clair:
     # Frequency the database will be updated with vulnerabilities from the default data sources
     # The value 0 disables the updater entirely.
     interval: 2h
-    enabledupdaters: 
+    enabledupdaters:
       - debian
       - ubuntu
       - rhel
@@ -79,9 +83,9 @@ clair:
       # https://github.com/cloudflare/cfssl
       # https://github.com/coreos/etcd-ca
       servername:
-      cafile: 
-      keyfile: 
-      certfile: 
+      cafile:
+      keyfile:
+      certfile:
 
       # Optional HTTP Proxy: must be a valid URL (including the scheme).
       proxy:

--- a/database/pgsql/pgsql.go
+++ b/database/pgsql/pgsql.go
@@ -24,7 +24,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/remind101/migrate"
 	log "github.com/sirupsen/logrus"
 
@@ -86,6 +86,7 @@ type Config struct {
 	ManageDatabaseLifecycle bool
 	FixturePath             string
 	PaginationKey           string
+	MaxOpenConnections      int
 }
 
 // openDatabase opens a PostgresSQL-backed Datastore using the given
@@ -139,6 +140,10 @@ func openDatabase(registrableComponentConfig database.RegistrableComponentConfig
 	if err = pg.DB.Ping(); err != nil {
 		pg.Close()
 		return nil, fmt.Errorf("pgsql: could not open database: %v", err)
+	}
+
+	if pg.config.MaxOpenConnections != 0 {
+		pg.DB.SetMaxOpenConns(pg.config.MaxOpenConnections)
 	}
 
 	// Run migrations.


### PR DESCRIPTION
This PR adds the ability to limit the maximum number of connections that the `database/sql` library will make to a pgsql database.

If the configuration is not specified, the pre-existing behaviour is retained (i.e. no max connection limit is set).