### PR TITLE
logging: add similar logging to v3

### DIFF
--- a/httptransport/logginghandler.go
+++ b/httptransport/logginghandler.go
@@ -1,0 +1,34 @@
+package httptransport
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type httpStatusWriter struct {
+	http.ResponseWriter
+
+	StatusCode int
+}
+
+// LoggingHandler will log HTTP requests using the pre initialized zerolog.
+func LoggingHandler(next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		log := zerolog.Ctx(r.Context())
+
+		next.ServeHTTP(w, r)
+
+		log.Info().
+			Str("remote addr", r.RemoteAddr).
+			Str("method", r.Method).
+			Str("request uri", r.RequestURI).
+			Str("status", strconv.Itoa(http.StatusOK)).
+			Float64("elapsed time (md)", float64(time.Since(start).Nanoseconds())*1e-6).
+			Msg("handled HTTP request")
+	}
+}

--- a/httptransport/logginghandler.go
+++ b/httptransport/logginghandler.go
@@ -10,7 +10,6 @@ import (
 
 type httpStatusWriter struct {
 	http.ResponseWriter
-
 	StatusCode int
 }
 
@@ -21,13 +20,16 @@ func LoggingHandler(next http.Handler) http.HandlerFunc {
 
 		log := zerolog.Ctx(r.Context())
 
+		// default HTTP StatusOK
+		lrw := &httpStatusWriter{ResponseWriter: w, StatusCode: http.StatusOK}
+
 		next.ServeHTTP(w, r)
 
 		log.Info().
 			Str("remote addr", r.RemoteAddr).
 			Str("method", r.Method).
 			Str("request uri", r.RequestURI).
-			Str("status", strconv.Itoa(http.StatusOK)).
+			Str("status", strconv.Itoa(lrw.StatusCode)).
 			Float64("elapsed time (md)", float64(time.Since(start).Nanoseconds())*1e-6).
 			Msg("handled HTTP request")
 	}

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -121,7 +121,7 @@ func New(ctx context.Context, conf config.Config, indexer indexer.Service, match
 func (t *Server) configureDiscovery(_ context.Context) error {
 	h := intromw.Handler(
 		othttp.NewHandler(
-			DiscoveryHandler(),
+			LoggingHandler(DiscoveryHandler()),
 			OpenAPIV1Path,
 			t.traceOpt,
 		),
@@ -171,7 +171,7 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 	// affected manifest handler register
 	affectedH := intromw.Handler(
 		othttp.NewHandler(
-			AffectedManifestHandler(t.indexer),
+			LoggingHandler(AffectedManifestHandler(t.indexer)),
 			AffectedManifestAPIPath,
 			t.traceOpt,
 		),
@@ -182,7 +182,7 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 	// index handler register
 	indexH := intromw.Handler(
 		othttp.NewHandler(
-			IndexHandler(t.indexer),
+			LoggingHandler(IndexHandler(t.indexer)),
 			IndexAPIPath,
 			t.traceOpt,
 		),
@@ -193,7 +193,7 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 	// index report handler register
 	indexReportH := intromw.Handler(
 		othttp.NewHandler(
-			IndexReportHandler(t.indexer),
+			LoggingHandler(IndexReportHandler(t.indexer)),
 			IndexReportAPIPath,
 			t.traceOpt,
 		),
@@ -204,7 +204,7 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 	// index state handler register
 	stateH := intromw.Handler(
 		othttp.NewHandler(
-			IndexStateHandler(t.indexer),
+			LoggingHandler(IndexStateHandler(t.indexer)),
 			IndexStateAPIPath,
 			t.traceOpt,
 		),
@@ -226,7 +226,7 @@ func (t *Server) configureMatcherMode(_ context.Context) error {
 	// vulnerability report handler register
 	vulnReportH := intromw.Handler(
 		othttp.NewHandler(
-			VulnerabilityReportHandler(t.matcher, t.indexer),
+			LoggingHandler(VulnerabilityReportHandler(t.matcher, t.indexer)),
 			VulnerabilityReportPath,
 			t.traceOpt,
 		),
@@ -237,7 +237,7 @@ func (t *Server) configureMatcherMode(_ context.Context) error {
 	// update operation handler register
 	opH := intromw.Handler(
 		othttp.NewHandler(
-			UpdateOperationHandler(t.matcher),
+			LoggingHandler(UpdateOperationHandler(t.matcher)),
 			UpdateOperationAPIPath,
 			t.traceOpt,
 		),
@@ -248,7 +248,7 @@ func (t *Server) configureMatcherMode(_ context.Context) error {
 	// update diff handler register
 	diffH := intromw.Handler(
 		othttp.NewHandler(
-			UpdateDiffHandler(t.matcher),
+			LoggingHandler(UpdateDiffHandler(t.matcher)),
 			UpdateDiffAPIPath,
 			t.traceOpt,
 		),
@@ -270,7 +270,7 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 	// notifications callback handler
 	callbackH := intromw.Handler(
 		othttp.NewHandler(
-			NotificationHandler(t.notifier),
+			LoggingHandler(NotificationHandler(t.notifier)),
 			NotificationAPIPath,
 			t.traceOpt,
 		),
@@ -286,7 +286,7 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 	// keys handler
 	keysH := intromw.Handler(
 		othttp.NewHandler(
-			KeysHandler(ks),
+			LoggingHandler(KeysHandler(ks)),
 			KeysAPIPath,
 			t.traceOpt,
 		),
@@ -297,7 +297,7 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 	// key by ID handler
 	keyByIDH := intromw.Handler(
 		othttp.NewHandler(
-			KeyByIDHandler(ks),
+			LoggingHandler(KeyByIDHandler(ks)),
 			KeyByIDAPIPath,
 			t.traceOpt,
 		),


### PR DESCRIPTION
Add back in HTTP logging to what was present in v3, to each of the handlers.

Matched the existing format/fields from v3 here:
https://github.com/quay/clair/blob/1d1417737209cfe2e1d0b870658c8c6767832905/api/v3/server.go#L62 

Didn't add tests as there isn't really much to test. 