### PR TITLE
Revert "cicd: use golang image from quay.io"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: quay.io/app-sre/golang:${{ matrix.go }}-alpine
+    container: docker.io/library/golang:${{ matrix.go }}-alpine
     env:
       POSTGRES_CONNECTION_STRING: "host=clair-db port=5432 user=clair dbname=clair sslmode=disable"
       RABBITMQ_CONNECTION_STRING: "amqp://guest:guest@clair-rabbitmq:5672/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/app-sre/golang:1.15 AS build
+FROM docker.io/library/golang:1.15 AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev


### PR DESCRIPTION
Unfortunately it seems we need to go back to DockerHub image as app-sre image has become private.

Reverting two previous commits

Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>