### PR TITLE
Fix rhel updater

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -17,13 +17,14 @@
 package rhel
 
 import (
-	"bufio"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -32,17 +33,12 @@ import (
 	"github.com/quay/clair/v2/ext/versionfmt/rpm"
 	"github.com/quay/clair/v2/ext/vulnsrc"
 	"github.com/quay/clair/v2/pkg/commonerr"
-	"github.com/quay/clair/v2/pkg/httputil"
 )
 
 const (
-	// Before this RHSA, it deals only with RHEL <= 4.
-	firstRHEL5RHSA      = 20070044
 	firstConsideredRHEL = 5
-
-	ovalURI        = "https://www.redhat.com/security/data/oval/"
-	rhsaFilePrefix = "com.redhat.rhsa-"
-	updaterFlag    = "rhelUpdater"
+	updaterFlag         = "rhelUpdater"
+	dbURL               = `https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL%d.xml`
 )
 
 var (
@@ -54,6 +50,7 @@ var (
 	}
 
 	rhsaRegexp = regexp.MustCompile(`com.redhat.rhsa-(\d+).xml`)
+	releases   = []int{3, 4, 5, 6, 7, 8}
 )
 
 type oval struct {
@@ -90,55 +87,41 @@ func init() {
 
 func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
 	log.WithField("package", "RHEL").Info("Start fetching vulnerabilities")
-	// Get the first RHSA we have to manage.
+
+	// flagValue is rfc1132 format timestamp of when this updater last ran
+	var useLastModifiedHeader bool = true
 	flagValue, err := datastore.GetKeyValue(updaterFlag)
 	if err != nil {
 		return resp, err
 	}
-	firstRHSA, err := strconv.Atoi(flagValue)
-	if firstRHSA == 0 || err != nil {
-		firstRHSA = firstRHEL5RHSA
-	}
-
-	// Fetch the update list.
-	r, err := httputil.GetWithUserAgent(ovalURI)
+	// if we cannot parse the flag as a timestamp we'll fix it
+	// this time around.
+	_, err = time.Parse(time.RFC1123, flagValue)
 	if err != nil {
-		log.WithError(err).Error("could not download RHEL's update list")
-		return resp, commonerr.ErrCouldNotDownload
-	}
-	defer r.Body.Close()
-
-	if !httputil.Status2xx(r) {
-		log.WithField("StatusCode", r.StatusCode).Error("Failed to update RHEL")
-		return resp, commonerr.ErrCouldNotDownload
+		useLastModifiedHeader = false
 	}
 
-	// Get the list of RHSAs that we have to process.
-	var rhsaList []int
-	scanner := bufio.NewScanner(r.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-		r := rhsaRegexp.FindStringSubmatch(line)
-		if len(r) == 2 {
-			rhsaNo, _ := strconv.Atoi(r[1])
-			if rhsaNo > firstRHSA {
-				rhsaList = append(rhsaList, rhsaNo)
-			}
-		}
-	}
-
-	for _, rhsa := range rhsaList {
-		// Download the RHSA's XML file.
-		r, err := httputil.GetWithUserAgent(ovalURI + rhsaFilePrefix + strconv.Itoa(rhsa) + ".xml")
+	for _, release := range releases {
+		url := fmt.Sprintf(dbURL, release)
+		req, err := http.NewRequest("GET", url, nil)
 		if err != nil {
-			log.WithError(err).Error("could not download RHEL's update list")
-			return resp, commonerr.ErrCouldNotDownload
+			return resp, fmt.Errorf("failed to create request: %v", err)
 		}
-		defer r.Body.Close()
+		if useLastModifiedHeader {
+			req.Header.Set("If-Modified-Since", flagValue)
+		}
 
-		if !httputil.Status2xx(r) {
-			log.WithField("StatusCode", r.StatusCode).Error("Failed to update RHEL")
-			return resp, commonerr.ErrCouldNotDownload
+		c := http.Client{}
+		r, err := c.Do(req)
+		switch {
+		case err != nil:
+			return resp, fmt.Errorf("failed to download %s: %v", url, err)
+		case r.StatusCode == http.StatusNotModified:
+			log.WithField("package", "Red Hat").Infof("%s has not been modified since %v. no update necessary", url, flagValue)
+			continue
+		case r.StatusCode != http.StatusOK:
+			log.WithField("package", "Red Hat").Debugf("%s request failed with %s", url, r.Status)
+			return resp, fmt.Errorf("received %d code downloading %s", r.StatusCode, url)
 		}
 
 		// Parse the XML.
@@ -153,14 +136,9 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		}
 	}
 
-	// Set the flag if we found anything.
-	if len(rhsaList) > 0 {
-		resp.FlagName = updaterFlag
-		resp.FlagValue = strconv.Itoa(rhsaList[len(rhsaList)-1])
-	} else {
-		log.WithField("package", "Red Hat").Debug("no update")
-	}
-
+	ts := time.Now().UTC().Format(http.TimeFormat)
+	resp.FlagName = updaterFlag
+	resp.FlagValue = ts
 	return resp, nil
 }
 
@@ -364,7 +342,7 @@ func severity(def definition) database.Severity {
 	case "Critical":
 		return database.CriticalSeverity
 	default:
-		log.Warningf("could not determine vulnerability severity from: %s.", def.Title)
+		log.Debugf("could not determine vulnerability severity from: %s.", def.Title)
 		return database.UnknownSeverity
 	}
 }

--- a/updater.go
+++ b/updater.go
@@ -195,7 +195,7 @@ func update(datastore database.Datastore, firstUpdate bool) (updateSuccessful bo
 	updateSuccessful, vulnerabilities, flags, notes := fetch(datastore)
 
 	// Insert vulnerabilities.
-	log.WithField("count", len(vulnerabilities)).Debug("inserting vulnerabilities for update")
+	log.WithField("count", len(vulnerabilities)).Info("inserting vulnerabilities for update")
 	err := datastore.InsertVulnerabilities(vulnerabilities, !firstUpdate)
 	if err != nil {
 		promUpdaterErrorsTotal.Inc()
@@ -313,6 +313,7 @@ func addMetadata(datastore database.Datastore, vulnerabilities []database.Vulner
 
 	wg.Wait()
 
+	log.Info("finished adding metadata to vulnerabilities")
 	return vulnerabilities
 }
 


### PR DESCRIPTION
This PR fixes an issue where RHEL downloads were failing.
A new method is implemented which downloads a per-release database and uses a timestamp as a flag. 

This fix will work in-place for existing deployments. On updater run previous flag format will fail timestamp parse and the code will gracefully handle this, setting a new timestamp on exit of the update method. 