### PR TITLE
cicd: use quay.io image in CI and Dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:latest
+    container: quay.io/claircore/golang:1.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: docker.io/library/golang:${{ matrix.go }}-alpine
+    container: quay.io/claircore/golang:${{ matrix.go }}
     env:
       POSTGRES_CONNECTION_STRING: "host=clair-db port=5432 user=clair dbname=clair sslmode=disable"
       RABBITMQ_CONNECTION_STRING: "amqp://guest:guest@clair-rabbitmq:5672/"
@@ -96,8 +96,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: OS Dependencies
-        run: apk add --no-cache tar rpm build-base
       - name: Go Dependencies
         run: go mod vendor
       - name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.15 AS build
+FROM quay.io/claircore/golang:1.15 AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev


### PR DESCRIPTION
This PR complements https://github.com/quay/claircore/pull/284 where the rationale is explained. Main changes in this repo:
- Use quay.io/claircore/golang as build stage in Dockerfile
- Swtich to  UBI-based image in `tests` job as opposed to alpine-based image. I also removed OS Dependencies step in `tests` job as both `tar` and `rpm` are present in the UBI-based image. I don't really know what was the purpose of [build-base package](https://pkgs.alpinelinux.org/package/v3.3/main/x86/build-base). It seems that its dependencies are not used in `tests` job.