### PR TITLE
Ensure Amazon Linux is correctly identified

### DIFF
--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -25,6 +25,18 @@ import (
 func TestDetector(t *testing.T) {
 	testData := []featurens.TestData{
 		{
+			ExpectedNamespace: &database.Namespace{Name: "amzn:2"},
+			Files: tarutil.FilesMap{
+				"etc/system-release": []byte(`Amazon Linux release 2 (Karoo)`),
+			},
+		},
+		{
+			ExpectedNamespace: &database.Namespace{Name: "amzn:2018.03"},
+			Files: tarutil.FilesMap{
+				"etc/system-release": []byte(`Amazon Linux AMI release 2018.03`),
+			},
+		},
+		{
 			ExpectedNamespace: &database.Namespace{Name: "oracle:6"},
 			Files: tarutil.FilesMap{
 				"etc/oracle-release": []byte(`Oracle Linux Server release 6.8`),


### PR DESCRIPTION
Backport of aa04bb7d6d3b5bc0284ae9b618f9fcc5c772fb4c for release-2.0 branch.