### PR TITLE
Add new plugin for fetching modular rpms

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -41,6 +41,7 @@ import (
 	// Register extensions.
 	_ "github.com/quay/clair/v3/ext/featurefmt/apk"
 	_ "github.com/quay/clair/v3/ext/featurefmt/dpkg"
+	_ "github.com/quay/clair/v3/ext/featurefmt/modulerpm"
 	_ "github.com/quay/clair/v3/ext/featurefmt/rpm"
 	_ "github.com/quay/clair/v3/ext/featurens/alpinerelease"
 	_ "github.com/quay/clair/v3/ext/featurens/aptsources"

--- a/ext/featurefmt/modulerpm/modulerpm.go
+++ b/ext/featurefmt/modulerpm/modulerpm.go
@@ -1,0 +1,140 @@
+// Copyright 2019 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modulerpm implements a featurefmt.Lister for modular rpm packages.
+package modulerpm
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/quay/clair/v3/database"
+	"github.com/quay/clair/v3/ext/featurefmt"
+	"github.com/quay/clair/v3/ext/versionfmt"
+	"github.com/quay/clair/v3/ext/versionfmt/modulerpm"
+	"github.com/quay/clair/v3/pkg/commonerr"
+	"github.com/quay/clair/v3/pkg/tarutil"
+)
+
+var ignoredPackages = []string{
+	"gpg-pubkey", // Ignore gpg-pubkey packages which are fake packages used to store GPG keys - they are not versionned properly.
+}
+
+type lister struct{}
+
+func init() {
+	featurefmt.RegisterLister("module-rpm", "1.0", &lister{})
+}
+
+func (l lister) RequiredFilenames() []string {
+	return []string{"^var/lib/rpm/Packages"}
+}
+
+func isIgnored(packageName string) bool {
+	for _, pkg := range ignoredPackages {
+		if pkg == packageName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l lister) ListFeatures(files tarutil.FilesMap) ([]database.LayerFeature, error) {
+	f, hasFile := files["var/lib/rpm/Packages"]
+	if !hasFile {
+		return []database.LayerFeature{}, nil
+	}
+
+	// Write the required "Packages" file to disk
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "modulerpm")
+	defer os.RemoveAll(tmpDir)
+	if err != nil {
+		log.WithError(err).Error("could not create temporary folder for module RPM detection")
+		return []database.LayerFeature{}, commonerr.ErrFilesystem
+	}
+
+	err = ioutil.WriteFile(tmpDir+"/Packages", f, 0700)
+	if err != nil {
+		log.WithError(err).Error("could not create temporary file for module RPM detection")
+		return []database.LayerFeature{}, commonerr.ErrFilesystem
+	}
+
+	// Extract binary package names because RHSA refers to binary package names.
+	out, err := exec.Command(
+		"rpm", "--dbpath", tmpDir, "-qa", "--qf", "%{NAME} %{EPOCH}:%{VERSION}-%{RELEASE} %{RPMTAG_MODULARITYLABEL}\n").Output()
+	if err != nil {
+		log.WithError(err).WithField("output", string(out)).Error("failed to query module RPM")
+		// Do not bubble up because we probably won't be able to fix it,
+		// the database must be corrupted
+		return []database.LayerFeature{}, nil
+	}
+
+	packages := []database.LayerFeature{}
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		rpmPackage := parseRPMOutput(scanner.Text())
+		if rpmPackage == nil {
+			continue
+		}
+		packages = append(packages, *rpmPackage)
+
+	}
+
+	return packages, nil
+}
+
+func parseRPMOutput(raw string) (rpmPackage *database.LayerFeature) {
+	line := strings.Split(raw, " ")
+	if len(line) != 3 {
+		// We may see warnings on some RPM versions:
+		// "warning: Generating 12 missing index(es), please wait..."
+		return
+	}
+
+	if isIgnored(line[0]) {
+		return
+	}
+	if !isModuleRpm(line) {
+		return
+	}
+
+	name, version := line[0], strings.Replace(line[1], "(none):", "", -1)
+	if err := versionfmt.Valid(modulerpm.ParserName, version); err != nil {
+		log.WithError(err).WithFields(log.Fields{"name": name, "version": version}).Warning("skipped unparseable package")
+		return
+	}
+	log.Warning(line)
+	// module format: name:stream:version:context
+	moduleSplit := strings.Split(line[2], ":")
+	if len(moduleSplit) < 2 {
+		return
+	}
+
+	rpmPackage = &database.LayerFeature{
+		Feature:            database.Feature{Name: name, Version: version, VersionFormat: modulerpm.ParserName, Type: database.BinaryPackage},
+		PotentialNamespace: database.Namespace{Name: fmt.Sprintf("%s:%s", moduleSplit[0], moduleSplit[1]), VersionFormat: modulerpm.ParserName},
+	}
+	return
+}
+
+func isModuleRpm(rpmOut []string) bool {
+	return rpmOut[2] != "(none)"
+}

--- a/ext/featurefmt/modulerpm/modulerpm_test.go
+++ b/ext/featurefmt/modulerpm/modulerpm_test.go
@@ -1,0 +1,54 @@
+// Copyright 2017 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modulerpm
+
+import (
+	"testing"
+
+	"github.com/quay/clair/v3/database"
+	"github.com/quay/clair/v3/ext/featurefmt"
+	"github.com/quay/clair/v3/ext/versionfmt/modulerpm"
+)
+
+func TestModuleRpmFeatureDetection(t *testing.T) {
+	for _, test := range []featurefmt.TestCase{
+		{
+			"Module rpm test",
+			map[string]string{"var/lib/rpm/Packages": "modulerpm/testdata/module_rpm_db"},
+			[]database.LayerFeature{
+				{
+					Feature: database.Feature{
+						Name:          "npm",
+						Version:       "1:6.9.0-1.10.16.3.2.module+el8.0.0+4214+49953fda",
+						VersionFormat: "module-rpm",
+						Type:          "binary",
+					},
+					PotentialNamespace: database.Namespace{Name: "nodejs:10", VersionFormat: modulerpm.ParserName},
+				},
+				{
+					Feature: database.Feature{
+						Name:          "nodejs",
+						Version:       "1:10.16.3-2.module+el8.0.0+4214+49953fda",
+						VersionFormat: "module-rpm",
+						Type:          "binary",
+					},
+					PotentialNamespace: database.Namespace{Name: "nodejs:10", VersionFormat: modulerpm.ParserName},
+				},
+			},
+		},
+	} {
+		featurefmt.RunTest(t, test, lister{}, modulerpm.ParserName)
+	}
+}

--- a/ext/versionfmt/modulerpm/modulerpm.go
+++ b/ext/versionfmt/modulerpm/modulerpm.go
@@ -1,0 +1,289 @@
+// Copyright 2017 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package modulerpm implements a versionfmt.Parser for version numbers used
+// in modular rpm based software packages.
+package modulerpm
+
+import (
+	"errors"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/quay/clair/v3/ext/versionfmt"
+)
+
+// ParserName is the name by which the module-rpm parser is registered.
+const ParserName = "module-rpm"
+
+var (
+	// alphanumPattern is a regular expression to match all sequences of numeric
+	// characters or alphanumeric characters.
+	alphanumPattern = regexp.MustCompile("([a-zA-Z]+)|([0-9]+)|(~)")
+	allowedSymbols  = []rune{'.', '-', '+', '~', ':', '_'}
+)
+
+type version struct {
+	epoch   int
+	version string
+	release string
+}
+
+var (
+	minVersion = version{version: versionfmt.MinVersion}
+	maxVersion = version{version: versionfmt.MaxVersion}
+)
+
+// newVersion parses a string into a version type which can be compared.
+func newVersion(str string) (version, error) {
+	var v version
+
+	// Trim leading and trailing space
+	str = strings.TrimSpace(str)
+
+	if len(str) == 0 {
+		return version{}, errors.New("Version string is empty")
+	}
+
+	// Max/Min versions
+	if str == maxVersion.String() {
+		return maxVersion, nil
+	}
+	if str == minVersion.String() {
+		return minVersion, nil
+	}
+
+	// Find epoch
+	sepepoch := strings.Index(str, ":")
+	if sepepoch > -1 {
+		intepoch, err := strconv.Atoi(str[:sepepoch])
+		if err == nil {
+			v.epoch = intepoch
+		} else {
+			return version{}, errors.New("epoch in version is not a number")
+		}
+		if intepoch < 0 {
+			return version{}, errors.New("epoch in version is negative")
+		}
+	} else {
+		v.epoch = 0
+	}
+
+	// Find version / release
+	seprevision := strings.Index(str, "-")
+	if seprevision > -1 {
+		v.version = str[sepepoch+1 : seprevision]
+		v.release = str[seprevision+1:]
+	} else {
+		v.version = str[sepepoch+1:]
+		v.release = ""
+	}
+	// Verify format
+	if len(v.version) == 0 {
+		return version{}, errors.New("No version")
+	}
+
+	for i := 0; i < len(v.version); i = i + 1 {
+		r := rune(v.version[i])
+		if !unicode.IsDigit(r) && !unicode.IsLetter(r) && !validSymbol(r) {
+			return version{}, errors.New("invalid character in version")
+		}
+	}
+
+	for i := 0; i < len(v.release); i = i + 1 {
+		r := rune(v.release[i])
+		if !unicode.IsDigit(r) && !unicode.IsLetter(r) && !validSymbol(r) {
+			return version{}, errors.New("invalid character in revision")
+		}
+	}
+
+	return v, nil
+}
+
+type parser struct{}
+
+func (p parser) Valid(str string) bool {
+	_, err := newVersion(str)
+	return err == nil
+}
+
+func (p parser) InRange(versionA, rangeB string) (bool, error) {
+	cmp, err := p.Compare(versionA, rangeB)
+	if err != nil {
+		return false, err
+	}
+	return cmp < 0, nil
+}
+
+func (p parser) GetFixedIn(fixedIn string) (string, error) {
+	// In the old version format parser design, the string to determine fixed in
+	// version is the fixed in version.
+	return fixedIn, nil
+}
+
+func (p parser) Compare(a, b string) (int, error) {
+	v1, err := newVersion(a)
+	if err != nil {
+		return 0, err
+	}
+
+	v2, err := newVersion(b)
+	if err != nil {
+		return 0, err
+	}
+
+	// Quick check
+	if v1 == v2 {
+		return 0, nil
+	}
+
+	// Max/Min comparison
+	if v1 == minVersion || v2 == maxVersion {
+		return -1, nil
+	}
+	if v2 == minVersion || v1 == maxVersion {
+		return 1, nil
+	}
+
+	// Compare epochs
+	if v1.epoch > v2.epoch {
+		return 1, nil
+	}
+	if v1.epoch < v2.epoch {
+		return -1, nil
+	}
+
+	// Compare version
+	rc := rpmvercmp(v1.version, v2.version)
+	if rc != 0 {
+		return rc, nil
+	}
+
+	// Compare revision
+	return rpmvercmp(v1.release, v2.release), nil
+}
+
+// rpmcmpver compares two version or release strings.
+//
+// Lifted from github.com/cavaliercoder/go-rpm.
+// For the original C implementation, see:
+// https://github.com/rpm-software-management/rpm/blob/master/lib/rpmvercmp.c#L16
+func rpmvercmp(strA, strB string) int {
+	// shortcut for equality
+	if strA == strB {
+		return 0
+	}
+
+	// get alpha/numeric segements
+	segsa := alphanumPattern.FindAllString(strA, -1)
+	segsb := alphanumPattern.FindAllString(strB, -1)
+	segs := int(math.Min(float64(len(segsa)), float64(len(segsb))))
+
+	// compare each segment
+	for i := 0; i < segs; i++ {
+		a := segsa[i]
+		b := segsb[i]
+
+		// compare tildes
+		if []rune(a)[0] == '~' && []rune(b)[0] == '~' {
+			continue
+		}
+		if []rune(a)[0] == '~' && []rune(b)[0] != '~' {
+			return -1
+		}
+		if []rune(a)[0] != '~' && []rune(b)[0] == '~' {
+			return 1
+		}
+
+		if unicode.IsNumber([]rune(a)[0]) {
+			// numbers are always greater than alphas
+			if !unicode.IsNumber([]rune(b)[0]) {
+				// a is numeric, b is alpha
+				return 1
+			}
+
+			// trim leading zeros
+			a = strings.TrimLeft(a, "0")
+			b = strings.TrimLeft(b, "0")
+
+			// longest string wins without further comparison
+			if len(a) > len(b) {
+				return 1
+			} else if len(b) > len(a) {
+				return -1
+			}
+		} else if unicode.IsNumber([]rune(b)[0]) {
+			// a is alpha, b is numeric
+			return -1
+		}
+
+		// string compare
+		if a < b {
+			return -1
+		} else if a > b {
+			return 1
+		}
+	}
+
+	// segments were all the same but separators must have been different
+	if len(segsa) == len(segsb) {
+		return 0
+	}
+
+	// If there is a tilde in a segment past the min number of segments, find it.
+	if len(segsa) > segs && []rune(segsa[segs])[0] == '~' {
+		return -1
+	} else if len(segsb) > segs && []rune(segsb[segs])[0] == '~' {
+		return 1
+	}
+
+	// whoever has the most segments wins
+	if len(segsa) > len(segsb) {
+		return 1
+	}
+
+	return -1
+}
+
+// String returns the string representation of a Version.
+func (v version) String() (s string) {
+	if v.epoch != 0 {
+		s = strconv.Itoa(v.epoch) + ":"
+	}
+	s += v.version
+	if v.release != "" {
+		s += "-" + v.release
+	}
+	return
+}
+
+func validSymbol(r rune) bool {
+	return containsRune(allowedSymbols, r)
+}
+
+func containsRune(s []rune, e rune) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	versionfmt.RegisterParser(ParserName, parser{})
+}


### PR DESCRIPTION
Modular rpm is a special type of RPMs which requires different handler.
Modular rpms have been introduced in RHEL8 and Fedora 28.

Modular rpms are stored in rpm database, but to be able to tell if given
modular rpm is vulnerable we need to know which module contains given
rpm. Module name and streams are used as an rpm namespace.


https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_managing_and_removing_user_space_components/installing-rhel-8-content_using-appstream
https://fedoramagazine.org/modularity-fedora-28-server-edition/
