### PR TITLE
Severity Mapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/klauspost/compress v1.9.4
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
-	github.com/quay/claircore v0.0.14
+	github.com/quay/claircore v0.0.15
 	github.com/rs/zerolog v1.16.0
 	golang.org/x/tools v0.0.0-20191210200704-1bcf67c9cb49 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,7 @@ github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-containerregistry v0.0.0-20191206185556-eb7c14b719c6/go.mod h1:rodaC7jYStJ2mjR8Y+5a/jCzcRPFRH74KmqSnJC88co=
 github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -215,6 +216,8 @@ github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
 github.com/quay/claircore v0.0.14 h1:5vyKXX99sNVUGTJDlEcEi2NThFo6GgQX3eeSkYwf738=
 github.com/quay/claircore v0.0.14/go.mod h1:sHoFUbkDaGyq0tg1uepnE02LTUz55DCPMRl7/OJTPkI=
+github.com/quay/claircore v0.0.15 h1:uMq3dn7zaG3lmxjZOzlGHvvDqTn3wy+thP9GdgxfpKA=
+github.com/quay/claircore v0.0.15/go.mod h1:3kXoPFGsTh5crmB5CDw7Icdq7w1GkHLyFynL0Eufcjc=
 github.com/quay/goval-parser v0.7.0 h1:QhJXufv2w5BUzfLJSfLz01yya9MS5SWGtyo8J/EAvkY=
 github.com/quay/goval-parser v0.7.0/go.mod h1:9mCSx+kqC0rq6bKyAWiplMUzTWLpr4HRlez+iuxEkhc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=
@@ -344,6 +347,7 @@ golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -200,7 +200,8 @@ components:
           https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34238
           https://sourceware.org/bugzilla/show_bug.cgi?id=18986"
         severity: "Low"
-        package:
+        normalized_severity: "Low"
+        package: 
           id: "0"
           name: "glibc"
           version: ""
@@ -416,6 +417,10 @@ components:
           description: |
             A severity keyword taken verbatim from the vulnerability source.
           type: string
+        normalized_severity:
+          description: "A well defined set of severity strings guaranteed to be present."
+          type: string
+          enum: [Unkonwn, Negligible, Low, Medium, High, Critical, Defcon1]
         package:
           $ref: '#/components/schemas/Package'
         dist:


### PR DESCRIPTION
This PR updates openapi spec with normalized severity changes in ClairCore. 
https://github.com/quay/claircore/pull/134

Draft until pull 134 goes in and we bump the release. 