### PR TITLE
Initial implementation of fix for alpine vuln source

### DIFF
--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -17,25 +17,32 @@
 package alpine
 
 import (
+	"gopkg.in/yaml.v2"
 	"io"
 	"os"
 	"path/filepath"
-
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"github.com/quay/clair/v3/database"
 	"github.com/quay/clair/v3/ext/versionfmt"
 	"github.com/quay/clair/v3/ext/versionfmt/dpkg"
 	"github.com/quay/clair/v3/ext/vulnsrc"
 	"github.com/quay/clair/v3/pkg/fsutil"
-	"github.com/quay/clair/v3/pkg/gitutil"
+	log "github.com/sirupsen/logrus"
+	//"github.com/quay/clair/v3/pkg/gitutil"
+
+	"crypto/sha256"
+	"encoding/hex"
+	"github.com/PuerkitoBio/goquery"
+	"io/ioutil"
+	"net/http"
+	"strings"
 )
 
 const (
 	// This Alpine vulnerability database affects origin packages, which has
 	// `origin` field of itself.
-	secdbGitURL  = "https://github.com/alpinelinux/alpine-secdb"
+	// secdbGitURL  = "https://github.com/alpinelinux/alpine-secdb" // No longer valid
+	baseURL = "https://secdb.alpinelinux.org/" // Web source for alpine vuln data
 	updaterFlag  = "alpine-secdbUpdater"
 	nvdURLPrefix = "https://cve.mitre.org/cgi-bin/cvename.cgi?name="
 	// affected type indicates if the affected feature hint is for binary or
@@ -49,6 +56,128 @@ func init() {
 
 type updater struct {
 	repositoryLocalPath string
+	currentDir string
+	hash_slice [][32] byte
+}
+
+func (u *updater) processFile(filename string) {
+	nameParts := strings.Split(filename, ".")
+	if nameParts[1] == "json" {
+		return
+	}
+	//log.WithField("package", "Alpine").Debug(filename)
+
+	response, err := http.Get(baseURL + u.currentDir + filename)
+	if err != nil {
+		//log.WithError(err).WithField("package", "Alpine").Error("Failed to get vuln file")
+		return
+	}
+	defer response.Body.Close()
+
+	file, err := os.Create(filepath.Join(filepath.Join(u.repositoryLocalPath, u.currentDir), filename))
+	if err != nil {
+		log.WithField("package", "Alpine").Fatal(err)
+		return
+	}
+	defer file.Close()
+
+	// find hash of file contents as part of checking for changes
+	file_hasher := sha256.New()
+	fileContents, err := ioutil.ReadAll(response.Body)
+	file_hasher.Write([] byte(fileContents[:]))
+
+	// Must be a better way to achieve this...
+	var file_hash [32]byte
+	copy(file_hash[:], file_hasher.Sum(nil))
+	u.hash_slice = append(u.hash_slice, file_hash)
+
+	file.WriteString(string(fileContents[:]))
+	return
+}
+
+func (u *updater) processFiles(index int, element *goquery.Selection) {
+	href, exists := element.Attr("href")
+	if exists {
+		if href != "../" {
+			u.processFile(href)
+		}
+	}
+}
+
+func (u *updater) processVersionDir(versionDir string) {
+	response, err := http.Get(baseURL + versionDir)
+	if err != nil {
+		log.WithError(err).WithField("package", "Alpine").Error("Failed to get version")
+	}
+	defer response.Body.Close()
+
+	document, err := goquery.NewDocumentFromReader(response.Body)
+	if err != nil {
+		log.Fatal("Error loading HTTP response body. ", err)
+	}
+	document.Find("a").Each(u.processFiles)
+}
+
+func (u *updater) processVersions(index int, element *goquery.Selection) {
+	href, exists := element.Attr("href")
+	if exists {
+		if href != "../" {
+			log.WithField("package", "Alpine").Debug(href)
+			// create Version directory
+			os.Mkdir(filepath.Join(u.repositoryLocalPath, href),0700)
+			u.currentDir = href
+			u.processVersionDir(href)
+		}
+	}
+}
+
+func sliceXOR (a, b [32]byte) (result [32]byte) {
+	var tmpval [32]byte
+	for i:=0; i<32; i++ {
+		tmpval[i] = a[i] ^ b[i]
+	}
+	result = tmpval
+	return
+}
+
+func (u *updater) getVulnFiles(repoPath, tempDirPrefix string) (commit string, err error) {
+	log.WithField("package", "alpine").Debug("Getting vulnerability data...")
+
+	// Set up temporary location for downlaods
+	if repoPath == "" {
+		u.repositoryLocalPath, err = ioutil.TempDir(os.TempDir(), tempDirPrefix)
+		if err != nil {
+			return
+		}
+	} else {
+		u.repositoryLocalPath = repoPath
+	}
+
+	u.hash_slice = nil
+	u.currentDir = ""
+
+	// Get root directory of web server
+	response, err := http.Get(baseURL)
+	if err != nil {
+		return
+	}
+	defer response.Body.Close()
+
+	document, err := goquery.NewDocumentFromReader(response.Body)
+	if err != nil {
+		log.WithError(err).WithField("package", "Alpine").Fatal("Error loading HTTP response body. ")
+		return
+	}
+	document.Find("a").Each(u.processVersions)
+
+	// Find XOR of all file hash values to use as commit hash replacement. Used to detect for changes to source files
+	var tmp_commit [32]byte
+	for i:=0; i < len(u.hash_slice); i++ {
+		tmp_commit = sliceXOR(tmp_commit, u.hash_slice[i])
+	}
+	commit = hex.EncodeToString(tmp_commit[:])
+
+	return
 }
 
 func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, err error) {
@@ -62,9 +191,11 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 		vulns          []database.VulnerabilityWithAffected
 	)
 
-	if u.repositoryLocalPath, commit, err = gitutil.CloneOrPull(secdbGitURL, u.repositoryLocalPath, updaterFlag); err != nil {
+	if commit, err = u.getVulnFiles(u.repositoryLocalPath, updaterFlag); err != nil {
+		log.WithField("package", "alpine").Debug("no file updates, skip")
 		return
 	}
+	log.WithField("package", "Alpine").Debugf("Commit Hash: %s", commit)
 
 	// Set the updaterFlag to equal the commit processed.
 	resp.FlagName = updaterFlag
@@ -141,6 +272,10 @@ func newSecDB(filePath string) (file *secDB, err error) {
 	defer f.Close()
 	file = &secDB{}
 	err = yaml.NewDecoder(f).Decode(file)
+
+	if err != nil {
+		log.WithError(err).WithField("package", "Alpine").Debug("Error decoding YAML file" + filePath)
+	}
 	return
 }
 

--- a/ext/vulnsrc/alpine/alpine.go
+++ b/ext/vulnsrc/alpine/alpine.go
@@ -65,7 +65,6 @@ func (u *updater) processFile(filename string) {
 	if nameParts[1] == "json" {
 		return
 	}
-	//log.WithField("package", "Alpine").Debug(filename)
 
 	response, err := http.Get(baseURL + u.currentDir + filename)
 	if err != nil {
@@ -195,7 +194,6 @@ func (u *updater) Update(db database.Datastore) (resp vulnsrc.UpdateResponse, er
 		log.WithField("package", "alpine").Debug("no file updates, skip")
 		return
 	}
-	log.WithField("package", "Alpine").Debugf("Commit Hash: %s", commit)
 
 	// Set the updaterFlag to equal the commit processed.
 	resp.FlagName = updaterFlag
@@ -272,10 +270,6 @@ func newSecDB(filePath string) (file *secDB, err error) {
 	defer f.Close()
 	file = &secDB{}
 	err = yaml.NewDecoder(f).Decode(file)
-
-	if err != nil {
-		log.WithError(err).WithField("package", "Alpine").Debug("Error decoding YAML file" + filePath)
-	}
 	return
 }
 


### PR DESCRIPTION
ext: switch alpine source to new web site from Github repo

Draft code to pull vulnerability data from Alpine web site instead of original Github repo. Commit is now XOR of file sha256 hash of source YAML files.

Fixes #1013 