### PR TITLE
move middleware to package

### DIFF
--- a/middleware/auth/handler.go
+++ b/middleware/auth/handler.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"context"
@@ -12,12 +12,12 @@ type AuthCheck interface {
 	Check(context.Context, *http.Request) bool
 }
 
-type authHandler struct {
+type handler struct {
 	auth AuthCheck
 	next http.Handler
 }
 
-func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if !h.auth.Check(r.Context(), r) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -25,10 +25,10 @@ func (h *authHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.next.ServeHTTP(w, r)
 }
 
-// AuthHandler returns a Handler that gates access to the passed Handler behind
+// Handler returns a http.Handler that gates access to the passed Handler behind
 // the passed AuthCheck.
-func AuthHandler(h http.Handler, f AuthCheck) http.Handler {
-	return &authHandler{
+func Handler(h http.Handler, f AuthCheck) http.Handler {
+	return &handler{
 		auth: f,
 		next: h,
 	}

--- a/middleware/auth/httpauth_keyserver_test.go
+++ b/middleware/auth/httpauth_keyserver_test.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"bytes"

--- a/middleware/auth/httpauth_psk.go
+++ b/middleware/auth/httpauth_psk.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"context"
@@ -8,12 +8,25 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-type psk struct {
+// PSK implements the AuthCheck interface.
+//
+// When Check is called the JWT on the incoming http request
+// will be validated against a pre-shared-key.
+type PSK struct {
 	key []byte
 	iss string
 }
 
-func (p *psk) Check(_ context.Context, r *http.Request) bool {
+// NewPSK returns an instance of a PSK
+func NewPSK(key []byte, issuer string) (*PSK, error) {
+	return &PSK{
+		key: key,
+		iss: issuer,
+	}, nil
+}
+
+// Check implements AuthCheck
+func (p *PSK) Check(_ context.Context, r *http.Request) bool {
 	wt, ok := fromHeader(r)
 	if !ok {
 		return false
@@ -33,13 +46,4 @@ func (p *psk) Check(_ context.Context, r *http.Request) bool {
 		return false
 	}
 	return true
-}
-
-// PSKAuth returns an AuthCheck that validates a JWT with the supplied key and
-// ensures the issuer claim matches.
-func PSKAuth(key []byte, issuer string) (AuthCheck, error) {
-	return &psk{
-		key: key,
-		iss: issuer,
-	}, nil
 }

--- a/middleware/auth/httpauth_psk_test.go
+++ b/middleware/auth/httpauth_psk_test.go
@@ -1,4 +1,4 @@
-package main
+package auth
 
 import (
 	"bytes"

--- a/middleware/compress/handler.go
+++ b/middleware/compress/handler.go
@@ -1,4 +1,4 @@
-package main
+package compress
 
 import (
 	"fmt"
@@ -15,10 +15,10 @@ import (
 	"github.com/klauspost/compress/snappy"
 )
 
-// Compress wraps the provided http.Handler and provides transparent body
+// Handler wraps the provided http.Handler and provides transparent body
 // compression based on a Request's "Accept-Encoding" header.
-func Compress(next http.Handler) http.Handler {
-	h := compressHandler{
+func Handler(next http.Handler) http.Handler {
+	h := handler{
 		next: next,
 	}
 	h.snappy.New = func() interface{} {
@@ -36,10 +36,10 @@ func Compress(next http.Handler) http.Handler {
 	return &h
 }
 
-var _ http.Handler = (*compressHandler)(nil)
+var _ http.Handler = (*handler)(nil)
 
-// CompressHandler performs transparent HTTP body compression.
-type compressHandler struct {
+// handler performs transparent HTTP body compression.
+type handler struct {
 	snappy, gzip, flate sync.Pool
 	next                http.Handler
 }
@@ -97,7 +97,7 @@ type accept struct {
 }
 
 // ServeHTTP implements http.Handler.
-func (c *compressHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (c *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ae, nok := parseAccept(r.Header.Get("accept-encoding"))
 	if ae == nil {
 		// If there was no header, play it cool.


### PR DESCRIPTION
PR Moves all middleware to a namespaced package and makes their identifiers the same. 