### PR TITLE
Ensure Amazon Linux is correctly identified

### DIFF
--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -30,6 +30,7 @@ import (
 )
 
 var (
+	amazonReleaseRegexp = regexp.MustCompile(`(?P<os>Amazon) (Linux release|Linux AMI release) (?P<version>[\d]+\.[\d]+|[\d]+)`)
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
 	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
 	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release) (?P<version>[\d]+)`)
@@ -51,6 +52,17 @@ func (d detector) Detect(files tarutil.FilesMap) (*database.Namespace, error) {
 		}
 
 		var r []string
+
+		// Attempt to match Amazon Linux.
+		r = amazonReleaseRegexp.FindStringSubmatch(string(f))
+		if len(r) == 4 {
+			// Amazon Linux's namespace name should be amzn but the
+			// /etc/system-release file uses Amazon.
+			return &database.Namespace{
+				Name:          "amzn" + ":" + r[3],
+				VersionFormat: rpm.ParserName,
+			}, nil
+		}
 
 		// Attempt to match Oracle Linux.
 		r = oracleReleaseRegexp.FindStringSubmatch(string(f))

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -25,6 +25,18 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
+			ExpectedNamespace: &database.Namespace{Name: "amzn:2"},
+			Files: tarutil.FilesMap{
+				"etc/system-release": []byte(`Amazon Linux release 2 (Karoo)`),
+			},
+		},
+		{
+			ExpectedNamespace: &database.Namespace{Name: "amzn:2018.03"},
+			Files: tarutil.FilesMap{
+				"etc/system-release": []byte(`Amazon Linux AMI release 2018.03`),
+			},
+		},
+		{
 			ExpectedNamespace: &database.Namespace{Name: "oracle:6"},
 			Files: tarutil.FilesMap{
 				"etc/oracle-release": []byte(`Oracle Linux Server release 6.8`),


### PR DESCRIPTION
Amazon Linux-based images are non-deterministically failing to be
detected with the correct namespace name. The CentOS regex in the
redhatrelease detector is too permissive causing Amazon Linux AMI
based images to return a namespace name of `AMI`. Additionally, Amazon
Linux 2 is detected to have the namespace name of `amazon". The correct
namespace name is `amzn`.

This change adds a more restrictive check for both Amazon Linux AMI and
Amazon Linux 2 so the redhatrelease detector correctly detects Amazon
Linux-based images.

Fixes #866