### PR TITLE
JSON Struct Tags for Config 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,16 +31,16 @@ type Config struct {
 	// "indexer": runs just the indexer node
 	// "matcher": runs just the matcher node
 	// "combo":	will run both indexer and matcher on the same node.
-	Mode string `yaml:"-"`
+	Mode string `yaml:"-" json:"-"`
 	// A string in <host>:<port> format where <host> can be an empty string.
 	//
 	// exposes Clair node's functionality to the network.
 	// see /openapi/v1 for api spec.
-	HTTPListenAddr string `yaml:"http_listen_addr"`
+	HTTPListenAddr string `yaml:"http_listen_addr" json:"http_listen_addr"`
 	// A string in <host>:<port> format where <host> can be an empty string.
 	//
 	// exposes Clair's metrics and health endpoints.
-	IntrospectionAddr string `yaml:"introspection_addr"`
+	IntrospectionAddr string `yaml:"introspection_addr" json:"introspection_addr"`
 	// Set the logging level.
 	//
 	// One of the following strings:
@@ -51,14 +51,14 @@ type Config struct {
 	// "error"
 	// "fatal"
 	// "panic"
-	LogLevel string `yaml:"log_level"`
+	LogLevel string `yaml:"log_level" json:"log_level"`
 	// See Indexer for details
-	Indexer Indexer `yaml:"indexer"`
+	Indexer Indexer `yaml:"indexer" json:"indexer"`
 	// See Matcher for details
-	Matcher Matcher `yaml:"matcher"`
-	Auth    Auth    `yaml:"auth"`
-	Trace   Trace   `yaml:"trace"`
-	Metrics Metrics `yaml:"metrics"`
+	Matcher Matcher `yaml:"matcher" json:"matcher"`
+	Auth    Auth    `yaml:"auth" json:"auth"`
+	Trace   Trace   `yaml:"trace" json:"trace"`
+	Metrics Metrics `yaml:"metrics" json:"metrics"`
 }
 
 // Indexer provides Clair Indexer node configuration
@@ -69,24 +69,24 @@ type Indexer struct {
 	// url: "postgres://pqgotest:password@localhost/pqgotest?sslmode=verify-full"
 	// or
 	// string: "user=pqgotest dbname=pqgotest sslmode=verify-full"
-	ConnString string `yaml:"connstring"`
+	ConnString string `yaml:"connstring" json:"connstring"`
 	// A positive value representing seconds.
 	//
 	// Concurrent Indexers lock on manifest scans to avoid clobbering.
 	// This value tunes how often a waiting Indexer will poll for the lock.
 	// TODO: Move to async operating mode
-	ScanLockRetry int `yaml:"scanlock_retry"`
+	ScanLockRetry int `yaml:"scanlock_retry" json:"scanlock_retry"`
 	// A positive values represeting quantity.
 	//
 	// Indexers will index a Manifest's layers concurrently.
 	// This value tunes the number of layers an Indexer will scan in parallel.
-	LayerScanConcurrency int `yaml:"layer_scan_concurrency"`
+	LayerScanConcurrency int `yaml:"layer_scan_concurrency" json:"layer_scan_concurrency"`
 	// A "true" or "false" value
 	//
 	// Whether Indexer nodes handle migrations to their database.
-	Migrations bool `yaml:"migrations"`
+	Migrations bool `yaml:"migrations" json:"migrations"`
 	// Scanner allows for passing configuration options to layer scanners.
-	Scanner map[string]yaml.Node `yaml:"scanner"`
+	Scanner map[string]yaml.Node `yaml:"scanner" json:"scanner"`
 }
 
 type Matcher struct {
@@ -96,22 +96,22 @@ type Matcher struct {
 	// url: "postgres://pqgotest:password@localhost/pqgotest?sslmode=verify-full"
 	// or
 	// string: "user=pqgotest dbname=pqgotest sslmode=verify-full"
-	ConnString string `yaml:"connstring"`
+	ConnString string `yaml:"connstring" json:"connstring"`
 	// A positive integer
 	//
 	// Clair allows for a custom connection pool size.
 	// This number will directly set how many active sql
 	// connections are allowed concurrently.
-	MaxConnPool int `yaml:"max_conn_pool"`
+	MaxConnPool int `yaml:"max_conn_pool" json:"max_conn_pool"`
 	// A string in <host>:<port> format where <host> can be an empty string.
 	//
 	// A Matcher contacts an Indexer to create a VulnerabilityReport.
 	// The location of this Indexer is required.
-	IndexerAddr string `yaml:"indexer_addr"`
+	IndexerAddr string `yaml:"indexer_addr" json:"indexer_addr"`
 	// A "true" or "false" value
 	//
 	// Whether Matcher nodes handle migrations to their databases.
-	Migrations bool `yaml:"migrations"`
+	Migrations bool `yaml:"migrations" json:"migrations"`
 	// A slice of strings representing which
 	// updaters matcher will create.
 	//
@@ -127,7 +127,7 @@ type Matcher struct {
 	// "rhel"
 	// "suse"
 	// "ubuntu"
-	UpdaterSets []string `yaml:"updater_sets"`
+	UpdaterSets []string `yaml:"updater_sets" json:"updater_sets"`
 }
 
 // Auth holds the specific configs for different authentication methods.
@@ -135,8 +135,8 @@ type Matcher struct {
 // These should be pointers to structs, so that it's possible to distinguish
 // between "absent" and "present and misconfigured."
 type Auth struct {
-	PSK       *AuthPSK       `yaml:"psk,omitempty"`
-	Keyserver *AuthKeyserver `yaml:"keyserver,omitempty"`
+	PSK       *AuthPSK       `yaml:"psk,omitempty" json:"psk,omitempty"`
+	Keyserver *AuthKeyserver `yaml:"keyserver,omitempty" json:"keyserver,omitempty"`
 }
 
 // Any reports whether any sort of authentication is configured.
@@ -151,15 +151,15 @@ func (a Auth) Any() bool {
 // The "Intraservice" key is only needed when the overall config mode is not
 // "combo".
 type AuthKeyserver struct {
-	API          string `yaml:"api"`
-	Intraservice []byte `yaml:"intraservice"`
+	API          string `yaml:"api" json:"api"`
+	Intraservice []byte `yaml:"intraservice" json:"intraservice"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
 	var m struct {
-		API          string `yaml:"api"`
-		Intraservice string `yaml:"intraservice"`
+		API          string `yaml:"api" json:"api"`
+		Intraservice string `yaml:"intraservice" json:"intraservice"`
 	}
 	if err := f(&m); err != nil {
 		return nil
@@ -177,15 +177,15 @@ func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
 //
 // The "Issuer" key is what the service expects to verify as the "issuer claim.
 type AuthPSK struct {
-	Key    []byte `yaml:"key"`
-	Issuer string `yaml:"iss"`
+	Key    []byte `yaml:"key" json:"key"`
+	Issuer string `yaml:"iss" json:"iss"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
 	var m struct {
-		Issuer string `yaml:"iss"`
-		Key    string `yaml:"key"`
+		Issuer string `yaml:"iss" json:"iss"`
+		Key    string `yaml:"key" json:"key"`
 	}
 	if err := f(&m); err != nil {
 		return nil
@@ -200,37 +200,37 @@ func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
 }
 
 type Trace struct {
-	Name        string   `yaml:"name"`
-	Probability *float64 `yaml:"probability"`
-	Jaeger      Jaeger   `yaml:"jaeger"`
+	Name        string   `yaml:"name" json:"name"`
+	Probability *float64 `yaml:"probability" json:"probability"`
+	Jaeger      Jaeger   `yaml:"jaeger" json:"jaeger"`
 }
 
 type Jaeger struct {
 	Agent struct {
-		Endpoint string `yaml:"agent_endpoint"`
-	} `yaml:",inline"`
+		Endpoint string `yaml:"agent_endpoint" json:"agent_endpoint"`
+	} `yaml:",inline" json:",inline"`
 	Collector struct {
-		Endpoint string  `yaml:"collector_endpoint"`
-		Username *string `yaml:"username"`
-		Password *string `yaml:"password"`
-	} `yaml:",inline"`
-	ServiceName string            `yaml:"service_name"`
-	Tags        map[string]string `yaml:"tags"`
-	BufferMax   int               `yaml:"buffer_max"`
+		Endpoint string  `yaml:"collector_endpoint" json:"collector_endpoint"`
+		Username *string `yaml:"username" json:"username"`
+		Password *string `yaml:"password" json:"password"`
+	} `yaml:",inline" json:",inline"`
+	ServiceName string            `yaml:"service_name" json:"service_name"`
+	Tags        map[string]string `yaml:"tags" json:"tags"`
+	BufferMax   int               `yaml:"buffer_max" json:"buffer_max"`
 }
 
 type Metrics struct {
-	Name       string     `yaml:"name"`
-	Prometheus Prometheus `yaml:"prometheus"`
-	Dogstatsd  Dogstatsd  `yaml:"dogstatsd"`
+	Name       string     `yaml:"name" json:"name"`
+	Prometheus Prometheus `yaml:"prometheus" json:"prometheus"`
+	Dogstatsd  Dogstatsd  `yaml:"dogstatsd" json:"dogstatsd"`
 }
 
 type Prometheus struct {
-	Endpoint *string `yaml:"endpoint"`
+	Endpoint *string `yaml:"endpoint" json:"endpoint"`
 }
 
 type Dogstatsd struct {
-	URL string `yaml:"url"`
+	URL string `yaml:"url" json:"url"`
 }
 
 // Validate confirms the required config values are present


### PR DESCRIPTION
### Description

Adds `json:` struct tags in addition to `yaml:` ones for parsers which require them (`sigs.k8s.io/yaml`).

Needed for https://issues.redhat.com/browse/PROJQUAY-871