### PR TITLE
codec: use stdlib time.Time encoding

### DIFF
--- a/internal/codec/codec.go
+++ b/internal/codec/codec.go
@@ -15,6 +15,10 @@ func init() {
 	// This is documented to cause "smart buffering".
 	jsonHandle.WriterBufferSize = 4096
 	jsonHandle.ReaderBufferSize = 4096
+	// Force calling time.Time's Marshal function. This causes an allocation on
+	// every time.Time value, but is the same behavior as the stdlib json
+	// encoder. If we decide nulls are OK, this should get removed.
+	jsonHandle.TimeNotBuiltin = true
 }
 
 // Encoder and decoder pools, to reuse if possible.

--- a/internal/codec/codec_test.go
+++ b/internal/codec/codec_test.go
@@ -1,11 +1,13 @@
 package codec
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -70,5 +72,30 @@ func BenchmarkDecodeStdlib(b *testing.B) {
 		if !cmp.Equal(got, want) {
 			b.Error(cmp.Diff(got, want))
 		}
+	}
+}
+
+func TestTimeNotNull(t *testing.T) {
+	type s struct {
+		Time time.Time
+	}
+	var b bytes.Buffer
+	enc := GetEncoder(&b)
+	defer PutEncoder(enc)
+
+	// Example encoding of a populated time:
+	if err := enc.Encode(s{Time: time.Unix(0, 0).UTC()}); err != nil {
+		t.Error(err)
+	}
+	t.Log(b.String())
+	b.Reset()
+
+	// Now encode a zero time and make sure it's a string.
+	if err := enc.Encode(s{}); err != nil {
+		t.Error(err)
+	}
+	t.Log(b.String())
+	if strings.Contains(b.String(), "null") {
+		t.Error("wanted non-null encoding")
 	}
 }


### PR DESCRIPTION
The new json encoder has different behavior for encoding zero time.Time
values. This change forces the Marshal method to be called, which gets
back the previous behavior (always produce a string) at the cost of
doing an allocation.

Closes #1231

Signed-off-by: Hank Donnay <hdonnay@redhat.com>