### PR TITLE
auth: psk fixup

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -513,11 +513,11 @@ a string value
 A shared key distributed between all parties signing and verifying JWTs.
 ```
 
-#### &emsp;&emsp;issuer: ""
+#### &emsp;&emsp;issuer: []string
 ```
-a string value
+a list of string value
 
-The "Issuer" key is what the service expects to verify as the "issuer" claim.
+A list of issuers to verify. An empty list will accept any issuer in a jwt claim.
 ```
 
 ### &emsp;keyserver: \<object\>

--- a/config/auth.go
+++ b/config/auth.go
@@ -49,15 +49,15 @@ func (a *AuthKeyserver) UnmarshalYAML(f func(interface{}) error) error {
 //
 // The "Issuer" key is what the service expects to verify as the "issuer" claim.
 type AuthPSK struct {
-	Key    []byte `yaml:"key" json:"key"`
-	Issuer string `yaml:"iss" json:"issuer"`
+	Key    []byte   `yaml:"key" json:"key"`
+	Issuer []string `yaml:"iss" json:"issuer"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler.
 func (a *AuthPSK) UnmarshalYAML(f func(interface{}) error) error {
 	var m struct {
-		Issuer string `yaml:"iss" json:"issuer"`
-		Key    string `yaml:"key" json:"key"`
+		Issuer []string `yaml:"iss" json:"issuer"`
+		Key    string   `yaml:"key" json:"key"`
 	}
 	if err := f(&m); err != nil {
 		return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,11 +82,12 @@ func TestAuthUnmarshal(t *testing.T) {
 				In: `---
 key: >-
   ZGVhZGJlZWZkZWFkYmVlZg==
-iss: iss
+iss: 
+  - iss
 `,
 				Want: config.AuthPSK{
 					Key:    []byte("deadbeefdeadbeef"),
-					Issuer: "iss",
+					Issuer: []string{"iss"},
 				},
 			},
 		}

--- a/httptransport/auth_test.go
+++ b/httptransport/auth_test.go
@@ -95,7 +95,7 @@ func TestAuth(t *testing.T) {
 			Config: config.Config{
 				Auth: config.Auth{
 					PSK: &config.AuthPSK{
-						Issuer: `sweet-bro`,
+						Issuer: []string{`sweet-bro`},
 						Key:    fakeKey,
 					},
 				},
@@ -117,7 +117,7 @@ func TestAuth(t *testing.T) {
 			Config: config.Config{
 				Auth: config.Auth{
 					PSK: &config.AuthPSK{
-						Issuer: `sweet-bro`,
+						Issuer: []string{`sweet-bro`},
 						Key:    fakeKey,
 					},
 				},
@@ -143,7 +143,7 @@ func TestAuth(t *testing.T) {
 			Config: config.Config{
 				Auth: config.Auth{
 					PSK: &config.AuthPSK{
-						Issuer: `sweet-bro`,
+						Issuer: []string{`sweet-bro`},
 						Key:    fakeKey,
 					},
 				},

--- a/middleware/auth/httpauth_psk.go
+++ b/middleware/auth/httpauth_psk.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rs/zerolog"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
@@ -14,11 +15,11 @@ import (
 // will be validated against a pre-shared-key.
 type PSK struct {
 	key []byte
-	iss string
+	iss []string
 }
 
 // NewPSK returns an instance of a PSK
-func NewPSK(key []byte, issuer string) (*PSK, error) {
+func NewPSK(key []byte, issuer []string) (*PSK, error) {
 	return &PSK{
 		key: key,
 		iss: issuer,
@@ -27,23 +28,44 @@ func NewPSK(key []byte, issuer string) (*PSK, error) {
 
 // Check implements AuthCheck
 func (p *PSK) Check(_ context.Context, r *http.Request) bool {
+	ctx := r.Context()
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "middleware/auth/PSK.Check").
+		Logger()
+	ctx = log.WithContext(ctx)
+
 	wt, ok := fromHeader(r)
 	if !ok {
+		log.Debug().Msg("failed to retrieve jwt from header")
 		return false
 	}
 	tok, err := jwt.ParseSigned(wt)
 	if err != nil {
+		log.Debug().Err(err).Msg("failed to parse jwt")
 		return false
 	}
 	cl := jwt.Claims{}
 	if err := tok.Claims(p.key, &cl); err != nil {
+		log.Debug().Err(err).Msg("failed to parse jwt")
 		return false
 	}
+
 	if err := cl.ValidateWithLeeway(jwt.Expected{
-		Issuer: p.iss,
-		Time:   time.Now(),
+		Time: time.Now(),
 	}, 15*time.Second); err != nil {
+		log.Debug().Err(err).Str("iss", cl.Issuer).Msg("could not validate claims")
 		return false
 	}
+
+	for i, iss := range p.iss {
+		if iss == cl.Issuer {
+			break
+		}
+		if i == len(p.iss)-1 {
+			log.Debug().Err(err).Str("iss", cl.Issuer).Msg("could not verify issuer")
+			return false
+		}
+	}
+
 	return true
 }


### PR DESCRIPTION
this commit no longer requires a base64 PSK in the config, decoding it
became an issue when interoping with Quay.

commit also simplifies the PSK check to look at multiple issuers. This
is mostly done for more accurate logging.

Signed-off-by: ldelossa <ldelossa@redhat.com>