### PR TITLE
Fix advisory date check in Red Hat oval plugin

### DIFF
--- a/database/pgsql/pgsql_test.go
+++ b/database/pgsql/pgsql_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pgsql
 
 import (

--- a/ext/featurefmt/rpm/contentmanifest/contentmanifest.go
+++ b/ext/featurefmt/rpm/contentmanifest/contentmanifest.go
@@ -1,3 +1,17 @@
+// Copyright 2020 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contentmanifest
 
 // ContentManifest structure is based on file provided by OSBS

--- a/ext/featurefmt/rpm/contentmanifest/mappingfile.go
+++ b/ext/featurefmt/rpm/contentmanifest/mappingfile.go
@@ -1,3 +1,17 @@
+// Copyright 2020 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contentmanifest
 
 // MappingFile is a data struct for mapping file between repositories and CPEs

--- a/ext/featurefmt/rpm/contentmanifest/repositorycpe.go
+++ b/ext/featurefmt/rpm/contentmanifest/repositorycpe.go
@@ -1,3 +1,17 @@
+// Copyright 2020 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contentmanifest
 
 import (

--- a/ext/featurefmt/rpm/contentmanifest/updater.go
+++ b/ext/featurefmt/rpm/contentmanifest/updater.go
@@ -1,3 +1,17 @@
+// Copyright 2020 clair authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package contentmanifest
 
 import (

--- a/ext/vulnmdsrc/mitre/mitre.go
+++ b/ext/vulnmdsrc/mitre/mitre.go
@@ -21,12 +21,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"github.com/coreos/clair/database"
-	"github.com/coreos/clair/ext/vulnmdsrc"
-	"github.com/coreos/clair/pkg/commonerr"
-	"github.com/coreos/clair/pkg/httputil"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/html/charset"
 	"io"
 	"io/ioutil"
 	"os"
@@ -34,6 +28,13 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/quay/clair/v3/database"
+	"github.com/quay/clair/v3/ext/vulnmdsrc"
+	"github.com/quay/clair/v3/pkg/commonerr"
+	"github.com/quay/clair/v3/pkg/httputil"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/html/charset"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.1
 	github.com/asottile/dockerfile v2.2.0+incompatible
 	github.com/buildkite/interpolate v0.0.0-20181028012610-973457fa2b4c
+	github.com/coreos/clair v1.2.6
 	github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf
 	github.com/deckarep/golang-set v1.7.1
 	github.com/fernet/fernet-go v0.0.0-20151007213151-1b2437bc582b

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/containerd/go-runc v0.0.0-20190911050354-e029b79d8cda/go.mod h1:IV7qH
 github.com/containerd/ttrpc v0.0.0-20190411181408-699c4e40d1e7/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.6.1-0.20180218032124-142cde0c766c/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/coreos/clair v1.2.6 h1:hhgkFHuEAx9l1iIwFfemrUZJc1lo1mVTs3MYZoDYiVQ=
+github.com/coreos/clair v1.2.6/go.mod h1:uXhHPWAoRqw0jJc2f8RrPCwRhIo9otQ8OEWUFtpCiwA=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf h1:CAKfRE2YtTUIjjh1bkBtyYFaUT/WmOqsJjgtihT0vMI=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=


### PR DESCRIPTION
There was a bug that ignores advisories released in the same day.