### PR TITLE
initialize: wire up DisableUpdaters option

### DIFF
--- a/initialize/services.go
+++ b/initialize/services.go
@@ -74,13 +74,18 @@ func (i *Init) Services() error {
 		for name, node := range i.conf.Updaters.Config {
 			updaterConfigs[name] = node.Decode
 		}
+		sets := i.conf.Updaters.Sets
+		if i.conf.Matcher.DisableUpdaters {
+			sets = []string{}
+		}
 		libV, err := libvuln.New(i.GlobalCTX, &libvuln.Opts{
-			MaxConnPool:    int32(i.conf.Matcher.MaxConnPool),
-			ConnString:     i.conf.Matcher.ConnString,
-			Migrations:     i.conf.Matcher.Migrations,
-			UpdaterSets:    i.conf.Updaters.Sets,
-			UpdateInterval: per,
-			UpdaterConfigs: updaterConfigs,
+			MaxConnPool:              int32(i.conf.Matcher.MaxConnPool),
+			ConnString:               i.conf.Matcher.ConnString,
+			Migrations:               i.conf.Matcher.Migrations,
+			UpdaterSets:              sets,
+			UpdateInterval:           per,
+			UpdaterConfigs:           updaterConfigs,
+			DisableBackgroundUpdates: i.conf.Matcher.DisableUpdaters,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to initialize libvuln: %v", err)
@@ -168,14 +173,19 @@ func (i *Init) Services() error {
 		for name, node := range i.conf.Updaters.Config {
 			updaterConfigs[name] = node.Decode
 		}
+		sets := i.conf.Updaters.Sets
+		if i.conf.Matcher.DisableUpdaters {
+			sets = []string{}
+		}
 		// configure a local matcher but a remote indexer
 		libV, err := libvuln.New(i.GlobalCTX, &libvuln.Opts{
-			MaxConnPool:    int32(i.conf.Matcher.MaxConnPool),
-			ConnString:     i.conf.Matcher.ConnString,
-			Migrations:     i.conf.Matcher.Migrations,
-			UpdaterSets:    i.conf.Updaters.Sets,
-			UpdateInterval: per,
-			UpdaterConfigs: updaterConfigs,
+			MaxConnPool:              int32(i.conf.Matcher.MaxConnPool),
+			ConnString:               i.conf.Matcher.ConnString,
+			Migrations:               i.conf.Matcher.Migrations,
+			UpdaterSets:              sets,
+			UpdateInterval:           per,
+			UpdaterConfigs:           updaterConfigs,
+			DisableBackgroundUpdates: i.conf.Matcher.DisableUpdaters,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to initialize libvuln: %v", err)


### PR DESCRIPTION
This should prevent all updaters from even being constructed in
claircore.

Fixes PROJQUAY-1759.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>