### PR TITLE
config: add 'omitempty' to 'updaters' config struct for correct marshalling

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,7 +58,7 @@ type Config struct {
 	Auth     Auth     `yaml:"auth" json:"auth"`
 	Trace    Trace    `yaml:"trace" json:"trace"`
 	Metrics  Metrics  `yaml:"metrics" json:"metrics"`
-	Updaters Updaters `yaml:"updaters" json:"updaters"`
+	Updaters Updaters `yaml:"updaters,omitempty" json:"updaters,omitempty"`
 }
 
 // Updaters configures updater behavior.
@@ -78,7 +78,7 @@ type Updaters struct {
 	// "rhel"
 	// "suse"
 	// "ubuntu"
-	Sets []string `yaml:"sets" json:"sets"`
+	Sets []string `yaml:"sets,omitempty" json:"sets,omitempty"`
 	// Config holds configuration blocks for UpdaterFactories and Updaters,
 	// keyed by name.
 	//


### PR DESCRIPTION
Clair treats the `updaters.sets` field differently when set to `nil` or `[]string{}`. Adds the `omitempty` struct tag to ensure when marshalling the config the empty `updaters` section is omitted rather than zeroed out.

Fixes https://issues.redhat.com/browse/PROJQUAY-1268