### PR TITLE
Louis/bump stable cc v0.1.24

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,6 +4,7 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/quay/clair
 options:
+  tag_sort_by: semver
   commits:
     sort_by: Scope
   commit_groups:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -35,10 +35,10 @@ jobs:
             touch changelog
             exit 0
           fi
-          curl -o git-chglog -L https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
-          chmod u+x git-chglog
+          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
+          chmod u+x /tmp/git-chglog
           echo "creating change log for tag: $TAG"
-          ./git-chglog "${TAG}" > changelog
+          /tmp/git-chglog "${TAG}" > changelog
       - name: Upload Release Archive
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Changelog
         shell: bash
         run: |
-          curl -o /tmp/git-chglog -L https://github.com/git-chglog/git-chglog/releases/download/0.9.1/git-chglog_linux_amd64
+          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
           chmod u+x /tmp/git-chglog
           echo "creating change log for tag: ${{ github.event.inputs.tag }}"
           /tmp/git-chglog --tag-filter-pattern "v4" --next-tag "${{ github.event.inputs.tag }}" -o CHANGELOG.md v4.0.0-alpha.2..

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/prometheus/client_golang v0.9.4 // indirect
 	github.com/prometheus/procfs v0.0.8 // indirect
-	github.com/quay/claircore v0.1.23
+	github.com/quay/claircore v0.1.24
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.16.0
 	github.com/streadway/amqp v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/claircore v0.1.23 h1:z56SZIvolvatQlT2kBYGw8fr7z1Mold2edFA1KmIH9I=
-github.com/quay/claircore v0.1.23/go.mod h1:V+YRnSPxjaChrR1OeM7RvhaQMGEI3JVg3i73j4jbZUo=
+github.com/quay/claircore v0.1.24 h1:xHjilUzsuKWtiH/XZ9VGHXcUqaGGm7t3OeRxki4dL7k=
+github.com/quay/claircore v0.1.24/go.mod h1:V+YRnSPxjaChrR1OeM7RvhaQMGEI3JVg3i73j4jbZUo=
 github.com/quay/goval-parser v0.8.6 h1:h1Xg3SZR/6I7UVa1LcsQZvQft/q7sJbosmFrjzSmdqE=
 github.com/quay/goval-parser v0.8.6/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=


### PR DESCRIPTION
Backports the changelog semver stuff first, then bumps to new stable cc v0.1.24