### PR TITLE
client: fix nil check

### DIFF
--- a/httptransport/client/indexer.go
+++ b/httptransport/client/indexer.go
@@ -38,7 +38,7 @@ func (s *HTTP) AffectedManifests(ctx context.Context, v []claircore.Vulnerabilit
 		return affected, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp.Body != nil {
+	if resp != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
@@ -73,7 +73,7 @@ func (s *HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*clairc
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp.Body != nil {
+	if resp != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
@@ -103,7 +103,7 @@ func (s *HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*cla
 		return nil, false, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp.Body != nil {
+	if resp != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
@@ -135,7 +135,7 @@ func (s *HTTP) State(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp.Body != nil {
+	if resp != nil {
 		defer resp.Body.Close()
 	}
 

--- a/httptransport/client/matcher.go
+++ b/httptransport/client/matcher.go
@@ -38,7 +38,7 @@ func (c *HTTP) Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.
 	}
 
 	resp, err := c.c.Do(req)
-	if resp.Body != nil {
+	if resp != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {


### PR DESCRIPTION
These nil checks were checking an http.Response's Body member instead of
the Response pointer, causing panics whenever the Response pointer was
nil.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>