### PR TITLE
cicd: changelog fixups

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -4,7 +4,7 @@ info:
   title: CHANGELOG
   repository_url: https://github.com/quay/clair
 options:
-  tag_sort_by: semver
+  sort: semver
   commits:
     sort_by: Scope
   commit_groups:

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -35,7 +35,9 @@ jobs:
             touch changelog
             exit 0
           fi
-          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
+          curl -o /tmp/git-chglog.tar.gz -fsSL\
+            https://github.com/git-chglog/git-chglog/releases/download/v0.14.0/git-chglog_0.14.0_linux_amd64.tar.gz
+          tar xvf /tmp/git-chglog.tar.gz --directory /tmp
           chmod u+x /tmp/git-chglog
           echo "creating change log for tag: $TAG"
           /tmp/git-chglog "${TAG}" > changelog

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -25,10 +25,25 @@ jobs:
       - name: Changelog
         shell: bash
         run: |
-          curl -o /tmp/git-chglog -L https://github.com/ldelossa/git-chglog/releases/download/v0.11.2-sortbysemver/linux.amd64.git-chglog
+          curl -o /tmp/git-chglog.tar.gz -fsSL\
+            https://github.com/git-chglog/git-chglog/releases/download/v0.14.0/git-chglog_0.14.0_linux_amd64.tar.gz
+          tar xvf /tmp/git-chglog.tar.gz --directory /tmp
           chmod u+x /tmp/git-chglog
           echo "creating change log for tag: ${{ github.event.inputs.tag }}"
-          /tmp/git-chglog --tag-filter-pattern "v4" --next-tag "${{ github.event.inputs.tag }}" -o CHANGELOG.md v4.0.0-alpha.2..
+
+          # if this is a release branch filter our change
+          # log to only include logs with the same minor
+          # versions
+          # otherwise just filter v4 for full v4 history
+          # on main branch
+          filter_tag="--tag-filter-pattern v4"
+          branch=${{ github.event.inputs.branch }}
+          echo "discovered branch $branch"
+          if [[ ${branch%-*} == "release" ]]; then 
+            filter_tag="--tag-filter-pattern v${branch#release-}"
+          fi
+
+          /tmp/git-chglog $filter_tag --next-tag "${{ github.event.inputs.tag }}" -o CHANGELOG.md v4.0.0-alpha.2..
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3.5.1
         with:


### PR DESCRIPTION
swaps out my fork for the latest git-chglog tool
with semver sorting.

in addition this pr performs the correct semver filtering
for release branch changelogs.

Signed-off-by: ldelossa <ldelossa@redhat.com>