### PR TITLE
local-dev: add pgadmin4 container

### DIFF
--- a/Documentation/howto/testing.md
+++ b/Documentation/howto/testing.md
@@ -50,6 +50,11 @@ localhost:5433 --- Quay's Postgres DB
                      username: quay
                      database: quay
 
+localhost:8081 --- Postgres GUI (pgadmin4)
+                   Login:
+                     username: clair@clair.com
+                     password: clair
+
 localhost:8082 --- OpenAPI Swagger Editor.
                    You can view ClairV4's public API here.
 

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ local-dev-up: vendor
 	$(docker-compose) up -d activemq
 	$(docker-compose) up -d clair-db
 	$(docker) exec -it clair-db bash -c 'while ! pg_isready; do echo "waiting for postgres"; sleep 2; done'
+	$(docker-compose) up -d pgadmin
 	$(docker-compose) up -d indexer
 	$(docker-compose) up -d matcher
 	$(docker-compose) up -d notifier
@@ -55,6 +56,7 @@ local-dev-up-with-quay: vendor
 	$(docker-compose) up -d activemq
 	$(docker-compose) up -d clair-db
 	$(docker) exec -it clair-db bash -c 'while ! pg_isready; do echo "waiting for clair postgres"; sleep 2; done'
+	$(docker-compose) up -d pgadmin
 	$(docker-compose) up -d indexer-quay
 	$(docker-compose) up -d matcher
 	$(docker-compose) up -d notifier
@@ -125,10 +127,17 @@ local-dev-matcher-restart:
 local-dev-notifier-restart:
 	$(docker-compose) up -d --force-recreate notifier
 
-# restart the local development rabbitmq
-.PHONY: local-dev-notifier-restart
-local-dev-rabbitmq-restart:
+# restart all clair instances
+.PHONY: local-dev-clair-restart
+local-dev-clair-restart:
+	$(docker-compose) up -d --force-recreate indexer
+	$(docker-compose) up -d --force-recreate matcher
 	$(docker-compose) up -d --force-recreate notifier
+
+# restart the local development rabbitmq
+.PHONY: local-dev-rabbitmq-restart
+local-dev-rabbitmq-restart:
+	$(docker-compose) up -d --force-recreate rabbitmq
 
 # restart the local development swagger-ui, any local code changes will take effect
 .PHONY: local-dev-swagger-ui-restart

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,21 @@ services:
       retries: 3
       start_period: 10s
 
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4:latest
+    environment:
+      PGADMIN_DEFAULT_EMAIL: clair@clair.com
+      PGADMIN_DEFAULT_PASSWORD: clair
+      PGADMIN_SERVER_JSON_FILE: /pgadmin4/config/servers.json
+      PGADMIN_LISTEN_PORT: 8081
+    ports:
+      - "8081:8081"
+    volumes:
+      - "./local-dev/pgadmin:/pgadmin4/config"
+    depends_on:
+      - clair-db
+
   traefik:
     container_name: clair-traefik
     image: traefik:v2.2

--- a/local-dev/pgadmin/passfile.txt
+++ b/local-dev/pgadmin/passfile.txt
@@ -1,0 +1,2 @@
+# hostname:port:database:username:password
+clair-db:5432:clair-db:clair:clair

--- a/local-dev/pgadmin/servers.json
+++ b/local-dev/pgadmin/servers.json
@@ -1,0 +1,14 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "clair-db",
+            "Group": "Servers",
+            "Port": 5432,
+            "Username": "clair",
+            "Host": "clair-db",
+            "SSLMode": "disable",
+            "MaintenanceDB": "postgres",
+            "PassFile": "/pgadmin4/config/passfile.txt"
+        }
+    }
+}


### PR DESCRIPTION
The purpose here is to make clair-db introspection easier. With this change, a developer can use [pgadmin](https://www.pgadmin.org/) browser GUI to view clair-db database. Having it run in container and pre-configured removes the need for a developer to install it manually on their system and set up clair-db connection every time. With this change, one can simply:
1. `make local-dev-up`
1. Enter `localhost:80` in the browser
1. Log-in with the default user (clair@clair.com/clair)
1. Inspect the clair-db (no need for setting up the connection, it's already pre-loaded)
![image](https://user-images.githubusercontent.com/22600243/95863188-2d219b80-0d64-11eb-8c24-5a481713c248.png)

I don't know about exposing port 80 though. It's the one that is used in [pdagmin4 docs](https://www.pgadmin.org/docs/pgadmin4/development/container_deployment.html), so I chose it for compliance. At the same time, I know it's heavily contested port. What do you think?
