### PR TITLE
Remove misleading sentence from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Thus, the project was named `Clair` after the French term which translates to *c
 * Follow instructions to get Clair [up and running]
 * Explore [the API] on SwaggerHub
 * Discover third party [integrations] that help integrate Clair with your infrastructure
-* Read the rest of the documentation on the [CoreOS website] or in the [Documentation directory]
 * Get up and running with [Local Development]
 
 [the terminology]: /Documentation/terminology.md


### PR DESCRIPTION
In the README it says that in order to read the rest of Clair's documentation 
we should go to the CoreOs website.
On the CoreOs website there is a message which says:
"These docs are deprecated while they are being migrated to Red Hat. 
For the most up to date docs, please see the corresponding GitHub repository."

So, it doesn't make sense to point the people to the CoreOs website.
Also, it doesn't make sense to point them to the documentation folder on GitHub when
every documentation page has its own link on the README.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>