### PR TITLE
ext/featurens: add support for RHEL8

### DIFF
--- a/ext/featurens/redhatrelease/redhatrelease.go
+++ b/ext/featurens/redhatrelease/redhatrelease.go
@@ -33,7 +33,7 @@ var (
 	amazonReleaseRegexp = regexp.MustCompile(`(?P<os>Amazon) (Linux release|Linux AMI release) (?P<version>[\d]+\.[\d]+|[\d]+)`)
 	oracleReleaseRegexp = regexp.MustCompile(`(?P<os>Oracle) (Linux Server release) (?P<version>[\d]+)`)
 	centosReleaseRegexp = regexp.MustCompile(`(?P<os>[^\s]*) (Linux release|release) (?P<version>[\d]+)`)
-	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release) (?P<version>[\d]+)`)
+	redhatReleaseRegexp = regexp.MustCompile(`(?P<os>Red Hat Enterprise Linux) (Client release|Server release|Workstation release|release) (?P<version>[\d]+)`)
 
 	filenames = []string{"etc/oracle-release", "etc/centos-release", "etc/redhat-release", "etc/system-release"}
 )

--- a/ext/featurens/redhatrelease/redhatrelease_test.go
+++ b/ext/featurens/redhatrelease/redhatrelease_test.go
@@ -61,6 +61,12 @@ func TestDetector(t *testing.T) {
 			},
 		},
 		{
+			ExpectedNamespace: &database.Namespace{Name: "centos:8"},
+			Files: tarutil.FilesMap{
+				"etc/redhat-release": []byte(`Red Hat Enterprise Linux release 8.0 (Ootpa)`),
+			},
+		},
+		{
 			ExpectedNamespace: &database.Namespace{Name: "centos:7"},
 			Files: tarutil.FilesMap{
 				"etc/system-release": []byte(`CentOS Linux release 7.1.1503 (Core)`),


### PR DESCRIPTION
RHEL8 features a new string composition in its `/etc/redhat-release` file, e.g.
`Red Hat Enterprise Linux release 8.0 (Ootpa)`. This change modifies the featurens
detector to account for this.

Fixes #889