### PR TITLE
Fixes for V2 for alpine, rhel, nvd, and ubuntu

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -339,6 +339,8 @@ func link(def definition) (link string) {
 
 func severity(def definition) database.Severity {
 	switch strings.TrimSpace(def.Title[strings.LastIndex(def.Title, "(")+1 : len(def.Title)-1]) {
+	case "None":
+		return database.NegligibleSeverity
 	case "Low":
 		return database.LowSeverity
 	case "Moderate":

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
+	github.com/coreos/clair v2.1.0+incompatible // indirect
 	github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf
 	github.com/davecgh/go-spew v1.0.1-0.20160907170601-6d212800a42e
 	github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a
-	github.com/coreos/clair v2.1.0+incompatible // indirect
 	github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf
 	github.com/davecgh/go-spew v1.0.1-0.20160907170601-6d212800a42e
 	github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a h1:BtpsbiV638WQZwhA98cEZw2BsbnQJrbd0BI7tsy0W1c=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/coreos/clair v1.2.6 h1:hhgkFHuEAx9l1iIwFfemrUZJc1lo1mVTs3MYZoDYiVQ=
+github.com/coreos/clair v2.1.0+incompatible h1:lY0fTAGneYxXfq0j2vM+Xxip30XBzSn2tzSolAwkMnc=
+github.com/coreos/clair v2.1.0+incompatible/go.mod h1:uXhHPWAoRqw0jJc2f8RrPCwRhIo9otQ8OEWUFtpCiwA=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf h1:CAKfRE2YtTUIjjh1bkBtyYFaUT/WmOqsJjgtihT0vMI=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/davecgh/go-spew v1.0.1-0.20160907170601-6d212800a42e h1:9EoM2C6YAkhnxTxG3LrAos2/KaALZdSNG5HTGPEEedE=
@@ -38,6 +41,7 @@ github.com/stretchr/testify v1.1.4 h1:ToftOQTytwshuOSj6bDSolVUa3GINfJP/fg3OkkOzQ
 github.com/stretchr/testify v1.1.4/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
+golang.org/x/sys v0.0.0-20170427041856-9ccfe848b9db h1:znurcNjtwV7XblDOBERYCP1TUjpwbp8bi3Szx8gbNBE=
 golang.org/x/sys v0.0.0-20170427041856-9ccfe848b9db/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e h1:o/mfNjxpTLivuKEfxzzwrJ8PmulH2wEp7t713uMwKAA=
 gopkg.in/yaml.v2 v2.0.0-20170407172122-cd8b52f8269e/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=


### PR DESCRIPTION
Signed-off-by: nycnewman <edward@digitalasset.com>

several: Fixes for NVD, RHEL, ubuntu, and alpine

NVD - switch to JSON V1.1 data feeds and use CVSS V3 scores
RHEL - fix to correctly handle vulnerabilities where severity tagged as None
Ubuntu - fix for multiple packages in name (should created unique versions in DB for each referenced package)
alpine - backport of fix I made for V3 to use new web site to download alpine vuln data

Test process:
- spin up new clean DB 
- load clair in debug mode and wait to pull all vuln data
- test some images (alpine:3.9.4 and internal docker) to get results using klar, paclair and clair-scanner

Fixes #966 #1013 #843 #916 