### PR TITLE
httptransport: use correct handler for state endpoint

### DIFF
--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -174,7 +174,7 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 		intromw.InstrumentedHandler(IndexReportAPIPath+"GET", t.traceOpt, IndexReportHandler(t.indexer)))
 
 	t.Handle(IndexStateAPIPath,
-		intromw.InstrumentedHandler(IndexStateAPIPath, t.traceOpt, IndexReportHandler(t.indexer)))
+		intromw.InstrumentedHandler(IndexStateAPIPath, t.traceOpt, IndexStateHandler(t.indexer)))
 
 	return nil
 }


### PR DESCRIPTION
Looks like this was missed in the metrics pass and review.

This should resolve some part of #1199.