### PR TITLE
Add ability to configure read-only pgsql database

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -131,7 +131,9 @@ func Boot(config *Config) {
 
 	defer db.Close()
 
-	clair.RegisterConfiguredDetectors(db)
+	if ro, ok := db.(database.ReadOnly); !ok || !ro.ReadOnly() {
+		clair.RegisterConfiguredDetectors(db)
+	}
 
 	// Start notifier
 	st.Begin()

--- a/database/database.go
+++ b/database/database.go
@@ -42,6 +42,12 @@ var (
 	ErrMissingEntities = NewStorageError("associated immutable entities are missing in the database")
 )
 
+// ReadOnly defines the function that can be used to determine if we are in
+// read only mode for databases that can support read only operation
+type ReadOnly interface {
+	ReadOnly() bool
+}
+
 // RegistrableComponentConfig is a configuration block that can be used to
 // determine which registrable component should be initialized and pass custom
 // configuration to it.

--- a/database/pgsql/pgsql.go
+++ b/database/pgsql/pgsql.go
@@ -16,6 +16,7 @@
 package pgsql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"io/ioutil"
@@ -50,7 +51,11 @@ type pgSQL struct {
 // The expected transaction isolation level in this implementation is "Read
 // Committed".
 func (pgSQL *pgSQL) Begin() (database.Session, error) {
-	tx, err := pgSQL.DB.Begin()
+	opts := &sql.TxOptions{
+		ReadOnly: pgSQL.config.ReadOnly,
+	}
+
+	tx, err := pgSQL.DB.BeginTx(context.Background(), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/database/pgsql/pgsql.go
+++ b/database/pgsql/pgsql.go
@@ -166,12 +166,10 @@ func openDatabase(registrableComponentConfig database.RegistrableComponentConfig
 		pg.DB.SetMaxOpenConns(pg.config.MaxOpenConnections)
 	}
 
-	if !pg.config.ReadOnly {
-		// Run migrations.
-		if err = migrateDatabase(pg.DB); err != nil {
-			pg.Close()
-			return nil, err
-		}
+	// Run migrations.
+	if err = pg.migrateDatabase(); err != nil {
+		pg.Close()
+		return nil, err
 	}
 
 	// Load fixture data.

--- a/database/pgsql/pgsql.go
+++ b/database/pgsql/pgsql.go
@@ -87,6 +87,7 @@ type Config struct {
 	FixturePath             string
 	PaginationKey           string
 	MaxOpenConnections      int
+	ReadOnly                bool
 }
 
 // openDatabase opens a PostgresSQL-backed Datastore using the given
@@ -146,10 +147,12 @@ func openDatabase(registrableComponentConfig database.RegistrableComponentConfig
 		pg.DB.SetMaxOpenConns(pg.config.MaxOpenConnections)
 	}
 
-	// Run migrations.
-	if err = migrateDatabase(pg.DB); err != nil {
-		pg.Close()
-		return nil, err
+	if !pg.config.ReadOnly {
+		// Run migrations.
+		if err = migrateDatabase(pg.DB); err != nil {
+			pg.Close()
+			return nil, err
+		}
 	}
 
 	// Load fixture data.

--- a/database/pgsql/pgsql.go
+++ b/database/pgsql/pgsql.go
@@ -83,6 +83,20 @@ func (pgSQL *pgSQL) Ping() bool {
 	return pgSQL.DB.Ping() == nil
 }
 
+func (pgSQL *pgSQL) ReadOnly() bool {
+	return pgSQL.config.ReadOnly
+}
+
+func (pgSQL *pgSQL) migrateDatabase() error {
+	if !pgSQL.ReadOnly() {
+		return pgSQLMigrateFn(pgSQL.DB)
+	}
+
+	return nil
+}
+
+var pgSQLMigrateFn = migrateDatabase
+
 // Config is the configuration that is used by openDatabase.
 type Config struct {
 	Source    string

--- a/database/pgsql/pgsql_test.go
+++ b/database/pgsql/pgsql_test.go
@@ -1,0 +1,48 @@
+package pgsql
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCallsMigrateOnReadWriteDB(t *testing.T) {
+	testDB := pgSQL{
+		config: Config{
+			ReadOnly: false,
+		},
+	}
+
+	migrationCalled := false
+
+	pgSQLMigrateFn = func(db *sql.DB) error {
+		migrationCalled = true
+
+		return nil
+	}
+
+	testDB.migrateDatabase()
+
+	assert.True(t, migrationCalled)
+}
+
+func TestMigrateNotCalledOnReadOnlyDB(t *testing.T) {
+	testDB := pgSQL{
+		config: Config{
+			ReadOnly: true,
+		},
+	}
+
+	migrationCalled := false
+
+	pgSQLMigrateFn = func(db *sql.DB) error {
+		migrationCalled = true
+
+		return nil
+	}
+
+	testDB.migrateDatabase()
+
+	assert.False(t, migrationCalled)
+}


### PR DESCRIPTION
Postgres has the ability to configure read-only streaming replicas but by the current Clair startup attempts a number of operations that do not work on these read-only replicas.

This PR adds support for configuring a read-only database and skips the `RegisterConfiguredDetectors` and `migrateDatabase` calls that would block startup.