### PR TITLE
httptransport: fix LatestUpdateOperations method

### DIFF
--- a/httptransport/client/matcher.go
+++ b/httptransport/client/matcher.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 
@@ -151,7 +152,9 @@ func (c *HTTP) LatestUpdateOperations(ctx context.Context) (map[string][]driver.
 	if err != nil {
 		return nil, err
 	}
-	u.Query().Add("latest", "true")
+	v := url.Values{}
+	v.Add("latest", "true")
+	u.RawQuery = v.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {


### PR DESCRIPTION
It's not that the changed method was broken, but it actually returned _all_ update operations for each updater.
Before my change: 
![image](https://user-images.githubusercontent.com/22600243/116101288-ff6fc480-a6ad-11eb-9eaa-7c3ee4cc538d.png)

After it:
![image](https://user-images.githubusercontent.com/22600243/116100855-9c7e2d80-a6ad-11eb-8aa1-a5eb1545980a.png)

It's unnecessary to return all of the update operations because from [this point](https://github.com/quay/clair/blob/1f9b56577957ce28044b221af58b160328a671a2/notifier/poller.go#L118), we only work with the latest one anyway. I think with this, the actual workings of the function and its docstring are more in sync.

Signed-off-by: Jan Zmeskal <jzmeskal@redhat.com>