### PR TITLE
Fixed Clair-pg dependencies to work with Kubernetes 1.16+ + Improved Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,8 @@ deploy-local:
 	# Both minikube and docker desktop is supported.
 	./local-dev/build.sh
 	-helm dependency update ./local-dev/helm/clair-pg
-	-helm install --name clair-pg ./local-dev/helm/clair-pg
-	-helm delete --purge clair
-	helm install --name clair ./local-dev/helm/clair
+	-helm upgrade --install clair-pg ./local-dev/helm/clair-pg
+	helm upgrade --install clair ./local-dev/helm/clair
 
 .PHONY: teardown-local
 teardown-local:

--- a/local-dev/helm/clair-pg/requirements.yaml
+++ b/local-dev/helm/clair-pg/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: postgresql
-    version: "5.1.2"
+    version: "6.3.9"
     condition: postgresql.enabled
     repository: "alias:stable"


### PR DESCRIPTION
In [Kubernetes 1.16 Changelog](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals) we can see various endpoint changed from various v1beta[1|2] to v1; breaking Clair's dependency with Postgresql (whose Chart version 5.1.2 still uses the old Kubernetes endpoints).

It is fixed since [Postgresql Chart version 6.3.9](https://github.com/helm/charts/pull/17281).

The fix on Makefile allows to be really idempotent without having to purge the Chart.