### PR TITLE
Dockerfile: Get build image from Quay instead of DockerHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.15 AS build
+FROM quay.io/app-sre/golang:1.15 AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev


### PR DESCRIPTION
quay.io/repository/app-sre/golang is supposed to mirror docker.io/golang. Using it will enable us to work around DockerHub's newly introduced pull limits.