### PR TITLE
notifier: ensure Content-Type header present in webhook notification

### DIFF
--- a/notifier/webhook/config.go
+++ b/notifier/webhook/config.go
@@ -45,5 +45,11 @@ func (c *Config) Validate() (Config, error) {
 		return conf, fmt.Errorf("failed to parse callback url")
 	}
 	conf.callback = callback
+
+	if conf.Headers == nil {
+		conf.Headers = map[string][]string{}
+	}
+	conf.Headers.Set("Content-Type", "application/json")
+
 	return conf, nil
 }


### PR DESCRIPTION
When receiving the notification webhook in Quay, we call Flask's `.json()` method. This returns `None` if the `Content-Type` header is not set to `application/json`.

