### PR TITLE
Make and Sample Config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ local-dev-down:
 # often a service should be restarted as well to run migrations on the now schemaless database.
 .PHONY: local-dev-db-restart
 local-dev-db-restart:
+	$(docker) kill clair_clair-db_1 && $(docker) rm clair_clair-db_1
 	$(docker-compose) up -d --force-recreate clair-db
 
 # restart the local development indexer, any local code changes will take effect

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 mode: dev
-inrospection_addr: localhost:8089
+introspection_addr: localhost:8089
 http_listen_addr: localhost:8080
 log_level: debug
 indexer:
+  http_listen_addr: localhost:8080
   connstring: host=localhost port=5432 user=clair dbname=clair sslmode=disable
   scanlock_retry: 10
   layer_scan_concurrency: 5
   migrations: true
 matcher:
+  http_listen_addr: localhost:8080
   connstring: host=localhost port=5432 user=clair dbname=clair sslmode=disable
   max_conn_pool: 100
   run: ""
@@ -32,7 +34,8 @@ trace:
   name: "jaeger"
   probability: 1
   jaeger:
-    agent_endpoint: "addr"
+    agent_endpoint: "localhost:6831"
+    service_name: "clair"
 
 metrics:
   name: "prometheus"


### PR DESCRIPTION
PR makes the sample configuration work (useful for running `dlv debug -- -conf ../../config.yaml.sample` in the clair cmd directory) 

Also fixes db recreate make target to blow away the db and restore. 