### PR TITLE
chore: bump cc and golang container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.13', '1.14']
+        go: ['1.13', '1.14', '1.15']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.14 AS build
+FROM docker.io/library/golang:1.15 AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
       
   notifier:
     container_name: clair-notifier
-    image: quay.io/claircore/golang:1.13.5
+    image: quay.io/claircore/golang:1.15.2
     volumes:
       - "./:/src/clair/"
     environment:
@@ -78,7 +78,7 @@ services:
   # this should only be created and deleted via the make target "local-dev-notifier-test"
   notifier-test-mode:
     container_name: clair-notifier
-    image: quay.io/claircore/golang:1.13.5
+    image: quay.io/claircore/golang:1.15.2
     volumes:
       - "./:/src/clair/"
     environment:
@@ -97,7 +97,7 @@ services:
 
   indexer:
     container_name: clair-indexer
-    image: quay.io/claircore/golang:1.13.5
+    image: quay.io/claircore/golang:1.15.2
     volumes:
       - "./:/src/clair/"
     environment:
@@ -129,7 +129,7 @@ services:
   ## allows layer fetching over localhost
   indexer-quay:
     container_name: clair-indexer
-    image: quay.io/claircore/golang:1.13.5
+    image: quay.io/claircore/golang:1.15.2
     volumes:
       - "./:/src/clair/"
     environment:
@@ -160,7 +160,7 @@ services:
 
   matcher:
     container_name: clair-matcher
-    image: quay.io/claircore/golang:1.13.5
+    image: quay.io/claircore/golang:1.15.2
     volumes:
       - "./:/src/clair/"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/quay/claircore v0.1.2
+	github.com/quay/claircore v1.0.5
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.16.0
 	github.com/streadway/amqp v1.0.0
@@ -27,7 +27,7 @@ require (
 	go.opentelemetry.io/otel/exporter/metric/prometheus v0.2.2-0.20200111012159-d85178b63b15
 	go.opentelemetry.io/otel/exporter/trace/jaeger v0.2.1
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/tools v0.0.0-20200828013309-97019fc2e64b // indirect
+	golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
 )

--- a/go.sum
+++ b/go.sum
@@ -508,10 +508,10 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/claircore v0.1.2 h1:Oh210uFPAHmLqB65HZj/2z33cF3gk1PiKTy1bdfE3DI=
-github.com/quay/claircore v0.1.2/go.mod h1:pgMsQAbCsIn3ESKqEKHl4Xztvl+SJHBp0CXz9lkxSTU=
-github.com/quay/goval-parser v0.8.2 h1:6lZVroZhBw6okKBHvxS5a+/B2Q/b3cuKaSmRpz//9WA=
-github.com/quay/goval-parser v0.8.2/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
+github.com/quay/claircore v1.0.5 h1:Q7zz0MedTefnHEv8rB8gxJJENT76NEHdAx/XL4mBMp0=
+github.com/quay/claircore v1.0.5/go.mod h1:1VYiPH3IWZLwNhPrzuV5gEz5yXIm2xflFCYN4EtNod8=
+github.com/quay/goval-parser v0.8.3 h1:bWRK6S8fhrlzslhq0fV7BHpcZJyAdk9ZF5QXiFiHdhU=
+github.com/quay/goval-parser v0.8.3/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319/go.mod h1:rhSvwcijY9wfmrBYrfCvapX8/xOTV46NAUjBRgUyJqc=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
@@ -605,6 +605,7 @@ github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -682,6 +683,7 @@ golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200421231249-e086a090c8fd/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -773,8 +775,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191205215504-7b8c8591a921/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200811032001-fd80f4dbb3ea/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
-golang.org/x/tools v0.0.0-20200828013309-97019fc2e64b h1:TlHrnfzYWpw9fgHafO5AaiaqK81ZaJzPi+srvBuZUIQ=
-golang.org/x/tools v0.0.0-20200828013309-97019fc2e64b/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd h1:EsTBWdirTvPYbomEwlpq2y7Z3qqsNm6BkseJHhdOvYM=
+golang.org/x/tools v0.0.0-20200911153331-7ad463ce66dd/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
PR bumps CC to latest and updates golang containers to 1.15 to support SSL_CERT_DIR

Signed-off-by: ldelossa <ldelossa@redhat.com>