### PR TITLE
Fixing some small testing race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,3 +159,8 @@ docs-build:
 	mdbook build
 	rsync --recursive --delete-after --exclude 'v4.*' --exclude .git\
 		./book/ $(DOCS_DIR)/
+
+# runs unit tests
+.PHONY: unit
+unit:
+	go test -race ./...

--- a/httptransport/server_test.go
+++ b/httptransport/server_test.go
@@ -52,10 +52,11 @@ func TestUpdateEndpoints(t *testing.T) {
 	if err := s.configureMatcherMode(ctx); err != nil {
 		t.Error(err)
 	}
-	srv := httptest.NewServer(s)
+	srv := httptest.NewUnstartedServer(s)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context {
 		return ctx
 	}
+	srv.Start()
 	defer srv.Close()
 	u, err := url.Parse(srv.URL)
 	if err != nil {

--- a/notifier/processor_create_test.go
+++ b/notifier/processor_create_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -216,13 +217,13 @@ func testProcessorCreate(t *testing.T) {
 			}, nil
 		},
 	}
-	count := 0
+	count := uint64(0)
 	im := &indexer.Mock{
 		AffectedManifests_: func(ctx context.Context, vulns []claircore.Vulnerability) (*claircore.AffectedManifests, error) {
-			if count > 1 {
+			if atomic.LoadUint64(&count) > 1 {
 				return nil, fmt.Errorf("unexpected number of calls")
 			}
-			count++
+			atomic.AddUint64(&count, 1)
 			switch vulns[0].ID {
 			case "0":
 				return affectedManifestsAdd, nil


### PR DESCRIPTION
These are both pretty insignificant as they are only present in the testing code, but I suppose it helps to not pollute the testing output when searching for real-world race conditions.

I added the target in the test file for unit-tests, that should probably reflect what the CI is running unit-test wise.