### PR TITLE
cicd: pin mdbook version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.3'
       - run: mdbook build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
The latest run seems to have goofed up some paths, so this pins the
version I used to correct it.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>