### PR TITLE
Remove reference to non-existing com.redhat.rhsa-RHEL3.xml

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -50,7 +50,7 @@ var (
 	}
 
 	rhsaRegexp = regexp.MustCompile(`com.redhat.rhsa-(\d+).xml`)
-	releases   = []int{3, 4, 5, 6, 7, 8}
+	releases   = []int{4, 5, 6, 7, 8}
 	httpClient = http.Client{
 		Timeout: 5 * time.Minute,
 	}


### PR DESCRIPTION
Title of the https://www.redhat.com/security/data/oval/ clearly states that it is listing "OVAL definitions for Red Hat Enterprise Linux 4 and above". Updater is trying to download non existing `com.redhat.rhsa-RHEL3.xml` and shows errors in the log. This PR removing it from the list.