### PR TITLE
Notifier efficiency

### DIFF
--- a/cmd/clairctl/jsonformatter.go
+++ b/cmd/clairctl/jsonformatter.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"encoding/json"
 	"io"
+
+	"github.com/quay/clair/v4/internal/codec"
 )
 
 var _ Formatter = (*jsonFormatter)(nil)
@@ -10,10 +11,14 @@ var _ Formatter = (*jsonFormatter)(nil)
 // JsonFormatter is a very simple formatter; it just calls
 // (*json.Encoder).Encode.
 type jsonFormatter struct {
-	enc *json.Encoder
-	io.Closer
+	enc *codec.Encoder
+	c   io.Closer
 }
 
 func (f *jsonFormatter) Format(r *Result) error {
 	return f.enc.Encode(r.Report)
+}
+func (f *jsonFormatter) Close() error {
+	codec.PutEncoder(f.enc)
+	return f.c.Close()
 }

--- a/cmd/clairctl/manifest.go
+++ b/cmd/clairctl/manifest.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -16,6 +14,8 @@ import (
 	"github.com/quay/claircore"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/clair/v4/internal/codec"
 )
 
 var ManifestCmd = &cli.Command{
@@ -37,12 +37,10 @@ func manifestAction(c *cli.Context) error {
 	eg, ctx := errgroup.WithContext(c.Context)
 	go func() {
 		defer close(done)
-		buf := bufio.NewWriter(os.Stdout)
-		defer buf.Flush()
-		enc := json.NewEncoder(buf)
+		enc := codec.GetEncoder(os.Stdout)
+		defer codec.PutEncoder(enc)
 		for m := range result {
-			enc.Encode(m)
-			buf.Flush()
+			enc.MustEncode(m)
 		}
 	}()
 

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -14,6 +13,8 @@ import (
 	"github.com/quay/claircore"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/quay/clair/v4/internal/codec"
 )
 
 // ReportCmd is the "report" subcommand.
@@ -73,8 +74,8 @@ func (o *outFmt) Formatter(w io.WriteCloser) Formatter {
 	case "json":
 		debug.Println("using json output")
 		return &jsonFormatter{
-			enc:    json.NewEncoder(w),
-			Closer: w,
+			enc: codec.GetEncoder(w),
+			c:   w,
 		}
 	case "xml":
 		debug.Println("using xml output")

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/rs/zerolog v1.20.0
 	github.com/streadway/amqp v1.0.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
+	github.com/ugorji/go/codec v1.2.4
 	github.com/urfave/cli/v2 v2.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.16.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -700,7 +700,12 @@ github.com/temoto/robotstxt v1.1.1/go.mod h1:+1AmkuG3IYkh1kv0d2qEB9Le88ehNO0zwOr
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
+github.com/ugorji/go v1.2.4 h1:cTciPbZ/VSOzCLKclmssnfQ/jyoVyOcJ3aoJyUV1Urc=
+github.com/ugorji/go v1.2.4/go.mod h1:EuaSCk8iZMdIspsu6HXH7X2UGKw1ezO4wCfGszGmmo4=
+github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8 h1:3SVOIvH7Ae1KRYyQWRjXWJEA9sS/c/pjvH++55Gr648=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
+github.com/ugorji/go/codec v1.2.4 h1:C5VurWRRCKjuENsbM6GYVw8W++WVW9rSxoACKIvxzz8=
+github.com/ugorji/go/codec v1.2.4/go.mod h1:bWBu1+kIRWcF8uMklKaJrR6fTWQOwAlrIzX22pHwryA=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/httptransport/indexreporthandler.go
+++ b/httptransport/indexreporthandler.go
@@ -1,7 +1,6 @@
 package httptransport
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	je "github.com/quay/claircore/pkg/jsonerr"
 
 	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/internal/codec"
 )
 
 // IndexReportHandler utilizes a Reporter to serialize
@@ -80,6 +80,8 @@ func IndexReportHandler(serv indexer.StateReporter) http.HandlerFunc {
 
 		w.Header().Add("etag", validator)
 		defer writerError(w, &err)()
-		err = json.NewEncoder(w).Encode(report)
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(report)
 	}
 }

--- a/httptransport/indexstatehandler.go
+++ b/httptransport/indexstatehandler.go
@@ -1,12 +1,12 @@
 package httptransport
 
 import (
-	"encoding/json"
 	"net/http"
 
 	je "github.com/quay/claircore/pkg/jsonerr"
 
 	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/internal/codec"
 )
 
 // IndexStateHandler utilizes a Stater to report the
@@ -43,7 +43,9 @@ func IndexStateHandler(service indexer.Stater) http.HandlerFunc {
 		w.Header().Set("content-type", "application/json")
 
 		defer writerError(w, &err)()
-		err = json.NewEncoder(w).Encode(struct {
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(struct {
 			State string `json:"state"`
 		}{
 			State: s,

--- a/httptransport/keybyidhandler.go
+++ b/httptransport/keybyidhandler.go
@@ -1,17 +1,17 @@
 package httptransport
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"path"
 
+	"github.com/google/uuid"
+	je "github.com/quay/claircore/pkg/jsonerr"
 	jose "gopkg.in/square/go-jose.v2"
 
-	"github.com/google/uuid"
 	clairerror "github.com/quay/clair/v4/clair-error"
+	"github.com/quay/clair/v4/internal/codec"
 	"github.com/quay/clair/v4/notifier"
-	je "github.com/quay/claircore/pkg/jsonerr"
 )
 
 // KeyByIDHandler returns a particular key queried by ID in JWK format.
@@ -72,6 +72,8 @@ func KeyByIDHandler(keystore notifier.KeyStore) http.HandlerFunc {
 			Use:   "sig",
 		}
 		defer writerError(w, &err)()
-		err = json.NewEncoder(w).Encode(&jwk)
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(&jwk)
 	}
 }

--- a/httptransport/keyshandler.go
+++ b/httptransport/keyshandler.go
@@ -1,13 +1,13 @@
 package httptransport
 
 import (
-	"encoding/json"
 	"net/http"
 
+	je "github.com/quay/claircore/pkg/jsonerr"
 	jose "gopkg.in/square/go-jose.v2"
 
+	"github.com/quay/clair/v4/internal/codec"
 	"github.com/quay/clair/v4/notifier"
-	je "github.com/quay/claircore/pkg/jsonerr"
 )
 
 // KeysHandler returns all keys persisted in the keystore in JWK set format.
@@ -54,6 +54,8 @@ func KeysHandler(keystore notifier.KeyStore) http.HandlerFunc {
 		}
 
 		defer writerError(w, &err)()
-		err = json.NewEncoder(w).Encode(&set)
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(&set)
 	}
 }

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -219,7 +219,7 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 		intromw.InstrumentedHandler(KeysAPIPath, t.traceOpt, KeysHandler(ks)))
 
 	t.Handle(KeyByIDAPIPath,
-		intromw.InstrumentedHandler(KeyByIDAPIPath, t.traceOpt, KeyByIDHandler(ks)))
+		intromw.InstrumentedHandler(KeyByIDAPIPath+"_KEY", t.traceOpt, KeyByIDHandler(ks)))
 
 	return nil
 }

--- a/httptransport/updatediffhandler.go
+++ b/httptransport/updatediffhandler.go
@@ -1,13 +1,14 @@
 package httptransport
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/quay/clair/v4/matcher"
 	je "github.com/quay/claircore/pkg/jsonerr"
+
+	"github.com/quay/clair/v4/internal/codec"
+	"github.com/quay/clair/v4/matcher"
 )
 
 // UpdateDiffHandler provides an endpoint to GET update diffs
@@ -69,6 +70,8 @@ func UpdateDiffHandler(serv matcher.Differ) http.HandlerFunc {
 		}
 
 		defer writerError(w, &err)()
-		err = json.NewEncoder(w).Encode(&diff)
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(&diff)
 	}
 }

--- a/httptransport/vulnerabilityreporthandler.go
+++ b/httptransport/vulnerabilityreporthandler.go
@@ -2,7 +2,6 @@ package httptransport
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptrace"
@@ -13,6 +12,7 @@ import (
 	oteltrace "go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 
 	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/internal/codec"
 	"github.com/quay/clair/v4/matcher"
 )
 
@@ -61,7 +61,7 @@ func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service
 			je.Error(w, resp, http.StatusInternalServerError)
 			return
 		}
-		// now check bool only after comfirning no errr
+		// now check bool only after confirming no err
 		if !ok {
 			resp := &je.Response{
 				Code:    "not-found",
@@ -83,7 +83,8 @@ func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service
 		}
 
 		defer writerError(w, &err)()
-		w.WriteHeader(http.StatusOK)
-		err = json.NewEncoder(w).Encode(vulnReport)
+		enc := codec.GetEncoder(w)
+		defer codec.PutEncoder(enc)
+		err = enc.Encode(vulnReport)
 	}
 }

--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -1,0 +1,64 @@
+// Package codec is a unified place for configuring and allocating JSON encoders
+// and decoders.
+package codec
+
+import (
+	"io"
+	"sync"
+
+	"github.com/ugorji/go/codec"
+)
+
+var jsonHandle codec.JsonHandle
+
+func init() {
+	// This is documented to cause "smart buffering".
+	jsonHandle.WriterBufferSize = 4096
+	jsonHandle.ReaderBufferSize = 4096
+}
+
+// Encoder and decoder pools, to reuse if possible.
+var (
+	encPool = sync.Pool{
+		New: func() interface{} {
+			return codec.NewEncoder(nil, &jsonHandle)
+		},
+	}
+	decPool = sync.Pool{
+		New: func() interface{} {
+			return codec.NewDecoder(nil, &jsonHandle)
+		},
+	}
+)
+
+// Encoder encodes.
+type Encoder = codec.Encoder
+
+// GetEncoder returns an encoder configured to write to w.
+func GetEncoder(w io.Writer) *Encoder {
+	e := encPool.Get().(*Encoder)
+	e.Reset(w)
+	return e
+}
+
+// PutEncoder returns an encoder to the pool.
+func PutEncoder(e *Encoder) {
+	e.Reset(nil)
+	encPool.Put(e)
+}
+
+// Decoder decodes.
+type Decoder = codec.Decoder
+
+// GetDecoder returns a decoder configured to read from r.
+func GetDecoder(r io.Reader) *Decoder {
+	d := decPool.Get().(*Decoder)
+	d.Reset(r)
+	return d
+}
+
+// PutDecoder returns a decoder to the pool.
+func PutDecoder(d *Decoder) {
+	d.Reset(nil)
+	decPool.Put(d)
+}

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -1,0 +1,74 @@
+package codec
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func Example() {
+	enc := GetEncoder(os.Stdout)
+	defer PutEncoder(enc)
+	enc.MustEncode([]string{"a", "slice", "of", "strings"})
+	fmt.Fprintln(os.Stdout)
+	enc.MustEncode(nil)
+	fmt.Fprintln(os.Stdout)
+	enc.MustEncode(map[string]string{})
+	fmt.Fprintln(os.Stdout)
+	// Output: ["a","slice","of","strings"]
+	// null
+	// {}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	b.ReportAllocs()
+	want := map[string]string{
+		"a": strings.Repeat(`A`, 2048),
+		"b": strings.Repeat(`B`, 2048),
+		"c": strings.Repeat(`C`, 2048),
+		"d": strings.Repeat(`D`, 2048),
+	}
+	got := make(map[string]string, len(want))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dec := GetDecoder(JSONReader(want))
+		err := dec.Decode(&got)
+		PutDecoder(dec)
+		if err != nil {
+			b.Error(err)
+		}
+		if !cmp.Equal(got, want) {
+			b.Error(cmp.Diff(got, want))
+		}
+	}
+}
+
+func BenchmarkDecodeStdlib(b *testing.B) {
+	b.ReportAllocs()
+	want := map[string]string{
+		"a": strings.Repeat(`A`, 2048),
+		"b": strings.Repeat(`B`, 2048),
+		"c": strings.Repeat(`C`, 2048),
+		"d": strings.Repeat(`D`, 2048),
+	}
+	got := make(map[string]string, len(want))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		x, err := json.Marshal(want)
+		if err != nil {
+			b.Error(err)
+		}
+		if err := json.Unmarshal(x, &got); err != nil {
+			b.Error(err)
+		}
+		if !cmp.Equal(got, want) {
+			b.Error(cmp.Diff(got, want))
+		}
+	}
+}

--- a/internal/codec/reader.go
+++ b/internal/codec/reader.go
@@ -1,0 +1,20 @@
+package codec
+
+import "io"
+
+// JSONReader returns an io.ReadCloser backed by a pipe being fed by a JSON
+// encoder.
+func JSONReader(v interface{}) io.ReadCloser {
+	r, w := io.Pipe()
+	// This unsupervised goroutine should be fine, because the writer will error
+	// once the reader is closed.
+	go func() {
+		enc := GetEncoder(w)
+		defer PutEncoder(enc)
+		defer w.Close()
+		if err := enc.Encode(v); err != nil {
+			w.CloseWithError(err)
+		}
+	}()
+	return r
+}

--- a/notifier/callback_test.go
+++ b/notifier/callback_test.go
@@ -1,0 +1,41 @@
+package notifier
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
+)
+
+func TestCallbackSerializtion(t *testing.T) {
+	var want = []byte(`{"callback":"https://example.com","notification_id":"00000000-0000-0000-0000-000000000000"}`)
+	cb := Callback{
+		NotificationID: uuid.Nil,
+	}
+	u, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Error(err)
+	}
+	cb.Callback = *u
+	got, err := json.Marshal(&cb)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+
+	var rt Callback
+	if err := json.Unmarshal(want, &rt); err != nil {
+		t.Error(err)
+	}
+	got, err = json.Marshal(&rt)
+	if err != nil {
+		t.Error(err)
+	}
+	if !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+}

--- a/notifier/processor_create_test.go
+++ b/notifier/processor_create_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -243,6 +244,10 @@ func testProcessorCreate(t *testing.T) {
 			if opts.NotificationID == uuid.Nil {
 				t.Fatalf("malformed notification id: %v", opts.NotificationID)
 			}
+			// Need some sort of stable order here:
+			sort.Slice(opts.Notifications, func(i, j int) bool {
+				return opts.Notifications[i].Reason < opts.Notifications[j].Reason
+			})
 			if !cmp.Equal(opts.Notifications, notifications, cmpopts.IgnoreUnexported(claircore.Digest{})) {
 				t.Fatalf("%v", cmp.Diff(opts.Notifications, notifications, cmpopts.IgnoreUnexported(claircore.Digest{})))
 			}

--- a/notifier/stomp/deliverer.go
+++ b/notifier/stomp/deliverer.go
@@ -8,6 +8,7 @@ import (
 
 	gostomp "github.com/go-stomp/stomp"
 	"github.com/google/uuid"
+
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/notifier"
 )

--- a/notifier/stomp/directdeliverer.go
+++ b/notifier/stomp/directdeliverer.go
@@ -8,6 +8,7 @@ import (
 
 	gostomp "github.com/go-stomp/stomp"
 	"github.com/google/uuid"
+
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/notifier"
 )

--- a/notifier/webhook/deliverer.go
+++ b/notifier/webhook/deliverer.go
@@ -1,21 +1,20 @@
 package webhook
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"time"
 
 	"github.com/google/uuid"
-	clairerror "github.com/quay/clair/v4/clair-error"
-	"github.com/quay/clair/v4/notifier"
-	"github.com/quay/clair/v4/notifier/keymanager"
 	"github.com/rs/zerolog"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
+
+	clairerror "github.com/quay/clair/v4/clair-error"
+	"github.com/quay/clair/v4/internal/codec"
+	"github.com/quay/clair/v4/notifier"
+	"github.com/quay/clair/v4/notifier/keymanager"
 )
 
 type Deliverer struct {
@@ -91,16 +90,11 @@ func (d *Deliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 		NotificationID: nID,
 		Callback:       *callback,
 	}
-	b, err := json.Marshal(&wh)
-	if err != nil {
-		return err
-	}
-	buf := bytes.NewReader(b)
 
 	req := &http.Request{
 		URL:    d.conf.target,
 		Header: d.conf.Headers,
-		Body:   ioutil.NopCloser(buf),
+		Body:   codec.JSONReader(&wh),
 		Method: http.MethodPost,
 	}
 


### PR DESCRIPTION
This changeset attempts to improve memory usage across clair, and especially around the `affected_manifests` call.

* It attempts to use `io.Pipe` to cross-wire JSON encoding and API requests, to avoid buffering the entire body request in memory.
* It replaces usage of `encoding/json` with `github.com/ugorji/go/codec` configured for JSON in order to allow streaming the JSON encoding.
* It chunks `affected_manifests` calls in the notifier. This should prevent large vulnerability turnovers from causing extremely large API calls.

cc @jan-zmeskal