### PR TITLE
HTTP Readiness

### DIFF
--- a/httptransport/client/matcher.go
+++ b/httptransport/client/matcher.go
@@ -236,3 +236,9 @@ func (c *HTTP) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.Upd
 	}
 	return &d, nil
 }
+
+// Initialized is present to fulfill the interface, but isn't exposed as part of
+// the HTTP API. This method is stubbed out.
+func (c *HTTP) Initialized(_ context.Context) (bool, error) {
+	return true, nil
+}

--- a/httptransport/vulnerabilityreporthandler.go
+++ b/httptransport/vulnerabilityreporthandler.go
@@ -51,6 +51,20 @@ func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service
 			return
 		}
 
+		initd, err := service.Initialized(ctx)
+		if err != nil {
+			resp := &je.Response{
+				Code:    "internal-server-error",
+				Message: err.Error(),
+			}
+			je.Error(w, resp, http.StatusInternalServerError)
+			return
+		}
+		if !initd {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
 		indexReport, ok, err := indexer.IndexReport(ctx, manifest)
 		// check err first
 		if err != nil {

--- a/httptransport/vulnerabilityreporthandler_test.go
+++ b/httptransport/vulnerabilityreporthandler_test.go
@@ -1,0 +1,58 @@
+package httptransport
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/quay/claircore"
+
+	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/matcher"
+)
+
+func TestInitialized(t *testing.T) {
+	var initd bool
+	digest := claircore.MustParseDigest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	h := VulnerabilityReportHandler(
+		&matcher.Mock{
+			Initialized_: func(_ context.Context) (bool, error) {
+				return initd, nil
+			},
+		},
+		&indexer.Mock{
+			IndexReport_: func(ctx context.Context, d claircore.Digest) (*claircore.IndexReport, bool, error) {
+				if got, want := d.String(), digest.String(); got != want {
+					return nil, false, fmt.Errorf("unexpected digest: %v", got)
+				}
+				return nil, false, nil
+			},
+		},
+	)
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+	c := srv.Client()
+
+	res, err := c.Get(srv.URL + "/" + digest.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	t.Log(res.Status)
+	if res.StatusCode != http.StatusAccepted {
+		t.Errorf("unexpected response")
+	}
+
+	initd = true
+	res, err = c.Get(srv.URL + "/" + digest.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+	t.Log(res.Status)
+	if res.StatusCode != http.StatusNotFound {
+		t.Errorf("unexpected response")
+	}
+}

--- a/matcher/mock.go
+++ b/matcher/mock.go
@@ -22,6 +22,7 @@ type Mock struct {
 	LatestUpdateOperations_ func(context.Context) (map[string][]driver.UpdateOperation, error)
 	UpdateDiff_             func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error)
 	Scan_                   func(context.Context, *claircore.IndexReport) (*claircore.VulnerabilityReport, error)
+	Initialized_            func(context.Context) (bool, error)
 	// TestUOs provide memory for the mock.
 	// usage of this field can be dictated by the test case's needs.
 	sync.Mutex
@@ -76,4 +77,11 @@ func (d *Mock) Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.
 		panic("mock matcher: unexpected call to Scan")
 	}
 	return d.Scan_(ctx, ir)
+}
+
+func (d *Mock) Initialized(ctx context.Context) (bool, error) {
+	if d.Initialized_ == nil {
+		panic("mock matcher: unexpected call to Initialized")
+	}
+	return d.Initialized_(ctx)
 }

--- a/matcher/service.go
+++ b/matcher/service.go
@@ -19,6 +19,7 @@ type Service interface {
 
 // Scanner is an interface providing a claircore.VulnerabilityReport given a claircore.IndexReport
 type Scanner interface {
+	Initialized(context.Context) (bool, error)
 	Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.VulnerabilityReport, error)
 }
 


### PR DESCRIPTION
This change (based on #1111) has the http server start serving requests immediately, and start serving the API after initialization is done.