### PR TITLE
docs: Add information about AMQP delivery compatibility

### DIFF
--- a/Documentation/concepts/notifications.md
+++ b/Documentation/concepts/notifications.md
@@ -121,6 +121,8 @@ The notifier also supports delivering to an AMQP broker. With AMQP delivery you 
 
 This allows the developer of the AMQP consumer to determine the logic of notification processing.
 
+Note that AMQP delivery only supports AMQP 0.x protocol (e.g. RabbitMQ). If you need to publish notifications on AMQP 1.x message queue (e.g. ActiveMQ), you can use STOMP delivery.
+
 ### Direct Delivery
 
 If the notifier's configuration specifies `direct: true` for AMQP, notifications will be delivered directly to the configured exchange.


### PR DESCRIPTION
In clair we use this library for AMQP connection: https://github.com/streadway/amqp#goals

According to its documentation (and I also ran into that wall personally), it supports only AMQP 0.9.1 protocol. Since it may not be obvious to the end user (it was not obvious to me), I though it would be good to mention this in docs so that other users might avoid this pitfall.