### PR TITLE
Use NVD 1.1 feed

### DIFF
--- a/ext/vulnmdsrc/nvd/nvd.go
+++ b/ext/vulnmdsrc/nvd/nvd.go
@@ -39,8 +39,8 @@ import (
 )
 
 const (
-	dataFeedURL     string = "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%s.json.gz"
-	dataFeedMetaURL string = "https://nvd.nist.gov/feeds/json/cve/1.0/nvdcve-1.0-%s.meta"
+	dataFeedURL     string = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%s.json.gz"
+	dataFeedMetaURL string = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%s.meta"
 
 	appenderName string = "NVD"
 


### PR DESCRIPTION
NVD 1.0 feed is no longer available which seems to break classification of finding criticality.
Cf. https://github.com/quay/clair/pull/1021 which this is a small subset of.