### PR TITLE
contrib/helm/clair: replace deprecated postgresql reposiotry

### DIFF
--- a/contrib/helm/clair/Chart.yaml
+++ b/contrib/helm/clair/Chart.yaml
@@ -1,6 +1,6 @@
 name: clair
 home: https://coreos.com/clair
-version: 0.2.0
+version: 0.3.0
 appVersion: 3.0.0-pre
 description: Clair is an open source project for the static analysis of vulnerabilities in application containers.
 icon: https://cloud.githubusercontent.com/assets/343539/21630811/c5081e5c-d202-11e6-92eb-919d5999c77a.png

--- a/contrib/helm/clair/requirements.yaml
+++ b/contrib/helm/clair/requirements.yaml
@@ -2,4 +2,4 @@ dependencies:
   - name: postgresql
     version: "*"
     condition: postgresql.enabled
-    repository: "https://kubernetes-charts.storage.googleapis.com"
+    repository: "https://charts.bitnami.com/bitnami"


### PR DESCRIPTION
The postgresql chart is no longer avaiable in the old helm chart repository, move to new address.