### PR TITLE
clair: use Etag header to communicate indexer state change

### DIFF
--- a/cmd/clair/httptransport.go
+++ b/cmd/clair/httptransport.go
@@ -11,9 +11,6 @@ import (
 	"github.com/quay/claircore/libvuln"
 	"go.opentelemetry.io/otel/plugin/othttp"
 
-	"github.com/quay/clair/v4/middleware/auth"
-	"github.com/quay/clair/v4/middleware/compress"
-
 	"github.com/quay/clair/v4/config"
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"


### PR DESCRIPTION
In the course of this change, the Etag validation logic is also
corrected.