### PR TITLE
Improve the documentation on running Clair

### DIFF
--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -50,8 +50,9 @@ See [Local Development] for our Kubernetes based local development environment.
 ```sh
 $ mkdir $PWD/clair_config
 $ curl -L https://raw.githubusercontent.com/coreos/clair/master/config.yaml.sample -o $PWD/clair_config/config.yaml
-$ docker run -d -e POSTGRES_PASSWORD="" -p 5432:5432 postgres:9.6
-$ docker run --net=host -d -p 6060-6061:6060-6061 -v $PWD/clair_config:/config quay.io/coreos/clair:latest -config=/config/config.yaml
+$ docker network create clairnet
+$ docker run -d --name clairdb --network clairnet postgres:9.6
+$ docker run --net=clairnet --name clair -d -p 6060-6061:6060-6061 -v $PWD/clair_config:/config quay.io/coreos/clair:latest -config=/config/config.yaml
 ```
 
 #### Source

--- a/Documentation/running-clair.md
+++ b/Documentation/running-clair.md
@@ -45,6 +45,15 @@ A [PostgreSQL 9.4+] database instance is required for all instructions.
 
 See [Local Development] for our Kubernetes based local development environment.
 
+### Docker-compose
+
+```sh
+$ curl -L https://raw.githubusercontent.com/coreos/clair/master/docker-compose.yaml.sample -o $PWD/docker-compose.yaml
+$ mkdir $PWD/clair_config
+$ curl -L https://raw.githubusercontent.com/coreos/clair/master/config.yaml.sample -o $PWD/clair_config/config.yaml
+$ docker-compose -f docker-compose.yaml up -d
+```
+
 ### Docker
 
 ```sh

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -20,7 +20,7 @@ clair:
     options:
       # PostgreSQL Connection string
       # https://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING
-      source: host=localhost port=5432 user=postgres sslmode=disable statement_timeout=60000
+      source: host=clairdb port=5432 user=postgres sslmode=disable statement_timeout=60000
 
       # Number of elements kept in the cache
       # Values unlikely to change (e.g. namespaces) are cached in order to save prevent needless roundtrips to the database.

--- a/docker-compose.yaml.sample
+++ b/docker-compose.yaml.sample
@@ -1,0 +1,26 @@
+version: '3.7'
+
+services:
+  clair:
+    image: quay.io/coreos/clair:latest
+    command: -config=/config/config.yaml
+    ports:
+      - "6060:6060"
+      - "6061:6061"
+    depends_on:
+      - clairdb
+    volumes:
+      - type: bind
+        source: $PWD/clair_config
+        target: /config
+    networks:
+      - clairnet
+    restart: on-failure
+  clairdb:
+    image: postgres:9.6
+    networks:
+      - clairnet
+
+networks:
+  clairnet:
+    driver: bridge


### PR DESCRIPTION
This PR contains:
- Modification of the documentation on running Clair for non-linux users.
    - Since Docker containers run on a virtual machine and not on the host machine itself for Windows and Mac users, it is especially hard to connect to Clair from the host network. In other words, `curl localhost:6060/...` does not work on Windows and Mac. More information can be found [here](https://docs.docker.com/network/host/) - "The host networking driver only works on Linux hosts, and is not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows".
- Adding docker-compose.yaml.sample and explaining how it can be used to start Clair in the documentation.
    - Related to [this](https://github.com/quay/clair/issues/815) issue.