### PR TITLE
clair: add "mode" argument

### DIFF
--- a/cmd/clair/httptransport.go
+++ b/cmd/clair/httptransport.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/quay/clair/v4/middleware/auth"
-	"github.com/quay/clair/v4/middleware/compress"
 	"github.com/quay/claircore/libindex"
 	"github.com/quay/claircore/libvuln"
 	"go.opentelemetry.io/otel/plugin/othttp"
@@ -16,6 +14,8 @@ import (
 	"github.com/quay/clair/v4/config"
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"
+	"github.com/quay/clair/v4/middleware/auth"
+	"github.com/quay/clair/v4/middleware/compress"
 )
 
 // httptransport configures an http server according to Clair's operation mode.
@@ -23,8 +23,8 @@ func httptransport(ctx context.Context, conf config.Config) (*http.Server, error
 	var srv *http.Server
 	var err error
 	switch {
-	case conf.Mode == config.DevMode:
-		srv, err = devMode(ctx, conf)
+	case conf.Mode == config.ComboMode:
+		srv, err = comboMode(ctx, conf)
 	case conf.Mode == config.IndexerMode:
 		srv, err = indexerMode(ctx, conf)
 	case conf.Mode == config.MatcherMode:
@@ -41,7 +41,7 @@ func httptransport(ctx context.Context, conf config.Config) (*http.Server, error
 	return srv, nil
 }
 
-func devMode(ctx context.Context, conf config.Config) (*http.Server, error) {
+func comboMode(ctx context.Context, conf config.Config) (*http.Server, error) {
 	libI, err := libindex.New(ctx, &libindex.Opts{
 		ConnString:           conf.Indexer.ConnString,
 		ScanLockRetry:        time.Duration(conf.Indexer.ScanLockRetry) * time.Second,
@@ -97,17 +97,21 @@ func indexerMode(ctx context.Context, conf config.Config) (*http.Server, error) 
 		return nil, err
 	}
 	return &http.Server{
-		Addr:    conf.Indexer.HTTPListenAddr,
+		Addr:    conf.HTTPListenAddr,
 		Handler: othttp.NewHandler(compress.Handler(indexer), "server"),
 	}, nil
 }
 
 func matcherMode(ctx context.Context, conf config.Config) (*http.Server, error) {
-	libV, err := libvuln.New(ctx, &libvuln.Opts{
+	vopt := libvuln.Opts{
 		MaxConnPool: int32(conf.Matcher.MaxConnPool),
 		ConnString:  conf.Matcher.ConnString,
 		Migrations:  conf.Matcher.Migrations,
-	})
+	}
+	if conf.Matcher.Updaters != nil {
+		vopt.Run = *conf.Matcher.Updaters
+	}
+	libV, err := libvuln.New(ctx, &vopt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize libvuln: %v", err)
 	}
@@ -121,7 +125,7 @@ func matcherMode(ctx context.Context, conf config.Config) (*http.Server, error) 
 		return nil, err
 	}
 	return &http.Server{
-		Addr:    conf.Matcher.HTTPListenAddr,
+		Addr:    conf.HTTPListenAddr,
 		Handler: othttp.NewHandler(compress.Handler(matcher), "server"),
 	}, nil
 }

--- a/cmd/clair/introspection.go
+++ b/cmd/clair/introspection.go
@@ -78,8 +78,8 @@ func introspection(ctx context.Context, cfg *config.Config, healthCheck func() b
 		// tracing.
 		DefaultSampler: sdktrace.NeverSample(),
 	}
-	if cfg.Mode == config.DevMode {
-		// Unless we're in dev mode, then go ham.
+	if logLevel(cfg) == zerolog.DebugLevel {
+		// Unless we're debugging, then go ham.
 		traceCfg.DefaultSampler = sdktrace.AlwaysSample()
 	}
 	if p := cfg.Trace.Probability; p != nil {

--- a/cmd/clair/values.go
+++ b/cmd/clair/values.go
@@ -34,3 +34,56 @@ func (v *ConfValue) Set(s string) error {
 	v.file = f
 	return nil
 }
+
+const (
+	_ ConfMode = iota
+	ModeCombo
+	ModeIndexer
+	ModeMatcher
+	ModeNotifier
+)
+
+// ConfMode enumerates the arguments that are acceptable "modes".
+type ConfMode int
+
+func (v *ConfMode) String() string {
+	if v == nil {
+		return ""
+	}
+	switch *v {
+	case ModeCombo:
+		return "combo"
+	case ModeIndexer:
+		return "indexer"
+	case ModeMatcher:
+		return "matcher"
+	case ModeNotifier:
+		return "notifier"
+	default:
+	}
+	return "invalid"
+}
+
+// Get implements flag.Getter
+func (v *ConfMode) Get() interface{} {
+	return *v
+}
+
+// Set implements flag.Value
+func (v *ConfMode) Set(s string) error {
+	switch s {
+	case "", "dev":
+		fallthrough
+	case "combo", "combination", "pizza": // "Pizza", of course, being the best Combos flavor.
+		*v = ModeCombo
+	case "index", "indexer":
+		*v = ModeIndexer
+	case "match", "matcher":
+		*v = ModeMatcher
+	case "notify", "notifier":
+		*v = ModeNotifier
+	default:
+		return fmt.Errorf("unknown mode argument %q", s)
+	}
+	return nil
+}

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -11,25 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-mode: dev
+---
 introspection_addr: localhost:8089
 http_listen_addr: localhost:8080
 log_level: debug
 indexer:
-  http_listen_addr: localhost:8080
   connstring: host=localhost port=5432 user=clair dbname=clair sslmode=disable
   scanlock_retry: 10
   layer_scan_concurrency: 5
   migrations: true
 matcher:
-  http_listen_addr: localhost:8080
   connstring: host=localhost port=5432 user=clair dbname=clair sslmode=disable
   max_conn_pool: 100
   run: ""
   migrations: true
 
-# tracing and metrics 
+# tracing and metrics
 trace:
   name: "jaeger"
   probability: 1

--- a/local-dev/indexer/indexer.config.yaml
+++ b/local-dev/indexer/indexer.config.yaml
@@ -1,8 +1,9 @@
+---
 mode: indexer
 log_level: debug
 introspection_addr: ":8089"
+http_listen_addr: ":80"
 indexer:
-  http_listen_addr: ":80"
   connstring: host=clair-db port=5432 user=clair dbname=clair sslmode=disable
   scanlock_retry: 10
   layer_scan_concurrency: 5

--- a/local-dev/matcher/matcher.config.yaml
+++ b/local-dev/matcher/matcher.config.yaml
@@ -1,8 +1,9 @@
+---
 mode: matcher
 log_level: debug
 introspection_addr: ":8089"
+http_listen_addr: ":80"
 matcher:
-  http_listen_addr: ":80"
   indexer_addr: http://indexer/
   connstring: host=clair-db port=5432 user=clair dbname=clair sslmode=disable
   max_conn_pool: 100


### PR DESCRIPTION
This change promotes "mode" out of the config file and makes it settable
via the command line and the environment.

Additional changes are introduced that make sure a single configuration
file can work in multiple "modes" and there's some clean-up changes.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>