### PR TITLE
Local Container, Consistent Names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ local-dev-up: vendor
 	$(docker-compose) up -d jaeger
 	$(docker-compose) up -d prometheus
 	$(docker-compose) up -d clair-db
-	$(docker) exec -it clair_clair-db_1 bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	$(docker) exec -it clair-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
 	$(docker-compose) up -d indexer
 	$(docker-compose) up -d matcher
 	$(docker-compose) up -d swagger-ui
@@ -47,7 +47,7 @@ local-dev-down:
 # often a service should be restarted as well to run migrations on the now schemaless database.
 .PHONY: local-dev-db-restart
 local-dev-db-restart:
-	$(docker) kill clair_clair-db_1 && $(docker) rm clair_clair-db_1
+	$(docker) kill clair-db && $(docker) rm clair-db
 	$(docker-compose) up -d --force-recreate clair-db
 
 # restart the local development indexer, any local code changes will take effect

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 version: "3.7"
 services:
   clair-db:
+    container_name: clair-db
     image: postgres:12.1
     environment:
       POSTGRES_USER: "clair"
@@ -15,7 +16,9 @@ services:
       start_period: 10s
 
   indexer:
-    image: quay.io/claircore/golang:1.13.3
+    container_name: clair-indexer
+    build: .
+    image: clair-local:latest
     ports:
       - "8080:80"
       - "8089:8089"
@@ -28,7 +31,9 @@ services:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor . -conf /src/clair/local-dev/indexer/indexer.config.yaml"]
 
   matcher:
-    image: quay.io/claircore/golang:1.13.3
+    container_name: matcher-indexer
+    image: clair-local:latest
+    build: .
     ports:
       - "8081:80"
       - "8090:8089"
@@ -41,6 +46,7 @@ services:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor . -conf /src/clair/local-dev/matcher/matcher.config.yaml"]
 
   swagger-ui:
+    container_name: clair-swagger
     image: swaggerapi/swagger-ui
     ports:
       - "8082:8080"
@@ -50,6 +56,7 @@ services:
       SWAGGER_JSON: "/clair/openapi.yaml"
 
   jaeger:
+    container_name: clair-jaeger
     image: jaegertracing/all-in-one:1.17
     ports:
         - "5775:5775/udp" 
@@ -64,6 +71,7 @@ services:
       COLLECTOR_ZIPKIN_HTTP_PORT: 9411
 
   prometheus:
+    container_name: clair-prometheus
     image: prom/prometheus:latest
     volumes:
       - "./local-dev/prometheus:/etc/prometheus/"


### PR DESCRIPTION
This PR first alters the docker-compose env to use the local docker file when building the local dev environment.

Second this PR adds git worktree support for local-development. all container names remain the same between work trees so local-dev commands do not break. 

Signed-off-by: ldelossa <louis.delos@gmail.com>