### PR TITLE
httptransport: check for err before deferring resp.Body.Close()

### DIFF
--- a/httptransport/client/indexer.go
+++ b/httptransport/client/indexer.go
@@ -38,12 +38,10 @@ func (s *HTTP) AffectedManifests(ctx context.Context, v []claircore.Vulnerabilit
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, &clairerror.ErrRequestFail{Code: resp.StatusCode, Status: resp.Status}
 	}
+	defer resp.Body.Close()
 	err = json.NewDecoder(resp.Body).Decode(&affected)
 	if err != nil {
 		return nil, &clairerror.ErrBadAffectedManifests{err}
@@ -73,12 +71,10 @@ func (s *HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*clairc
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to do request: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, &clairerror.ErrRequestFail{Code: resp.StatusCode, Status: resp.Status}
 	}
@@ -103,12 +99,10 @@ func (s *HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*cla
 		return nil, false, fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to do request: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, false, nil
 	}
@@ -135,13 +129,10 @@ func (s *HTTP) State(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to create request: %v", err)
 	}
 	resp, err := s.c.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
 	if err != nil {
 		return "", fmt.Errorf("failed to do request: %v", err)
 	}
+	defer resp.Body.Close()
 	buf := &bytes.Buffer{}
 	if _, err := buf.ReadFrom(resp.Body); err != nil {
 		return "", err

--- a/httptransport/client/matcher.go
+++ b/httptransport/client/matcher.go
@@ -38,12 +38,10 @@ func (c *HTTP) Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.
 	}
 
 	resp, err := c.c.Do(req)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%v: unexpected status: %s", u.Path, resp.Status)
 	}
@@ -89,13 +87,11 @@ func (c *HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) (in
 					return
 				}
 				res, err := c.c.Do(req)
-				if res != nil {
-					defer res.Body.Close()
-				}
 				if err != nil {
 					errs[i] = err
 					return
 				}
+				defer res.Body.Close()
 				if got, want := res.StatusCode, http.StatusOK; got != want {
 					errs[i] = fmt.Errorf("%v: unexpected status: %s", u.Path, res.Status)
 				}
@@ -176,12 +172,10 @@ func (c *HTTP) LatestUpdateOperations(ctx context.Context) (map[string][]driver.
 // if a subsequent response provides a StatusNotModified status, the map of UpdateOprations is served from cache.
 func (c *HTTP) updateOperations(ctx context.Context, req *http.Request, cache *uoCache) (map[string][]driver.UpdateOperation, error) {
 	res, err := c.c.Do(req)
-	if res != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	switch res.StatusCode {
 	case http.StatusOK:
 		m := make(map[string][]driver.UpdateOperation)
@@ -223,12 +217,10 @@ func (c *HTTP) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.Upd
 	req.URL.RawQuery = v.Encode()
 
 	res, err := c.c.Do(req)
-	if res != nil {
-		defer res.Body.Close()
-	}
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%v: unexpected status: %s", u.Path, res.Status)
 	}


### PR DESCRIPTION
There is quite a big story behind this PR. First, let me offer **TLDR**. If `err` isn't checked before referring to `resp.Body`, we might hit nil pointer dereference. See this [SO post](https://stackoverflow.com/questions/16280176/go-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference).

Here's the **whole story**. It all started with Red Hat Product Security team substantially extending data available in [OVAL v2 streams](https://www.redhat.com/security/data/oval/v2/). When this change hit the production, we started seeing issues with notifier deployed in our OpenShift cluster. 

The first symptom that I found was that notifier simply could not process update operation created by certain stream. In notifier pod, it looked like this:
![Screenshot from 2021-02-05 14-32-04](https://user-images.githubusercontent.com/22600243/107040417-7e481600-67bf-11eb-8aa8-45cbba4a31b2.png)
Basically all of the four [processors](https://github.com/quay/clair/blob/f2d731341722e3d59c9351c10b7e8eedbe74f276/notifier/service/service.go#L30) would try to [acquire lock](https://github.com/quay/clair/blob/f8adc0f6b451009c731ad975955101fbf061e40f/notifier/processor.go#L84) on one update operation and none of them could actually acquire it. This caused the whole notifier to be forever stuck on one update operation.

I connected to our Clair DB and found out that there is an advisory lock sitting there. 
![image](https://user-images.githubusercontent.com/22600243/107041058-53aa8d00-67c0-11eb-9a8a-9519f9cf6221.png)
I couldn't find out how long has it been there, but I started to monitor it and could see that it was still there after 30 minutes. No operation could take that long, so it must meant that the lock is stale.

As far as I can understand, these advisory [locks get freed](https://stackoverflow.com/questions/50098475/how-to-query-the-age-of-postgresql-advisory-locks#comment87213654_50098475) up when either a transaction or a session closes. So I came to the conclusion that some process must have died without gracefully tearing down whatever DB operation it was doing.

And indeed, I found out that our notifier crashed couple of hours ago and then OpenShift just spun up new pods:
![image](https://user-images.githubusercontent.com/22600243/107041631-0aa70880-67c1-11eb-9b42-ed8141a2065c.png)

So I guess you're getting the picture now:
1. Notifier pod is spun up but crashes during processing of update operation
2. As a result of the crash, new notifier pod is created
3. None of the notifier processors in the new pod can acquire lock on that update operation
4. Notifier is forever stuck on trying to acquire the lock

So the crash is the cause of it all. To my best knowledge, it happens [here](https://github.com/quay/clair/blob/f2d731341722e3d59c9351c10b7e8eedbe74f276/httptransport/client/indexer.go#L42) when we try to refer `resp.Body`. However, `resp.Body` is guaranteed to be non-nil only when `err` is nil, see [here](https://golang.org/pkg/net/http/#Client.Do).

Hence my change. I suggest we first check the error returned by `Do`. If it's non-nil, we return as we'd do anyway. If it's nil, we can safely `defer` closing of the body as it's guaranteed to be non-nil.

Addendum: The crash seems to have appeared after with sent HTTP request with 273MB JSON body [here](https://github.com/quay/clair/blob/f8adc0f6b451009c731ad975955101fbf061e40f/httptransport/client/indexer.go#L40-L40). I still don't know if that's as problem of clair per se or if this is related to our deployment. Be as it may, this PR won't solve that issue. However, it should make sure that notifier won't get stuck in an infinite loop.
