### PR TITLE
database: add mapping for Ubuntu Focal (20.04)

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -50,4 +50,5 @@ var UbuntuReleasesMapping = map[string]string{
 	"cosmic":  "18.10",
 	"disco":   "19.04",
 	"eoan":    "19.10",
+	"focal":   "20.04",
 }


### PR DESCRIPTION
Ubuntu 20.04 is [released](https://twitter.com/ubuntu/status/1253378475295232003). This is needed for it to be supported by clair.