### PR TITLE
Remove "Up and running" link duplication in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Thus, the project was named `Clair` after the French term which translates to *c
 * Follow instructions to get Clair [up and running]
 * Explore [the API] on SwaggerHub
 * Discover third party [integrations] that help integrate Clair with your infrastructure
-* Get up and running with [Local Development]
 
 [the terminology]: /Documentation/terminology.md
 [drivers and data sources]: /Documentation/drivers-and-data-sources.md


### PR DESCRIPTION
There is the " Follow instructions to get Clair [up and running]" link on the README
and the "Get up and running with [Local Development]" link on the README.
The second is a subset of the first and it doesn't make sense to include it on
the README.

Signed-off-by: Martin Vrachev <mvrachev@vmware.com>