### PR TITLE
logging: use duration stringer

### DIFF
--- a/httptransport/logginghandler.go
+++ b/httptransport/logginghandler.go
@@ -34,7 +34,7 @@ func LoggingHandler(next http.Handler) http.HandlerFunc {
 			Str("method", r.Method).
 			Str("request uri", r.RequestURI).
 			Int("status", lrw.StatusCode).
-			Float64("elapsed time (md)", float64(time.Since(start).Nanoseconds())*1e-6).
+			Str("elapsed time (md)", time.Since(start).String()).
 			Msg("handled HTTP request")
 	}
 }


### PR DESCRIPTION
this commit uses the duration stringer to pretty print the time it takes
or a http handler to complete

Signed-off-by: ldelossa <ldelossa@redhat.com>