### PR TITLE
Fix Binary Build

### DIFF
--- a/cmd/clair/httptransport.go
+++ b/cmd/clair/httptransport.go
@@ -11,9 +11,6 @@ import (
 	"github.com/quay/claircore/libvuln"
 	"go.opentelemetry.io/otel/plugin/othttp"
 
-	"github.com/quay/clair/v4/middleware/auth"
-	"github.com/quay/clair/v4/middleware/compress"
-
 	"github.com/quay/clair/v4/config"
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"


### PR DESCRIPTION
### Description

Fixes the following error during `docker build`:
```
Step 6/15 : RUN go build        -mod=vendor     -ldflags="-X main.Version=${CLAIR_VERSION}"     ./cmd/clair
 ---> Running in d480621dc2d1
# github.com/quay/clair/v4/cmd/clair
cmd/clair/httptransport.go:20:2: auth redeclared as imported package name                                              

cmd/clair/httptransport.go:21:2: compress redeclared as imported package name                                          

The command '/bin/sh -c go build        -mod=vendor     -ldflags="-X main.Version=${CLAIR_VERSION}"     ./cmd/clair' returned a non-zero code: 2
```