### PR TITLE
Louis/update ops api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/quay/claircore v0.0.24
+	github.com/quay/claircore v0.0.25
 	github.com/rs/zerolog v1.16.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/urfave/cli/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
+github.com/quay/claircore v0.0.25 h1:WcGJMAK5zeDscB/cjmSzHtehWun7NupF0cfdiCNBey4=
+github.com/quay/claircore v0.0.25/go.mod h1:ysm67dybuIT07tJWhmSGgqeWk2sug2DnNjGcesqVQpI=
 github.com/quay/goval-parser v0.8.1 h1:n5z8gtWHKEADljlnC6ySDZ+U+3cjAwYgVv9sMmIcGDM=
 github.com/quay/goval-parser v0.8.1/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,6 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/claircore v0.0.24 h1:cpugf8Q/BpESDkO9sJkWnk5buxyQ1FSCGObsXi4wdZc=
-github.com/quay/claircore v0.0.24/go.mod h1:ysm67dybuIT07tJWhmSGgqeWk2sug2DnNjGcesqVQpI=
 github.com/quay/goval-parser v0.8.1 h1:n5z8gtWHKEADljlnC6ySDZ+U+3cjAwYgVv9sMmIcGDM=
 github.com/quay/goval-parser v0.8.1/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=

--- a/httptransport/client/httpclient.go
+++ b/httptransport/client/httpclient.go
@@ -19,6 +19,32 @@ type uoCache struct {
 	uo        map[string][]driver.UpdateOperation
 }
 
+// Set persists the update operations map and it's associated
+// validator string used in conditional requests.
+//
+// It is safe for concurrent use.
+func (c *uoCache) Set(m map[string][]driver.UpdateOperation, v string) {
+	c.Lock()
+	defer c.Unlock()
+	c.uo = m
+	c.validator = v
+}
+
+// Copy returns a copy of the cache contents to the caller.
+//
+// It is safe for concurrent use.
+func (c *uoCache) Copy() map[string][]driver.UpdateOperation {
+	m := map[string][]driver.UpdateOperation{}
+	c.RLock()
+	defer c.RUnlock()
+	for u, ops := range c.uo {
+		o := make([]driver.UpdateOperation, len(ops), len(ops))
+		copy(o, ops)
+		m[u] = o
+	}
+	return m
+}
+
 func newOUCache() *uoCache {
 	return &uoCache{
 		RWMutex: sync.RWMutex{},

--- a/httptransport/client/indexer.go
+++ b/httptransport/client/indexer.go
@@ -88,7 +88,7 @@ func (s *HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*cla
 }
 
 func (s *HTTP) State(ctx context.Context) (string, error) {
-	u, err := s.addr.Parse(httptransport.StateAPIPath)
+	u, err := s.addr.Parse(httptransport.IndexStateAPIPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %v", err)
 	}

--- a/httptransport/indexreporthandler.go
+++ b/httptransport/indexreporthandler.go
@@ -12,18 +12,6 @@ import (
 	"github.com/quay/clair/v4/indexer"
 )
 
-// unmodified determines whether to return a conditonal response
-func unmodified(r *http.Request, v string) bool {
-	if vs, ok := r.Header["If-None-Match"]; ok {
-		for _, rv := range vs {
-			if rv == v {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // IndexReportHandler utilizes a Reporter to serialize
 // and return a claircore.IndexReport given a path parameter
 func IndexReportHandler(serv indexer.StateReporter) http.HandlerFunc {

--- a/httptransport/indexstatehandler.go
+++ b/httptransport/indexstatehandler.go
@@ -9,13 +9,13 @@ import (
 	"github.com/quay/clair/v4/indexer"
 )
 
-// StateHandler utilizes a Stater to report the
+// IndexStateHandler utilizes a Stater to report the
 // curent runtime state of an Indexer.
 //
 // Indexers running with different scanner versions
 // will produce unique states and indicate to clients
 // a re-index is necessary.
-func StateHandler(service indexer.Stater) http.HandlerFunc {
+func IndexStateHandler(service indexer.Stater) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/httptransport/server_test.go
+++ b/httptransport/server_test.go
@@ -28,8 +28,9 @@ func newTestMatcher() *testMatcher {
 		},
 		differ: differ{
 			delete:     func(context.Context, ...uuid.UUID) error { return nil },
-			latest:     func(context.Context) (uuid.UUID, error) { return uuid.Nil, nil },
-			latestOps:  func(context.Context) (map[string]uuid.UUID, error) { return nil, nil },
+			ops:        func(context.Context, ...string) (map[string][]driver.UpdateOperation, error) { return nil, nil },
+			latestOp:   func(context.Context) (uuid.UUID, error) { return uuid.Nil, nil },
+			latestOps:  func(context.Context) (map[string][]driver.UpdateOperation, error) { return nil, nil },
 			updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) { return nil, nil },
 		},
 	}
@@ -62,7 +63,7 @@ func TestUpdateEndpoints(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	u.Path = path.Join(u.Path, internalRoot, "updates", "")
+	u.Path = path.Join(u.Path, UpdateOperationAPIPath, "")
 	t.Log(u)
 
 	res, err := srv.Client().Get(u.String())

--- a/httptransport/updatediffhandler.go
+++ b/httptransport/updatediffhandler.go
@@ -26,23 +26,22 @@ func UpdateDiffHandler(serv matcher.Differ) http.HandlerFunc {
 		// prev param is optional.
 		var prev uuid.UUID
 		var err error
-		if param, ok := r.URL.Query()["prev"]; ok {
-			if len(param) != 0 {
-				prev, err = uuid.Parse(param[0])
-				if err != nil {
-					resp := &je.Response{
-						Code:    "bad-request",
-						Message: "could not parse \"prev\" query param into uuid",
-					}
-					je.Error(w, resp, http.StatusBadRequest)
-					return
+		if param := r.URL.Query().Get("prev"); param != "" {
+			prev, err = uuid.Parse(param)
+			if err != nil {
+				resp := &je.Response{
+					Code:    "bad-request",
+					Message: "could not parse \"prev\" query param into uuid",
 				}
+				je.Error(w, resp, http.StatusBadRequest)
+				return
 			}
 		}
+
 		// cur param is required
 		var cur uuid.UUID
-		param, ok := r.URL.Query()["cur"]
-		if !ok || len(param) == 0 {
+		var param string
+		if param = r.URL.Query().Get("cur"); param == "" {
 			resp := &je.Response{
 				Code:    "bad-request",
 				Message: "\"cur\" query param is required",
@@ -50,7 +49,7 @@ func UpdateDiffHandler(serv matcher.Differ) http.HandlerFunc {
 			je.Error(w, resp, http.StatusBadRequest)
 			return
 		}
-		if cur, err = uuid.Parse(param[0]); err != nil {
+		if cur, err = uuid.Parse(param); err != nil {
 			resp := &je.Response{
 				Code:    "bad-request",
 				Message: "could not parse \"cur\" query param into uuid",

--- a/httptransport/updatediffhandler_test.go
+++ b/httptransport/updatediffhandler_test.go
@@ -2,443 +2,224 @@ package httptransport
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/http/httputil"
 	"net/url"
-	"path"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/quay/claircore/libvuln/driver"
-
-	"github.com/quay/clair/v4/matcher"
 )
 
 // Differ implements matcher.Differ by calling the func members.
 type differ struct {
 	delete     func(context.Context, ...uuid.UUID) error
-	latest     func(context.Context) (uuid.UUID, error)
-	latestOps  func(context.Context) (map[string]uuid.UUID, error)
+	ops        func(context.Context, ...string) (map[string][]driver.UpdateOperation, error)
+	latestOp   func(context.Context) (uuid.UUID, error)
+	latestOps  func(context.Context) (map[string][]driver.UpdateOperation, error)
 	updateDiff func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error)
 }
 
-func (d *differ) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) error {
-	return d.delete(ctx, ref...)
+// DeleteUpdateOperations marks the provided refs as seen and processed.
+func (d *differ) DeleteUpdateOperations(ctx context.Context, refs ...uuid.UUID) error {
+	return d.delete(ctx, refs...)
 }
-func (d *differ) LatestUpdateOperation(ctx context.Context) (uuid.UUID, error) {
-	return d.latest(ctx)
-}
-func (d *differ) LatestUpdateOperations(ctx context.Context) (map[string]uuid.UUID, error) {
-	return d.latestOps(ctx)
-}
-func (d *differ) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error) {
+
+// UpdateDiff reports the differences between the provided refs.
+//
+// "Prev" can be `uuid.Nil` to indicate "earliest known ref."
+func (d *differ) UpdateDiff(ctx context.Context, prev uuid.UUID, cur uuid.UUID) (*driver.UpdateDiff, error) {
 	return d.updateDiff(ctx, prev, cur)
 }
 
-var _ matcher.Differ = (*differ)(nil)
+// UpdateOperations returns all the known UpdateOperations per updater.
+func (d *differ) UpdateOperations(ctx context.Context, updaters ...string) (map[string][]driver.UpdateOperation, error) {
+	return d.ops(ctx, updaters...)
+}
 
-// TestUpdateHandler exercises all the call paths of the UpdateDiffHandler.
-func TestUpdateHandler(t *testing.T) {
-	t.Run("Errors", func(t *testing.T) {
-		t.Parallel()
-		errExpected := errors.New("expected error")
-		h, err := UpdateDiffHandler(&differ{
-			delete: func(context.Context, ...uuid.UUID) error {
-				return errExpected
-			},
-			latest: func(context.Context) (uuid.UUID, error) {
-				return uuid.Nil, errExpected
-			},
-			latestOps: func(context.Context) (map[string]uuid.UUID, error) {
-				return nil, errExpected
-			},
-			updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) {
-				return nil, errExpected
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		srv := httptest.NewServer(h)
-		defer srv.Close()
-		c := srv.Client()
-		srv.URL += UpdatesAPIPath
+// LatestUpdateOperations returns the most recent UpdateOperation per updater.
+func (d *differ) LatestUpdateOperations(ctx context.Context) (map[string][]driver.UpdateOperation, error) {
+	return d.latestOps(ctx)
+}
 
-		t.Run("BadMethod", func(t *testing.T) {
-			methodInner := func(t *testing.T, m string, u *url.URL) {
-				req, err := http.NewRequest(m, u.String(), nil)
-				if err != nil {
-					t.Error(err)
-					return
-				}
-				dump, err := httputil.DumpRequestOut(req, false)
-				if err != nil {
-					t.Error(err)
-				}
-				t.Logf("%s", dump)
-				res, err := c.Do(req)
-				if res != nil {
-					defer res.Body.Close()
-				}
-				if err != nil {
-					t.Error(err)
-					return
-				}
-				got, want := res.StatusCode, http.StatusMethodNotAllowed
-				if got != want {
-					t.Errorf("got: %v, want: %v", got, want)
-				}
-				dump, err = httputil.DumpResponse(res, true)
-				if err != nil {
-					t.Error(err)
-				}
-				t.Logf("%s", dump)
-			}
-			t.Run(".", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, "/")
-				t.Log(u)
-				for _, m := range []string{
-					http.MethodConnect,
-					http.MethodDelete,
-					http.MethodHead,
-					http.MethodOptions,
-					http.MethodPatch,
-					http.MethodPost,
-					http.MethodPut,
-					http.MethodTrace,
-				} {
-					methodInner(t, m, u)
-				}
-			})
+// LatestUpdateOperation returns a ref for the most recent update operation
+// across all updaters.
+func (d *differ) LatestUpdateOperation(ctx context.Context) (uuid.UUID, error) {
+	return d.latestOp(ctx)
+}
 
-			ref := uuid.Nil.String()
-			t.Run(ref, func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, ref)
-				t.Log(u)
-				for _, m := range []string{
-					http.MethodConnect,
-					http.MethodGet,
-					http.MethodHead,
-					http.MethodOptions,
-					http.MethodPatch,
-					http.MethodPost,
-					http.MethodPut,
-					http.MethodTrace,
-				} {
-					methodInner(t, m, u)
-				}
-			})
+// TestUpdateDiffHandler is a parallel harness for testing a UpdateDiff handler.
+func TestUpdateDiffHandler(t *testing.T) {
+	t.Run("Matcher", testUpdateDiffMatcher)
+	t.Run("Params", testUpdateDiffHandlerParams)
+	t.Run("Methods", testUpdateDiffHandlerMethods)
+}
 
-			t.Run("diff", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, "diff")
-				t.Log(u)
-				for _, m := range []string{
-					http.MethodConnect,
-					http.MethodDelete,
-					http.MethodHead,
-					http.MethodOptions,
-					http.MethodPatch,
-					http.MethodPost,
-					http.MethodPut,
-					http.MethodTrace,
-				} {
-					methodInner(t, m, u)
-				}
-			})
-		})
-
-		t.Run("MalformedRequest", func(t *testing.T) {
-			reqInner := func(u string) func(*testing.T) {
-				return func(t *testing.T) {
-					t.Parallel()
-					req, err := http.NewRequest(http.MethodGet, u, nil)
-					if err != nil {
-						t.Error(err)
-						return
-					}
-					res, err := c.Do(req)
-					if res != nil {
-						defer res.Body.Close()
-					}
-					if err != nil {
-						t.Error(err)
-						return
-					}
-					got, want := res.StatusCode, http.StatusBadRequest
-					if got != want {
-						t.Errorf("got: %v, want: %v", got, want)
-					}
-				}
-			}
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			u.Path = path.Join(u.Path, "diff")
-			t.Log(u)
-
-			t.Run("missing cur", reqInner(u.String()))
-			u.RawQuery = (url.Values{"cur": {"12"}}).Encode()
-			t.Run("bad cur", reqInner(u.String()))
-			u.RawQuery = (url.Values{
-				"cur":  {uuid.Nil.String()},
-				"prev": {"12"},
-			}).Encode()
-			t.Run("bad prev", reqInner(u.String()))
-		})
-
-		t.Run("Expected", func(t *testing.T) {
-			ref := uuid.Nil.String()
-			t.Run("404", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, "/nonexistent")
-				t.Log(u)
-				res, err := c.Get(u.String())
-				if res != nil {
-					t.Log(res.Status)
-					defer res.Body.Close()
-				}
-				if err != nil {
-					t.Error(err)
-				}
-				if got, want := res.StatusCode, http.StatusNotFound; got != want {
-					t.Errorf("got: %v, want: %v", got, want)
-				}
-			})
-			t.Run(".", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, "/")
-				t.Log(u)
-				res, err := c.Get(u.String())
-				if res != nil {
-					t.Log(res.Status)
-					defer res.Body.Close()
-				}
-				if err != nil {
-					t.Error(err)
-				}
-				if got, want := res.StatusCode, http.StatusInternalServerError; got != want {
-					t.Errorf("got: %v, want: %v", got, want)
-				}
-			})
-			t.Run("diff", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, "diff")
-				u.RawQuery = (url.Values{
-					"prev": {ref},
-					"cur":  {ref},
-				}).Encode()
-				t.Log(u)
-				res, err := c.Get(u.String())
-				if res != nil {
-					t.Log(res.Status)
-					defer res.Body.Close()
-				}
-				if err != nil {
-					t.Error(err)
-				}
-				if got, want := res.StatusCode, http.StatusInternalServerError; got != want {
-					t.Errorf("got: %v, want: %v", got, want)
-				}
-			})
-			t.Run("delete", func(t *testing.T) {
-				t.Parallel()
-				u, err := url.Parse(srv.URL)
-				if err != nil {
-					t.Fatal(err)
-				}
-				u.Path = path.Join(u.Path, ref)
-				t.Log(u)
-				req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
-				if err != nil {
-					t.Fatal(err)
-				}
-				res, err := c.Do(req)
-				if res != nil {
-					t.Log(res.Status)
-					defer res.Body.Close()
-				}
-				if err != nil {
-					t.Error(err)
-				}
-				if got, want := res.StatusCode, http.StatusInternalServerError; got != want {
-					t.Errorf("got: %v, want: %v", got, want)
-				}
-			})
-		})
+// TestUpdateDiffMatcher confirms the UpdateDiff handler provides
+// the correct status codes when a matcher returns an error or success
+func testUpdateDiffMatcher(t *testing.T) {
+	t.Parallel()
+	hOK := UpdateDiffHandler(&differ{
+		updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) { return nil, nil },
 	})
-
-	t.Run("OK", func(t *testing.T) {
-		t.Parallel()
-		errUnexpected := errors.New("unexpected error")
-		deleteRef, curRef := uuid.New(), uuid.New()
-		diff := &driver.UpdateDiff{}
-		const updaterKey = `bogus`
-		h, err := UpdateDiffHandler(&differ{
-			delete: func(_ context.Context, refs ...uuid.UUID) error {
-				if len(refs) == 1 && refs[0].String() == deleteRef.String() {
-					return nil
-				}
-				return errUnexpected
-			},
-			latest: func(context.Context) (uuid.UUID, error) {
-				return curRef, nil
-			},
-			latestOps: func(context.Context) (map[string]uuid.UUID, error) {
-				return map[string]uuid.UUID{updaterKey: curRef}, nil
-			},
-			updateDiff: func(_ context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error) {
-				if prev.String() == uuid.Nil.String() && cur.String() == curRef.String() {
-					return diff, nil
-				}
-				return nil, errUnexpected
-			},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		srv := httptest.NewServer(h)
-		defer srv.Close()
-		c := srv.Client()
-		srv.URL += UpdatesAPIPath
-
-		t.Run("delete", func(t *testing.T) {
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			u.Path = path.Join(u.Path, deleteRef.String())
-			t.Log(u)
-			req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			res, err := c.Do(req)
-			if res != nil {
-				t.Log(res.Status)
-				defer res.Body.Close()
-			}
-			if err != nil {
-				t.Error(err)
-			}
-			if got, want := res.StatusCode, http.StatusOK; got != want {
-				t.Errorf("got: %v, want: %v", got, want)
-			}
-		})
-		t.Run("diff", func(t *testing.T) {
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			u.Path = path.Join(u.Path, "diff")
-			u.RawQuery = (url.Values{"cur": {curRef.String()}}).Encode()
-			t.Log(u)
-			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			res, err := c.Do(req)
-			if res != nil {
-				t.Log(res.Status)
-				defer res.Body.Close()
-			}
-			if err != nil {
-				t.Error(err)
-			}
-			if got, want := res.StatusCode, http.StatusOK; got != want {
-				t.Errorf("got: %v, want: %v", got, want)
-			}
-		})
-		t.Run(".", func(t *testing.T) {
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			u.Path = path.Join(u.Path, "/")
-			t.Log(u)
-			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			res, err := c.Do(req)
-			if res != nil {
-				t.Log(res.Status)
-				defer res.Body.Close()
-			}
-			if err != nil {
-				t.Error(err)
-			}
-			if got, want := res.StatusCode, http.StatusOK; got != want {
-				t.Errorf("got: %v, want: %v", got, want)
-			}
-			latest := make(map[string]uuid.UUID)
-			if err := json.NewDecoder(res.Body).Decode(&latest); err != nil {
-				t.Error(err)
-			}
-			ref, ok := latest[updaterKey]
-			if !ok {
-				t.Errorf("key %q not present", updaterKey)
-			}
-			if got, want := ref.String(), curRef.String(); got != want {
-				t.Errorf("got: %v, want: %v", got, want)
-			}
-		})
-		t.Run("NotModified", func(t *testing.T) {
-			u, err := url.Parse(srv.URL)
-			if err != nil {
-				t.Fatal(err)
-			}
-			u.Path = path.Join(u.Path, "/")
-			t.Log(u)
-			req, err := http.NewRequest(http.MethodGet, u.String(), nil)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// We happen to know how the validator is constructed, so just
-			// cheat and create it.
-			req.Header.Add("If-None-Match", fmt.Sprintf(`"%s"`, curRef.String()))
-			res, err := c.Do(req)
-			if res != nil {
-				t.Log(res.Status)
-				defer res.Body.Close()
-			}
-			if err != nil {
-				t.Error(err)
-			}
-			if got, want := res.StatusCode, http.StatusNotModified; got != want {
-				t.Errorf("got: %v, want: %v", got, want)
-			}
-		})
+	hErr := UpdateDiffHandler(&differ{
+		updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) {
+			return nil, fmt.Errorf("expected error")
+		},
 	})
+	srvOK := httptest.NewServer(hOK)
+	srvErr := httptest.NewServer(hErr)
+	defer srvOK.Close()
+	defer srvErr.Close()
+	cOK := srvOK.Client()
+	cErr := srvErr.Client()
+
+	// test matcher returns nil error
+	url, err := url.Parse(srvOK.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL into *net/URL")
+	}
+	q := url.Query()
+	q.Set("cur", "892737b2-a616-4113-a7a9-137139c8f91e")
+	url.RawQuery = q.Encode()
+
+	req := &http.Request{
+		URL:    url,
+		Method: http.MethodGet,
+	}
+	resp, err := cOK.Do(req)
+	if err != nil {
+		t.Fatalf("failed to do request: %v", err)
+	}
+	got, want := resp.StatusCode, http.StatusOK
+	if got != want {
+		t.Fatalf("got: %v, want: %v", got, want)
+	}
+
+	// test matcher returns error
+	url, err = url.Parse(srvErr.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL into *net/URL")
+	}
+	q = url.Query()
+	q.Set("cur", "892737b2-a616-4113-a7a9-137139c8f91e")
+	url.RawQuery = q.Encode()
+
+	req = &http.Request{
+		URL:    url,
+		Method: http.MethodGet,
+	}
+	resp, err = cErr.Do(req)
+	if err != nil {
+		t.Fatalf("failed to do request: %v", err)
+	}
+	got, want = resp.StatusCode, http.StatusInternalServerError
+	if got != want {
+		t.Fatalf("got: %v, want: %v", got, want)
+	}
+}
+
+// TestUpdateDiffHandlerParams confirms the UpdateDiff handler
+// returns correct status codes given a set or url parameters
+func testUpdateDiffHandlerParams(t *testing.T) {
+	t.Parallel()
+	table := []struct {
+		name       string
+		cur        string
+		prev       string
+		statusCode int
+	}{
+		{
+			name:       "no params",
+			cur:        "",
+			prev:       "",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "missing prev",
+			cur:        "892737b2-a616-4113-a7a9-137139c8f91e",
+			prev:       "",
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "missing cur",
+			cur:        "",
+			prev:       "892737b2-a616-4113-a7a9-137139c8f91e",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "all params",
+			cur:        "6ea97b35-d886-4845-8ba2-5a4b0a074bfe",
+			prev:       "892737b2-a616-4113-a7a9-137139c8f91e",
+			statusCode: http.StatusOK,
+		},
+	}
+
+	h := UpdateDiffHandler(&differ{
+		updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) { return nil, nil },
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL into *net/URL")
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			q := u.Query()
+			q.Set("cur", test.cur)
+			q.Set("prev", test.cur)
+			u.RawQuery = q.Encode()
+
+			req := &http.Request{
+				URL:    u,
+				Method: http.MethodGet,
+			}
+			resp, err := c.Do(req)
+			if err != nil {
+				t.Fatalf("failed to do request: %v", err)
+			}
+			got, want := resp.StatusCode, test.statusCode
+			if got != want {
+				t.Fatalf("got: %v, want: %v", got, want)
+			}
+		})
+	}
+}
+
+// TestUpdateDiffHandlerMethods confirms the UpdateDiffHandler responds correctly
+// to unaccepted HTTP methods.
+func testUpdateDiffHandlerMethods(t *testing.T) {
+	t.Parallel()
+	h := UpdateDiffHandler(&differ{
+		updateDiff: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) { return nil, nil },
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	for _, m := range []string{
+		http.MethodConnect,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace,
+	} {
+		req, err := http.NewRequest(m, srv.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		resp, err := c.Do(req)
+		if err != nil {
+			t.Fatalf("failed to make request: %v", err)
+		}
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("method: %v got: %v want: %v", m, resp.Status, http.StatusMethodNotAllowed)
+		}
+	}
 }

--- a/httptransport/updateoperationhandler.go
+++ b/httptransport/updateoperationhandler.go
@@ -59,8 +59,7 @@ func (h *UOHandler) Get(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	// handle conditional request. this is an optimization
 	if ref, err := h.serv.LatestUpdateOperation(ctx); err == nil {
-		var validator string
-		validator = `"` + ref.String() + `"`
+		validator := `"` + ref.String() + `"`
 		if unmodified(r, validator) {
 			w.WriteHeader(http.StatusNotModified)
 			return
@@ -68,12 +67,7 @@ func (h *UOHandler) Get(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("etag", validator)
 	}
 
-	var latest string
-	if param, ok := r.URL.Query()["latest"]; ok {
-		if len(param) != 0 {
-			latest = param[0]
-		}
-	}
+	latest := r.URL.Query().Get("latest")
 
 	var uos map[string][]driver.UpdateOperation
 	var err error

--- a/httptransport/updateoperationhandler.go
+++ b/httptransport/updateoperationhandler.go
@@ -1,0 +1,126 @@
+package httptransport
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/quay/clair/v4/matcher"
+	"github.com/quay/claircore/libvuln/driver"
+	je "github.com/quay/claircore/pkg/jsonerr"
+	"github.com/rs/zerolog"
+)
+
+var _ http.Handler = (*UOHandler)(nil)
+
+// UOHandler implements http.Handler and provides http.HandlerFunc(s)
+// for GET and DELETE operations.
+type UOHandler struct {
+	serv matcher.Differ
+}
+
+// UpdateOperationHandler creates a new UOHandler
+func UpdateOperationHandler(serv matcher.Differ) *UOHandler {
+	return &UOHandler{
+		serv: serv,
+	}
+}
+
+// ServeHTTP provides GET and DELETE operations for UpdateOperation models.
+//
+// Implements http.Handler interface and may also be used as a http.HandlerFunc
+func (h *UOHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.Get(w, r)
+	case http.MethodDelete:
+		h.Delete(w, r)
+	default:
+		resp := &je.Response{
+			Code:    "method-not-allowed",
+			Message: "endpoint only allows POST",
+		}
+		je.Error(w, resp, http.StatusMethodNotAllowed)
+		return
+	}
+}
+
+// Get retrieves UpdateOperation models.
+//
+// Supports conditional requests by providing the newest UpdateOperation as
+// an etag.
+
+// Clients may provide an 'If-None-Match' header with the etag value to receive
+// a StatusNotModified when no new UpdateOperations have been created.
+func (h *UOHandler) Get(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	// handle conditional request. this is an optimization
+	if ref, err := h.serv.LatestUpdateOperation(ctx); err == nil {
+		var validator string
+		validator = `"` + ref.String() + `"`
+		if unmodified(r, validator) {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("etag", validator)
+	}
+
+	var latest string
+	if param, ok := r.URL.Query()["latest"]; ok {
+		if len(param) != 0 {
+			latest = param[0]
+		}
+	}
+
+	var uos map[string][]driver.UpdateOperation
+	var err error
+	if b, _ := strconv.ParseBool(latest); b {
+		uos, err = h.serv.LatestUpdateOperations(ctx)
+	} else {
+		uos, err = h.serv.UpdateOperations(ctx)
+	}
+	if err != nil {
+		resp := &je.Response{
+			Code:    "internal server error",
+			Message: fmt.Sprintf("could not get update operations: %v", err),
+		}
+		je.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
+
+	defer writerError(w, &err)()
+	err = json.NewEncoder(w).Encode(&uos)
+	return
+}
+
+// Delete removes an UpdateOperation models from the system.
+func (h *UOHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := zerolog.Ctx(ctx)
+	path := r.URL.Path
+	id := filepath.Base(path)
+	uuid, err := uuid.Parse(id)
+	if err != nil {
+		resp := &je.Response{
+			Code:    "bad-request",
+			Message: fmt.Sprintf("could not deserialize manifest: %v", err),
+		}
+		log.Warn().Err(err).Msg("could not deserialize manifest")
+		je.Error(w, resp, http.StatusBadRequest)
+		return
+	}
+
+	err = h.serv.DeleteUpdateOperations(ctx, uuid)
+	if err != nil {
+		resp := &je.Response{
+			Code:    "internal server error",
+			Message: fmt.Sprintf("could not get update operations: %v", err),
+		}
+		je.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
+	return
+}

--- a/httptransport/updateoperationhandler_test.go
+++ b/httptransport/updateoperationhandler_test.go
@@ -1,0 +1,204 @@
+package httptransport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/quay/claircore/libvuln/driver"
+)
+
+// TestUpdateOperationHandler is a parallel harness for testing a UpdateOperation handler.
+func TestUpdateOperationHandler(t *testing.T) {
+	t.Run("Methods", testUpdateOperationHandlerMethods)
+	t.Run("Get", testUpdateOperationHandlerGet)
+	t.Run("Delete", testUpdateOperationHandlerGet)
+	t.Run("Errors", testUpdateOperationHandlerErrors)
+}
+
+// testUpdateOperationHandlerErrors confirms the handler perfoms the correct
+// actions when a matcher.Differ is failing.
+func testUpdateOperationHandlerErrors(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New().String()
+	var ErrExpected error = fmt.Errorf("expected error")
+	h := UpdateOperationHandler(&differ{
+		delete: func(context.Context, ...uuid.UUID) error { return ErrExpected },
+		// this will not immediately faile the handler
+		latestOp: func(context.Context) (uuid.UUID, error) {
+			return uuid.Nil, ErrExpected
+		},
+		latestOps: func(context.Context) (map[string][]driver.UpdateOperation, error) {
+			return nil, ErrExpected
+		},
+		ops: func(context.Context, ...string) (map[string][]driver.UpdateOperation, error) {
+			return nil, ErrExpected
+		},
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	// perform get with failing differ
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("got: %v, want: %v", resp.StatusCode, http.StatusInternalServerError)
+	}
+
+	// perform delete with failing differ
+	u := srv.URL + "/" + id
+	req, err = http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err = c.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("got: %v, want: %v", resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// testUpdateOperationHandlerMethods confirms the handler only responds
+// to the desired methods.
+func testUpdateOperationHandlerMethods(t *testing.T) {
+	t.Parallel()
+	h := UpdateOperationHandler(&differ{})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	for _, m := range []string{
+		http.MethodConnect,
+		http.MethodHead,
+		http.MethodOptions,
+		http.MethodPatch,
+		http.MethodPost,
+		http.MethodPut,
+		http.MethodTrace,
+	} {
+		req, err := http.NewRequest(m, srv.URL, nil)
+		if err != nil {
+			t.Fatalf("failed to create request: %v", err)
+		}
+		resp, err := c.Do(req)
+		if err != nil {
+			t.Fatalf("failed to make request: %v", err)
+		}
+		if resp.StatusCode != http.StatusMethodNotAllowed {
+			t.Fatalf("method: %v got: %v want: %v", m, resp.Status, http.StatusMethodNotAllowed)
+		}
+	}
+}
+
+// testUpdateOperationDelete confirms the handler performs the correct
+// actions on Delete.
+func testUpdateOperationDelete(t *testing.T) {
+	t.Parallel()
+
+	h := UpdateOperationHandler(&differ{
+		delete: func(context.Context, ...uuid.UUID) error { return nil },
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	id := uuid.New().String()
+	u := srv.URL + "/" + id
+	req, err := http.NewRequest(http.MethodDelete, u, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("failed to do request: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got: %v, want: %v", resp.StatusCode, http.StatusOK)
+	}
+}
+
+// testUpdateOperationHandlerGet confirms the handler performs the correct
+// actions on GET.
+func testUpdateOperationHandlerGet(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+	idStr := "\"" + id.String() + "\""
+	var called bool
+	var latestCalled bool
+	h := UpdateOperationHandler(&differ{
+		latestOp: func(context.Context) (uuid.UUID, error) {
+			return id, nil
+		},
+		latestOps: func(context.Context) (map[string][]driver.UpdateOperation, error) {
+			latestCalled = true
+			return nil, nil
+		},
+		ops: func(context.Context, ...string) (map[string][]driver.UpdateOperation, error) {
+			called = true
+			return nil, nil
+		},
+	})
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	// get without latest param
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got: %v, want: %v", resp.StatusCode, http.StatusOK)
+	}
+	if !called {
+		t.Fatalf("got: %v, want: %v", called, true)
+	}
+	etag := resp.Header.Get("etag")
+	if etag != idStr {
+		t.Fatalf("got: %v, want: %v", etag, id.String())
+	}
+
+	// get with latest param
+	u, _ := url.Parse(srv.URL)
+	q := u.Query()
+	q.Add("latest", "true")
+	u.RawQuery = q.Encode()
+	req = &http.Request{
+		URL:    u,
+		Method: http.MethodGet,
+	}
+	resp, err = c.Do(req)
+	if err != nil {
+		t.Fatalf("failed to make request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got: %v, want: %v", resp.StatusCode, http.StatusOK)
+	}
+	if !latestCalled {
+		t.Fatalf("got: %v, want: %v", latestCalled, true)
+	}
+	etag = resp.Header.Get("etag")
+	if etag != idStr {
+		t.Fatalf("got: %v, want: %v", etag, id.String())
+	}
+}

--- a/matcher/service.go
+++ b/matcher/service.go
@@ -23,8 +23,6 @@ type Scanner interface {
 }
 
 // Differ is an interface providing information on update operations.
-//
-// All operations are done via "ref", which is a UUID.
 type Differ interface {
 	// DeleteUpdateOperations marks the provided refs as seen and processed.
 	DeleteUpdateOperations(context.Context, ...uuid.UUID) error
@@ -32,9 +30,10 @@ type Differ interface {
 	//
 	// "Prev" can be `uuid.Nil` to indicate "earliest known ref."
 	UpdateDiff(_ context.Context, prev, cur uuid.UUID) (*driver.UpdateDiff, error)
-	// LatestUpdateOperations returns a ref for the most recent update operation
-	// per updater.
-	LatestUpdateOperations(context.Context) (map[string]uuid.UUID, error)
+	// UpdateOperations returns all the known UpdateOperations per updater.
+	UpdateOperations(context.Context, ...string) (map[string][]driver.UpdateOperation, error)
+	// LatestUpdateOperations returns the most recent UpdateOperation per updater.
+	LatestUpdateOperations(context.Context) (map[string][]driver.UpdateOperation, error)
 	// LatestUpdateOperation returns a ref for the most recent update operation
 	// across all updaters.
 	LatestUpdateOperation(context.Context) (uuid.UUID, error)


### PR DESCRIPTION
This PR bumps claircore to v0.0.25, plumbs the updated Updates api into ClairV4, and addresses some usability issues with the client. 