### PR TITLE
Fix JSON Struct Tags for Notifier Config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,11 +50,11 @@ type Config struct {
 	// "panic"
 	LogLevel string   `yaml:"log_level" json:"log_level"`
 	Indexer  Indexer  `yaml:"indexer" json:"indexer"`
-	Matcher  Matcher  `yaml:"matcher"`
-	Notifier Notifier `yaml:"notifier"`
-	Auth     Auth     `yaml:"auth"`
-	Trace    Trace    `yaml:"trace"`
-	Metrics  Metrics  `yaml:"metrics"`
+	Matcher  Matcher  `yaml:"matcher" json:"matcher"`
+	Notifier Notifier `yaml:"notifier" json:"notifier"`
+	Auth     Auth     `yaml:"auth" json:"auth"`
+	Trace    Trace    `yaml:"trace" json:"trace"`
+	Metrics  Metrics  `yaml:"metrics" json:"metrics"`
 }
 
 // Validate confirms the necessary values to support

--- a/config/notifier.go
+++ b/config/notifier.go
@@ -41,7 +41,7 @@ type Notifier struct {
 	// Only one of the following should be provided in the configuration
 	//
 	// Configures the notifier for webhook delivery
-	Webbook *webhook.Config `yaml:"webhook" json:"webbook"`
+	Webbook *webhook.Config `yaml:"webhook" json:"webhook"`
 	// Configures the notifier for AMQP delivery.
 	AMQP *amqp.Config `yaml:"amqp" json:"amqp"`
 	// Configures the notifier for STOMP delivery.

--- a/notifier/webhook/config.go
+++ b/notifier/webhook/config.go
@@ -9,14 +9,14 @@ import (
 // Config provides configuration for an Webhook deliverer.
 type Config struct {
 	// the URL where our webhook will be delivered
-	Target string `yaml:"target"`
+	Target string `yaml:"target" json:"target"`
 	target *url.URL
 	// the callback url where notifications can be received
 	// the notification will be appended to this url
-	Callback string `yaml:"callback"`
+	Callback string `yaml:"callback" json:"callback"`
 	callback *url.URL
 	// any htp headers necessary for the request to Target
-	Headers http.Header `yaml:"headers"`
+	Headers http.Header `yaml:"headers" json:"headers"`
 	// whether the webhook deliverer will sign out going.
 	// if true webhooks will be sent with a jwt signed by
 	// the notifier's private key.


### PR DESCRIPTION
### Description

Adds missing `json` struct tags and fixes existing ones. Needed for Quay Operator to deploy Clair v4 notifications.