### PR TITLE
Path Routes, Bug Stomping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 vendor/
 book/
+clairctl
+!clairctl/

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ goimports-local:
 # each services runs in it's own container to test service->service communication.
 .PHONY: local-dev-up
 local-dev-up: vendor
+	$(docker-compose) up -d traefik
 	$(docker-compose) up -d jaeger
 	$(docker-compose) up -d prometheus
 	$(docker-compose) up -d clair-db
@@ -65,3 +66,7 @@ local-dev-matcher-restart:
 local-dev-swagger-ui-restart:
 	$(docker-compose) up -d --force-recreate swagger-ui
 	 
+# restart the local development swagger-ui, any local code changes will take effect
+.PHONY: local-dev-traefik-restart
+local-dev-traefik-restart:
+	$(docker-compose) up -d --force-recreate traefik

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -25,9 +25,9 @@ var ReportCmd = &cli.Command{
 	ArgsUsage:   "container...",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "api",
+			Name:  "host",
 			Usage: "URL for the clairv4 v1 API.",
-			Value: "http://localhost:6060/api/v1/",
+			Value: "http://localhost:6060/",
 		},
 		&cli.GenericFlag{
 			Name:        "out",
@@ -107,7 +107,7 @@ func reportAction(c *cli.Context) error {
 		return errors.New("missing needed arguments")
 	}
 
-	cc, err := NewClient(c.String("api"))
+	cc, err := NewClient(c.String("host"))
 	if err != nil {
 		return err
 	}

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -21,6 +21,7 @@ indexer:
   layer_scan_concurrency: 5
   migrations: true
 matcher:
+  indexer_addr: "localhost:8080"
   connstring: host=localhost port=5432 user=clair dbname=clair sslmode=disable
   max_conn_pool: 100
   run: ""

--- a/config/httpclient.go
+++ b/config/httpclient.go
@@ -14,6 +14,9 @@ import (
 // It returns an *http.Client and a boolean indicating whether the client is
 // configured for authentication, or an error that occurred during construction.
 func (cfg *Config) Client(next *http.Transport) (c *http.Client, authed bool, err error) {
+	if next == nil {
+		next = &http.Transport{}
+	}
 	authed = false
 	sk := jose.SigningKey{Algorithm: jose.HS256}
 

--- a/config/httpclient.go
+++ b/config/httpclient.go
@@ -15,7 +15,7 @@ import (
 // configured for authentication, or an error that occurred during construction.
 func (cfg *Config) Client(next *http.Transport) (c *http.Client, authed bool, err error) {
 	if next == nil {
-		next = &http.Transport{}
+		next = http.DefaultTransport.(*http.Transport).Clone()
 	}
 	authed = false
 	sk := jose.SigningKey{Algorithm: jose.HS256}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,21 @@ services:
       retries: 3
       start_period: 10s
 
+  traefik:
+    container_name: clair-traefik
+    image: traefik:v2.2
+    command: 
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--entrypoints.clair.address=:6060"
+      - "--providers.docker.exposedbydefault=false"
+      - "--accesslog=true"
+    ports: 
+      - "6060:6060"
+      - "8079:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   indexer:
     container_name: clair-indexer
     image: quay.io/claircore/golang:1.13.5
@@ -28,6 +43,12 @@ services:
       CLAIR_MODE: "indexer"
     command:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor ."]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.index_report.entrypoints=clair"
+      - "traefik.http.routers.index_report.rule=PathPrefix(`/api/v1/index_report`)"
+      - "traefik.http.routers.index_state.entrypoints=clair"
+      - "traefik.http.routers.index_state.rule=PathPrefix(`/api/v1/index_state`)"
 
   matcher:
     container_name: clair-matcher
@@ -42,6 +63,10 @@ services:
       CLAIR_MODE: "matcher"
     command:
       ["bash", "-c", "cd /src/clair/cmd/clair; go run -mod vendor ."]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vulnerability_report.entrypoints=clair"
+      - "traefik.http.routers.vulnerability_report.rule=PathPrefix(`/api/v1/vulnerability_report`)"
 
   swagger-ui:
     container_name: clair-swagger

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -64,15 +64,31 @@ func New(ctx context.Context, conf config.Config, indexer indexer.Service, match
 		traceOpt: othttp.WithTracer(global.TraceProvider().Tracer("clair")),
 	}
 
+	var e error
 	switch conf.Mode {
 	case config.ComboMode:
-		t.configureComboMode()
-		t.configureUpdateEndpoints()
+		e = t.configureComboMode()
+		if e != nil {
+			return nil, e
+		}
+		e = t.configureUpdateEndpoints()
+		if e != nil {
+			return nil, e
+		}
 	case config.IndexerMode:
-		t.configureIndexerMode()
+		e = t.configureIndexerMode()
+		if e != nil {
+			return nil, e
+		}
 	case config.MatcherMode:
-		t.configureMatcherMode()
-		t.configureUpdateEndpoints()
+		e = t.configureMatcherMode()
+		if e != nil {
+			return nil, e
+		}
+		e = t.configureUpdateEndpoints()
+		if e != nil {
+			return nil, e
+		}
 	}
 
 	// attach HttpTransport to server, this works because we embed http.ServeMux

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -20,11 +20,11 @@ import (
 
 const (
 	apiRoot                 = "/api/v1/"
+	internalRoot            = apiRoot + "internal/"
 	VulnerabilityReportPath = apiRoot + "vulnerability_report/"
 	IndexAPIPath            = apiRoot + "index_report"
 	IndexReportAPIPath      = apiRoot + "index_report/"
-	StateAPIPath            = apiRoot + "state"
-	internalRoot            = apiRoot + "internal/"
+	StateAPIPath            = apiRoot + "index_state"
 	UpdatesAPIPath          = internalRoot + "updates/"
 )
 
@@ -67,16 +67,12 @@ func New(ctx context.Context, conf config.Config, indexer indexer.Service, match
 	switch conf.Mode {
 	case config.ComboMode:
 		t.configureComboMode()
-		if err := t.configureUpdateEndpoints(); err != nil {
-			return nil, err
-		}
+		t.configureUpdateEndpoints()
 	case config.IndexerMode:
 		t.configureIndexerMode()
 	case config.MatcherMode:
 		t.configureMatcherMode()
-		if err := t.configureUpdateEndpoints(); err != nil {
-			return nil, err
-		}
+		t.configureUpdateEndpoints()
 	}
 
 	// attach HttpTransport to server, this works because we embed http.ServeMux

--- a/httptransport/vulnerabilityreporthandler.go
+++ b/httptransport/vulnerabilityreporthandler.go
@@ -52,6 +52,16 @@ func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service
 		}
 
 		indexReport, ok, err := indexer.IndexReport(ctx, manifest)
+		// check err first
+		if err != nil {
+			resp := &je.Response{
+				Code:    "internal-server-error",
+				Message: fmt.Sprintf("experienced a server side error: %v", err),
+			}
+			je.Error(w, resp, http.StatusInternalServerError)
+			return
+		}
+		// now check bool only after comfirning no errr
 		if !ok {
 			resp := &je.Response{
 				Code:    "not-found",
@@ -60,14 +70,6 @@ func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service
 			je.Error(w, resp, http.StatusNotFound)
 			return
 
-		}
-		if err != nil {
-			resp := &je.Response{
-				Code:    "internal-server-error",
-				Message: fmt.Sprintf("experienced a server side error: %v", err),
-			}
-			je.Error(w, resp, http.StatusInternalServerError)
-			return
 		}
 
 		vulnReport, err := service.Scan(ctx, indexReport)

--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -8,7 +8,7 @@ indexer:
   layer_scan_concurrency: 5
   migrations: true
 matcher:
-  indexer_addr: http://clair-indexer/
+  indexer_addr: http://clair-indexer:8080/
   connstring: host=clair-db port=5432 user=clair dbname=clair sslmode=disable
   max_conn_pool: 100
   migrations: true


### PR DESCRIPTION
Traefik is now included in the local dev to confirm
path routing works and to provide a single url for local development.

Cliarctl is configured to point to the traefik instance doing the path
routing by default.

Found a few bugs along the way:
http.Transport in config.HttpClient was not checked for nil and did not provide
a default so we were getting nil deref panics on test.

HttpTransport client code checked bool before err and was masking an
issue. Actual error was bad local dev config value for indexer_addr in
matcher config

Signed-off-by: ldelossa <ldelossa@redhat.com>