### PR TITLE
ext/vulnsrc/rhel: correctly identify RHEL criterion comment

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -269,10 +269,14 @@ func toFeatureVersions(criteria criteria) []database.FeatureVersion {
 			err            error
 		)
 
+		const (
+			rhelPrefix = "Red Hat Enterprise Linux "
+		)
+
 		// Attempt to parse package data from trees of criterions.
 		for _, c := range criterions {
-			if strings.Contains(c.Comment, " is installed") {
-				const prefixLen = len("Red Hat Enterprise Linux ")
+			if strings.Contains(c.Comment, " is installed") && strings.HasPrefix(c.Comment, rhelPrefix) {
+				const prefixLen = len(rhelPrefix)
 				osVersion, err = strconv.Atoi(strings.TrimSpace(c.Comment[prefixLen : prefixLen+strings.Index(c.Comment[prefixLen:], " ")]))
 				if err != nil {
 					log.WithField("criterion comment", c.Comment).Warning("could not parse Red Hat release version from criterion comment")


### PR DESCRIPTION
In https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml
there can be "criterion" "comment" entries that match " is installed"
but start with "Red Hat CoreOS " which violate the implicit constraint
that they start with "Red Hat Enterprise Linux ".  These non-conforming
entries generate a panic due to "slice bounds out of range".

Fixes #1249