### PR TITLE
clairctl: add environment variables for clairctl

### DIFF
--- a/Documentation/reference/clairctl.md
+++ b/Documentation/reference/clairctl.md
@@ -3,10 +3,9 @@
 `clairctl` is a command line tool for working with Clair.
 This CLI is capable of generating manifests from most public registries (dockerhub, quay.io, Red Hat Container Catalog) and submitting them for analysis to a running Clair.
 
-
 ```
 NAME:
-   clairctl - A new cli application
+   clairctl - interact with a clair API
 
 USAGE:
    clairctl [global options] command [command options] [arguments...]
@@ -18,9 +17,11 @@ DESCRIPTION:
    A command-line tool for clair v4.
 
 COMMANDS:
-   manifest  
-   report    request vulnerability reports for the named containers
-   help, h   Shows a list of commands or help for one command
+   manifest         print a clair manifest for the named container
+   report           request vulnerability reports for the named containers
+   export-updaters  run updaters and export results
+   import-updaters  import updates
+   help, h          Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
    -D             print debugging logs (default: false)
@@ -30,18 +31,14 @@ GLOBAL OPTIONS:
 
 ```
 NAME:
-   clairctl manifest - 
+   clairctl manifest - print a clair manifest for the named container
 
 USAGE:
-   clairctl manifest [command options] [arguments...]
+   clairctl manifest [arguments...]
 
 DESCRIPTION:
-   print a clair manifest for the provided container
-
-OPTIONS:
-   --help, -h  show help (default: false)
+   print a clair manifest for the named container
 ```
-
 
 ```
 NAME:
@@ -51,10 +48,38 @@ USAGE:
    clairctl report [command options] container...
 
 DESCRIPTION:
-   Request and print a Clair vulnerability report for the provided container(s).
+   Request and print a Clair vulnerability report for the named container(s).
 
 OPTIONS:
-   --host value           URL for the clairv4 v1 API. (default: "http://localhost:6060/")
+   --host value           URL for the clairv4 v1 API. (default: "http://localhost:6060/") [$CLAIR_API]
    --out value, -o value  output format: text, json, xml (default: text)
-   --help, -h             show help (default: false)
+```
+
+```
+NAME:
+   clairctl export-updaters - run updaters and export results
+
+USAGE:
+   clairctl export-updaters [command options] [out]
+
+DESCRIPTION:
+   Run configured exporters and export to a file.
+
+OPTIONS:
+   --strict                  Return non-zero exit when updaters report errors. (default: false)
+   --config value, -c value  clair configuration file (default: "config.yaml") [$CLAIR_CONF]
+```
+
+```
+NAME:
+   clairctl import-updaters - import updates
+
+USAGE:
+   clairctl import-updaters [command options] in
+
+DESCRIPTION:
+   Import updates from a file.
+
+OPTIONS:
+   --config value, -c value  clair configuration file (default: "config.yaml") [$CLAIR_CONF]
 ```

--- a/cmd/clairctl/export.go
+++ b/cmd/clairctl/export.go
@@ -33,6 +33,7 @@ var ExportCmd = &cli.Command{
 			Usage:     "clair configuration file",
 			Value:     "config.yaml",
 			TakesFile: true,
+			EnvVars:   []string{"CLAIR_CONF"},
 		},
 	},
 }

--- a/cmd/clairctl/import.go
+++ b/cmd/clairctl/import.go
@@ -28,6 +28,7 @@ var ImportCmd = &cli.Command{
 			Usage:     "clair configuration file",
 			Value:     "config.yaml",
 			TakesFile: true,
+			EnvVars:   []string{"CLAIR_CONF"},
 		},
 	},
 }

--- a/cmd/clairctl/main.go
+++ b/cmd/clairctl/main.go
@@ -22,6 +22,7 @@ func main() {
 	app := &cli.App{
 		Name:                 "clairctl",
 		Version:              "0.1.0",
+		Usage:                "interact with a clair API",
 		Description:          "A command-line tool for clair v4.",
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -25,9 +25,10 @@ var ReportCmd = &cli.Command{
 	ArgsUsage:   "container...",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "host",
-			Usage: "URL for the clairv4 v1 API.",
-			Value: "http://localhost:6060/",
+			Name:    "host",
+			Usage:   "URL for the clairv4 v1 API.",
+			Value:   "http://localhost:6060/",
+			EnvVars: []string{"CLAIR_API"},
 		},
 		&cli.GenericFlag{
 			Name:        "out",


### PR DESCRIPTION
This makes the import/export commands respect the CLAIR_CONF environment
variable that `clair` proper uses.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>