### PR TITLE
fix content negotiation

### DIFF
--- a/cmd/clair/httpcompress.go
+++ b/cmd/clair/httpcompress.go
@@ -64,16 +64,19 @@ func (c *compressHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		case "gzip":
 			w.Header().Set("content-encoding", "gzip")
 			gz := c.gzip.Get().(*gzip.Writer)
+			gz.Reset(w)
 			defer c.gzip.Put(gz)
 			cw = gz
 		case "deflate":
 			w.Header().Set("content-encoding", "deflate")
 			z := c.flate.Get().(*flate.Writer)
+			z.Reset(w)
 			defer c.flate.Put(z)
 			cw = z
 		case "snappy": // Nonstandard
 			w.Header().Set("content-encoding", "snappy")
 			s := c.snappy.Get().(*snappy.Writer)
+			s.Reset(w)
 			defer c.snappy.Put(s)
 			cw = s
 		case "identity":

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/klauspost/compress v1.9.4
-	github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/quay/claircore v0.0.13
 	github.com/rs/zerolog v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1 h1:Qhv4Ni88zV+8TY65yr2ak8xU4sblgs6aRT9RuGM5SNU=
-github.com/markusthoemmes/goautoneg v0.0.0-20190713162725-c6008fefa5b1/go.mod h1:qFhy2RoC9EWZC7fgczcBbUpzGNFfIm5//VO/gde0AbI=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=


### PR DESCRIPTION
The library used previously is intended for the `Accept` header, and as such never actually triggered any of the payload compression. The custom `parseAccept` function expects the commonly used values and triggers compression correctly:

```
% curl -vvv -H 'Accept-Encoding: gzip' http://localhost:6080/api/v1/state | gunzip
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying ::1:6080...
* TCP_NODELAY set
* Connected to localhost (::1) port 6080 (#0)
> GET /api/v1/state HTTP/1.1
> Host: localhost:6080
> User-Agent: curl/7.66.0
> Accept: */*
> Accept-Encoding: gzip
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Encoding: gzip
< Content-Type: application/json
< Etag: "aae368a064d7c5a433d0bf2c4f5554cc"
< Trailer: clair-error
< Date: Wed, 15 Jan 2020 19:55:25 GMT
< Transfer-Encoding: chunked
< 
{ [84 bytes data]
100    73    0    73    0     0  18250      0 --:--:-- --:--:-- --:--:-- 18250
* Connection #0 to host localhost left intact
{"state":"aae368a064d7c5a433d0bf2c4f5554cc"}
```