### PR TITLE
cicd: add publish-golang-image workflow

### DIFF
--- a/.github/scripts/get-latest-golang-minor-version.sh
+++ b/.github/scripts/get-latest-golang-minor-version.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+MAJOR_VERSION=$1
+LOGFILE=$2
+
+LATEST_MINOR_VERSION=0
+
+while true
+do
+    let CHECK_MINOR_VERSION=LATEST_MINOR_VERSION+1
+    URL=https://dl.google.com/go/go${MAJOR_VERSION}.${CHECK_MINOR_VERSION}.linux-amd64.tar.gz
+    echo -n "${URL} " >> ${LOGFILE}
+    HTTP_RESP_CODE=`curl -I -o /dev/null -s -w "%{http_code}\n" "${URL}"`
+    echo "${HTTP_RESP_CODE}" >> ${LOGFILE}
+    if [[ HTTP_RESP_CODE -ne 200 ]]
+    then
+        break
+    fi
+    let LATEST_MINOR_VERSION++
+done
+
+# Return latest Golang version available for download in format "1.15.6"
+echo "${MAJOR_VERSION}.${LATEST_MINOR_VERSION}"

--- a/.github/workflows/golang-image.yml
+++ b/.github/workflows/golang-image.yml
@@ -1,0 +1,90 @@
+---
+name: Build and publish golang image
+
+on:
+  # Run every day at 5AM UTC
+  schedule:
+    - cron: '0 5 * * *'
+
+env:
+  QUAY_ORG: projectquay
+  QUAY_REPO: golang
+  QUAY_USER: projectquay+clair_github
+  CLAIRCORE_PATH: claircore
+
+jobs:
+  golang-image:
+    name: Build and publish golang image
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+      matrix:
+        go: ['1.13', '1.14', '1.15']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Determine the latest released minor version of golang
+        run: |
+          GO_VERSION=`./.github/scripts/get-latest-golang-minor-version.sh ${{ matrix.go }} ${{ matrix.go }}.log`
+          echo "The latest released golang version is ${GO_VERSION}"
+          echo "GO_VERSION=${GO_VERSION}" >> $GITHUB_ENV
+      - name: Archive logfile
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ matrix.go }}.log
+          name: ${{ matrix.go }}.log
+          retention-days: 14
+      - name: Determine when quay.io tag was last modified
+        run: |
+          API_RESPONSE=`curl -s \
+            "https://quay.io/api/v1/repository/${QUAY_ORG}/${QUAY_REPO}/tag/?specificTag=${{ matrix.go }}&onlyActiveTags=true"`
+          if [[ `jq -r '.tags' <<< $API_RESPONSE` = "[]" ]]
+          then
+            # The tag we're looking for doesn't exist in the repository so we make sure we'll publish it
+            TAG_LAST_MODIFIED="Thu, 01 Jan 1970 00:00:00 -0000"
+          else
+            TAG_LAST_MODIFIED=`jq -r '.tags[].last_modified' <<< $API_RESPONSE`
+          fi
+          echo "quay.io/${QUAY_ORG}/${QUAY_REPO} was last modified on ${TAG_LAST_MODIFIED}"
+          echo "TAG_LAST_MODIFIED=${TAG_LAST_MODIFIED}" >> $GITHUB_ENV
+      - name: Determine when released golang was last modified
+        run: |
+          GO_LAST_MODIFIED=`curl -sI \
+            https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
+            | awk 'BEGIN {FS=": "}/^last-modified/{print $2}'`
+          echo "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz was last modified on ${GO_LAST_MODIFIED}"
+          echo "GO_LAST_MODIFIED=${GO_LAST_MODIFIED}" >> $GITHUB_ENV
+      - name: Decide whether we need to build new golang image
+        run: |
+          TAG=`date -d "${TAG_LAST_MODIFIED}" +%s`
+          GO=`date -d "${GO_LAST_MODIFIED}" +%s`
+          if [[ $GO -gt $TAG ]]
+          then
+            echo "BUILD_IMAGE=1" >> $GITHUB_ENV
+            echo "We need to build and publish new golang image since new version of golang has been released"
+          else
+            echo "BUILD_IMAGE=0" >> $GITHUB_ENV
+            echo "No need to publish new golang image, it is up to date"
+          fi
+      - name: Prepare for new golang image build
+        run: |
+          TAG=quay.io/${QUAY_ORG}/${QUAY_REPO}:${{ matrix.go }}
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "::add-mask::${{ secrets.QUAY_TOKEN }}"
+        if: env.BUILD_IMAGE == 1
+      - name: Checkout claircore repository
+        uses: actions/checkout@v2
+        with:
+          repository: quay/claircore
+          path: ${{ env.CLAIRCORE_PATH }}
+        if: env.BUILD_IMAGE == 1
+      - name: Build golang image
+        run: |
+          docker build -f ${CLAIRCORE_PATH}/etc/Dockerfile -t ${TAG}\
+            --build-arg GO_VERSION=${GO_VERSION} ${CLAIRCORE_PATH}/etc
+        if: env.BUILD_IMAGE == 1
+      - name: Publish golang image
+        run: |
+          docker login -u "${QUAY_USER}" -p '${{ secrets.QUAY_TOKEN }}' quay.io
+          docker push "${TAG}"
+        if: env.BUILD_IMAGE == 1


### PR DESCRIPTION
Intent of this PR is to deal with most of the problems outlined in #1156. Please see the issue for in-depth analysis of why we need this. 

## Implementation
I've has some really good discussions about this with Louis and Hank in #clair-collaboration and this is the outcome. The new workflow will run every day, at 5AM UTC. Here's the basic logic:
```
Find out what is the latest released minor version of golang
(Example: For go1.15 it'll be 1.15.7)
|
v
Find out when respective tag (golang major version) of quay.io/projectquay/golang was last modified
(Example: quay.io/projectquay/golang:1.15 was last modified on January 1 2021)
|
v
Find out when the released minor version of golang was last modified
(Example: https://dl.google.com/go/go1.15.7.linux-amd64.tar.gz was last modified on January 15 2021)
|
v
Check if released golang is newer than the quay.io tag
|  |
|  L> If not, no need to do anything
|
v
If yes (case of our example), continue
|
v
Build new image and tag it quay.io/projectquay/golang:1.15
|
v
Push the newly built image
```

## Missing stuff
1. There's one thing I could not figure out and that is how to get sha256 checksum of golang archive programatically. Why do we even need this? The Dockerfile used to build our golang image [uses it to verify](https://github.com/quay/claircore/blob/fc1aa30841820e309653733db660c56deae033f8/etc/Dockerfile#L12) that the downloaded archive wasn't tampered with. This workflow works fine even without providing such checksum, but we have this in the GH Actions log:
![image](https://user-images.githubusercontent.com/22600243/106622547-ff12d200-6573-11eb-81f8-a377fcf11762.png)
So couple of points here:
- Do we really need this check?
- Do you guys have any idea how to fetch the checksum in the automation?
- I mean I could parse the HTML code of the download page but that seems like a [bad idea](https://stackoverflow.com/a/1732454/6758779)
2. For this initiative to be finalized, we need to make sure that our CI here and in quay/claircore consumes quay.io/projectquay/golang instead of quay.io/claircore/golang. I suggest to do it afterwards in separate, small PRs once we are sure this is running regularly and reliably.