### PR TITLE
cicd: enable CI on stable branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,11 @@ on:
   push:
     branches:
       - main
+      - release-4.*
   pull_request:
     branches:
       - main
+      - release-4.*
 
 jobs:
   commit-check:


### PR DESCRIPTION
Noticed this wasn't firing, I think this should fix it.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>