### PR TITLE
Notifier: Fix bugs that ignore some notification

### DIFF
--- a/notifier/amqp/directdeliverer.go
+++ b/notifier/amqp/directdeliverer.go
@@ -85,6 +85,7 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, _ uuid.UUID) error {
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
+	var currentBlock []notifier.Notification
 	for bs, be := 0, rollup; bs < len(d.n); bs, be = be, be+rollup {
 		buf.Reset()
 		// if block-end exceeds array bounds, slice block underflow.
@@ -93,8 +94,8 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, _ uuid.UUID) error {
 			be = len(d.n)
 		}
 
-		d.n = d.n[bs:be]
-		err := enc.Encode(&d.n)
+		currentBlock = d.n[bs:be]
+		err := enc.Encode(&currentBlock)
 		if err != nil {
 			ch.TxRollback()
 			return &clairerror.ErrDeliveryFailed{err}

--- a/notifier/stomp/directdeliverer.go
+++ b/notifier/stomp/directdeliverer.go
@@ -75,6 +75,7 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
+	var currentBlock []notifier.Notification
 	for bs, be := 0, rollup; bs < len(d.n); bs, be = be, be+rollup {
 		buf.Reset()
 		// if block-end exceeds array bounds, slice block underflow.
@@ -83,8 +84,8 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 			be = len(d.n)
 		}
 
-		d.n = d.n[bs:be]
-		err := enc.Encode(&d.n)
+		currentBlock = d.n[bs:be]
+		err := enc.Encode(&currentBlock)
 		if err != nil {
 			tx.Abort()
 			return &clairerror.ErrDeliveryFailed{err}


### PR DESCRIPTION
This PR fixes 2 bugs that caused a subset of notifications was completely ignored.

1)
Fix slices in the direct notifier
There was a bug in the direct notifier that caused only a subset of
notifications was sent to the client. The first iteration over notification
replaced the original notification slice with just the first "page". This caused
that only one "page" was sent and the rest was ignored.

This commit fixes amqp and stomp direct notification delivery.

2)
Create a notification for each vulnerability

The previous implementation sent only a subset of vulnerabilities which
can cause confusion on client side. The current implementation sends
notifications for each combination of vulnerability and affected image.