### PR TITLE
clair: fix initialization error logging

### DIFF
--- a/cmd/clair/version.go
+++ b/cmd/clair/version.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"time"
+)
+
+// This is a helper for development. In production, we shouldn't assume that the
+// process is running in a git repository or that git is installed. Our build
+// system does this for release builds.
+
+func init() {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+	if Version != "" {
+		// Had our version injected at build: do nothing.
+		return
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		// Couldn't find a git binary: do nothing.
+		return
+	}
+	if err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Run(); err != nil {
+		// Couldn't find a git repository: do nothing.
+		return
+	}
+	out, err := exec.CommandContext(ctx, "git", "describe").Output()
+	if err != nil {
+		// Couldn't describe the current commit: do nothing.
+		return
+	}
+	Version = string(bytes.TrimSpace(out))
+}


### PR DESCRIPTION
The initialization reorganization inadvertently shuffled things such
that initialization errors didn't tear down the errgroup and collect the
returned error, so any error was logged as "canceled context."

Fixes PROJQUAY-1760.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>