### PR TITLE
notifier: remove keyserver and explicit webhook signing

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -270,7 +270,11 @@ notifications
 #### &emsp;webhook: \<object\>
 ```
 Configures the notifier for webhook delivery
+
+If the global "Auth" key is populated with a PSK stanza the 
+webhook will be signed by a JWT issued by "clair-notifier"
 ```
+
 #### &emsp;&emsp;target: ""
 ```
 URL where our webhook will be delivered
@@ -287,12 +291,6 @@ This will typically be where the clair notifier is hosted
 { "header": [ "value" ] }
 
 A map associating header names to a list of header values
-```
-#### &emsp;&emsp;signed: ""
-```
-A "true" or "false" value
-
-If true the Notifier will use its internal key server to sign out going webhooks.
 ```
 
 #### &emsp;amqp: \<object\>

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -281,33 +281,6 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 	)
 	t.Handle(NotificationAPIPath, othttp.WithRouteTag(NotificationAPIPath, callbackH))
 
-	ks := t.notifier.KeyStore(ctx)
-	if ks == nil {
-		return clairerror.ErrNotInitialized{"NotifierMode requires the notifier to provide a non-nil key store"}
-	}
-
-	// keys handler
-	keysH := intromw.Handler(
-		othttp.NewHandler(
-			LoggingHandler(KeysHandler(ks)),
-			KeysAPIPath,
-			t.traceOpt,
-		),
-		KeysAPIPath,
-	)
-	t.Handle(KeysAPIPath, othttp.WithRouteTag(KeysAPIPath, keysH))
-
-	// key by ID handler
-	keyByIDH := intromw.Handler(
-		othttp.NewHandler(
-			LoggingHandler(KeyByIDHandler(ks)),
-			KeyByIDAPIPath,
-			t.traceOpt,
-		),
-		KeyByIDAPIPath,
-	)
-	t.Handle(KeyByIDAPIPath, othttp.WithRouteTag(KeyByIDAPIPath, keyByIDH))
-
 	return nil
 }
 

--- a/notifier/migrations/migration1.go
+++ b/notifier/migrations/migration1.go
@@ -41,14 +41,5 @@ const (
 		details         jsonb -- any additional details specific to the delivery mechanism
 	);
 	CREATE INDEX receipt_idx ON receipt (notification_id, uo_id);
-
-	--- a relation holding a pub_key in PKIX, ASN.1 DER form
-	--- expiration is application defined and not associated with the public key
-	CREATE TABLE IF NOT EXISTS key
-	(
-		id         uuid PRIMARY KEY,
-		expiration timestamptz,
-		pub_key    bytea
-	);
 	`
 )

--- a/notifier/postgres/keystore_test.go
+++ b/notifier/postgres/keystore_test.go
@@ -1,3 +1,5 @@
+// +build deprecated
+
 package postgres_test
 
 import (

--- a/notifier/webhook/config.go
+++ b/notifier/webhook/config.go
@@ -18,10 +18,6 @@ type Config struct {
 	callback *url.URL
 	// any htp headers necessary for the request to Target
 	Headers http.Header `yaml:"headers" json:"headers"`
-	// whether the webhook deliverer will sign out going.
-	// if true webhooks will be sent with a jwt signed by
-	// the notifier's private key.
-	Signed bool `yaml:"signed" json:"signed"`
 }
 
 // Validate will return a copy of the Config on success.

--- a/notifier/webhook/deliverer.go
+++ b/notifier/webhook/deliverer.go
@@ -4,29 +4,23 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/google/uuid"
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/notifier"
-	"github.com/quay/clair/v4/notifier/keymanager"
 	"github.com/rs/zerolog"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 type Deliverer struct {
 	conf Config
 	// a client to use for POSTing webhooks
-	c    *http.Client
-	kmgr *keymanager.Manager
+	c *http.Client
 }
 
 // New returns a new webhook Deliverer
-func New(conf Config, client *http.Client, keymanager *keymanager.Manager) (*Deliverer, error) {
+func New(conf Config, client *http.Client) (*Deliverer, error) {
 	var c Config
 	var err error
 	if c, err = conf.Validate(); err != nil {
@@ -38,39 +32,11 @@ func New(conf Config, client *http.Client, keymanager *keymanager.Manager) (*Del
 	return &Deliverer{
 		conf: c,
 		c:    client,
-		kmgr: keymanager,
 	}, nil
 }
 
 func (d *Deliverer) Name() string {
 	return "webhook"
-}
-
-// sign will use the provided private key to sign and attach a jwt to the provided
-// request.
-func (d *Deliverer) sign(ctx context.Context, req *http.Request, kp keymanager.KeyPair) error {
-	opts := (&jose.SignerOptions{}).
-		WithType("JWT").
-		WithHeader(jose.HeaderKey("kid"), kp.ID.String())
-	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.PS512, Key: kp.Private}, opts)
-	if err != nil {
-		return fmt.Errorf("failed to create jwt signer: %v", err)
-	}
-	now := jwt.NumericDate(time.Now().Unix())
-	expire := jwt.NumericDate(time.Now().Add(1 * time.Hour).Unix())
-	cl := jwt.Claims{
-		Issuer:   "notifier",
-		Expiry:   &expire,
-		IssuedAt: &now,
-		Audience: jwt.Audience{d.conf.target.String()},
-		Subject:  d.conf.target.Hostname(),
-	}
-	token, err := jwt.Signed(signer).Claims(cl).CompactSerialize()
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	return nil
 }
 
 // Deliver implements the notifier.Deliverer interface.
@@ -102,19 +68,6 @@ func (d *Deliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 		Header: d.conf.Headers,
 		Body:   ioutil.NopCloser(buf),
 		Method: http.MethodPost,
-	}
-
-	// sign a jwt using key manager's private key
-	if d.conf.Signed {
-		kp, err := d.kmgr.KeyPair()
-		if err != nil {
-			return fmt.Errorf("configured for signing but no private key available: %v", err)
-		}
-		err = d.sign(ctx, req, kp)
-		if err != nil {
-			return fmt.Errorf("failed to sign request: %v", err)
-		}
-		log.Debug().Msg("successfully signed request")
 	}
 
 	log.Info().Str("notification_id", nID.String()).


### PR DESCRIPTION
This commit removes the need for the keyserver in the notifier code
base.

PSK will be preferred and webhook JWT signing with be implicitly provided by the
passed in http client.

Signed-off-by: ldelossa <ldelossa@redhat.com>