### PR TITLE
cicd: bump in go.16, bump out go1.14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.14', '1.15']
+        go: ['1.15', '1.16']
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
in order to link to cc v0.3.2 a minimum
of go 1.15 is required.

this bumps out 1.14, keeps 1.15 and adds 1.16

Signed-off-by: ldelossa <ldelossa@redhat.com>