### PR TITLE
notifier: copy url struct

### DIFF
--- a/notifier/webhook/config.go
+++ b/notifier/webhook/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // Config provides configuration for an Webhook deliverer.
@@ -32,6 +33,12 @@ func (c *Config) Validate() (Config, error) {
 		return conf, fmt.Errorf("failed to parse target url")
 	}
 	conf.target = target
+
+	// require trailing slash so url.Parse() can easily
+	// append notification id.
+	if !strings.HasSuffix(c.Callback, "/") {
+		c.Callback = c.Callback + "/"
+	}
 
 	callback, err := url.Parse(c.Callback)
 	if err != nil {

--- a/notifier/webhook/deliverer.go
+++ b/notifier/webhook/deliverer.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/google/uuid"
@@ -83,8 +82,10 @@ func (d *Deliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 		Str("notification_id", nID.String()).
 		Logger()
 
-	callback := d.conf.callback
-	callback.Path = path.Join(callback.Path, nID.String())
+	callback, err := d.conf.callback.Parse(nID.String())
+	if err != nil {
+		return err
+	}
 
 	wh := notifier.Callback{
 		NotificationID: nID,


### PR DESCRIPTION
previous to this commit a reference to the callback url structure was
being mutated.

this commit ensures a copy of the url structure is made and the original
reference is no longer mutated.

Signed-off-by: ldelossa <ldelossa@redhat.com>