### PR TITLE
remove type alias infavor of pointer to struct

### DIFF
--- a/httptransport/client/differ.go
+++ b/httptransport/client/differ.go
@@ -17,10 +17,10 @@ import (
 	"github.com/quay/clair/v4/matcher"
 )
 
-var _ matcher.Differ = (HTTP)(nil)
+var _ matcher.Differ = (*HTTP)(nil)
 
 // DeleteUpdateOperations attempts to delete the referenced update operations.
-func (c HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) error {
+func (c *HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) error {
 	u, err := c.addr.Parse(httptransport.UpdatesAPIPath)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ func (c HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) erro
 
 // LatestUpdateOperation shouldn't be used by client code and is implemented
 // only to satisfy the matcher.Differ interface.
-func (c HTTP) LatestUpdateOperation(_ context.Context) (uuid.UUID, error) {
+func (c *HTTP) LatestUpdateOperation(_ context.Context) (uuid.UUID, error) {
 	return uuid.Nil, nil
 }
 
@@ -101,7 +101,7 @@ var ErrUnchanged = errors.New("response unchanged from last call")
 
 // LatestUpdateOperations returns a map of updater name to ref of its latest
 // update.
-func (c HTTP) LatestUpdateOperations(ctx context.Context) (map[string]uuid.UUID, error) {
+func (c *HTTP) LatestUpdateOperations(ctx context.Context) (map[string]uuid.UUID, error) {
 	u, err := c.addr.Parse(httptransport.UpdatesAPIPath)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (c HTTP) LatestUpdateOperations(ctx context.Context) (map[string]uuid.UUID,
 //
 // "Prev" may be passed uuid.Nil if the client's last known state has been
 // forgotten by the server.
-func (c HTTP) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error) {
+func (c *HTTP) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error) {
 	u, err := c.addr.Parse(path.Join(httptransport.UpdatesAPIPath, "diff"))
 	if err != nil {
 		return nil, err

--- a/httptransport/client/indexer.go
+++ b/httptransport/client/indexer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/quay/clair/v4/indexer"
 )
 
-var _ indexer.Service = (HTTP)(nil)
+var _ indexer.Service = (*HTTP)(nil)
 
 // Index receives a Manifest and returns a IndexReport providing the indexed
 // items in the resulting image.
@@ -23,7 +23,7 @@ var _ indexer.Service = (HTTP)(nil)
 // Index blocks until completion. An error is returned if the index operation
 // could not start. If an error occurs during the index operation the error will
 // be preset on the IndexReport.Err field of the returned IndexReport.
-func (s HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*claircore.IndexReport, error) {
+func (s *HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*claircore.IndexReport, error) {
 	buf := bytes.NewBuffer([]byte{})
 	err := json.NewEncoder(buf).Encode(manifest)
 	if err != nil {
@@ -57,7 +57,7 @@ func (s HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*clairco
 }
 
 // IndexReport retrieves a IndexReport given a manifest hash string
-func (s HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*claircore.IndexReport, bool, error) {
+func (s *HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*claircore.IndexReport, bool, error) {
 	u, err := s.addr.Parse(path.Join(httptransport.IndexReportAPIPath, manifest.String()))
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create request: %v", err)
@@ -87,7 +87,7 @@ func (s HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*clai
 	return ir, true, nil
 }
 
-func (s HTTP) State(ctx context.Context) (string, error) {
+func (s *HTTP) State(ctx context.Context) (string, error) {
 	u, err := s.addr.Parse(httptransport.StateAPIPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %v", err)


### PR DESCRIPTION
PR removes the need for a private and hidden implementation for a shareable HTTP client. 
This was self-documented as "weird" and I believe the original thought was it *needed* to remain private which is not the case. 