### PR TITLE
notifier: log failed delivery reason

### DIFF
--- a/clair-error/notifications.go
+++ b/clair-error/notifications.go
@@ -117,7 +117,7 @@ type ErrDeliveryFailed struct {
 }
 
 func (e ErrDeliveryFailed) Error() string {
-	return "failed to deliver notification"
+	return "failed to deliver notification: " + e.E.Error()
 }
 
 func (e ErrDeliveryFailed) Unwrap() error {


### PR DESCRIPTION
update ErrFailedDelivery to have its error method also print the
wrapped error's message.

Signed-off-by: ldelossa <ldelossa@redhat.com>