### PR TITLE
clairctl: move to zlog

### DIFF
--- a/cmd/clairctl/debug.go
+++ b/cmd/clairctl/debug.go
@@ -1,8 +1,0 @@
-package main
-
-import (
-	"io/ioutil"
-	"log"
-)
-
-var debug = log.New(ioutil.Discard, "debug: ", log.LstdFlags)

--- a/cmd/clairctl/main.go
+++ b/cmd/clairctl/main.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"context"
-	"log"
 	"os"
+	"time"
 
 	_ "github.com/quay/claircore/updater/defaults"
+	"github.com/quay/zlog"
+	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 var (
-	flagDebug bool
+	logout = zerolog.New(&zerolog.ConsoleWriter{
+		Out:        os.Stderr,
+		TimeFormat: time.RFC3339,
+	}).Level(zerolog.InfoLevel).
+		With().
+		Timestamp().
+		Logger()
 
 	commonClaim = jwt.Claims{}
 )
@@ -24,14 +32,18 @@ func main() {
 
 	app := &cli.App{
 		Name:                 "clairctl",
-		Version:              "0.1.0",
+		Version:              "0.2.0",
 		Usage:                "interact with a clair API",
 		Description:          "A command-line tool for clair v4.",
 		EnableBashCompletion: true,
 		Before: func(c *cli.Context) error {
-			if c.IsSet("D") {
-				debug.SetOutput(os.Stderr)
+			if c.IsSet("q") {
+				logout = logout.Level(zerolog.WarnLevel)
 			}
+			if c.IsSet("D") {
+				logout = logout.Level(zerolog.DebugLevel)
+			}
+			zlog.Set(&logout)
 			commonClaim.Issuer = c.String("issuer")
 			return nil
 		},
@@ -45,6 +57,10 @@ func main() {
 			&cli.BoolFlag{
 				Name:  "D",
 				Usage: "print debugging logs",
+			},
+			&cli.BoolFlag{
+				Name:  "q",
+				Usage: "quieter log output",
 			},
 			&cli.PathFlag{
 				Name:      "config",
@@ -61,14 +77,16 @@ func main() {
 				Value:   "clairctl",
 			},
 		},
+		ExitErrHandler: func(c *cli.Context, err error) {
+			if err != nil {
+				exit = 1
+				if err, ok := err.(cli.ExitCoder); ok {
+					exit = err.ExitCode()
+				}
+				logout.Error().Err(err).Send()
+			}
+		},
 	}
-	log.SetFlags(log.Flags())
 
-	if err := app.RunContext(ctx, os.Args); err != nil {
-		exit = 1
-		if err, ok := err.(cli.ExitCoder); ok {
-			exit = err.ExitCode()
-		}
-		log.Println(err)
-	}
+	app.RunContext(ctx, os.Args)
 }


### PR DESCRIPTION
This makes the command more chatty by default, which I don't particularly like, but it makes `clairctl`'s output commands actually affect the logging of the rest of the system, which is almost certainly what a user expects.

I added a flag to quiet the output as a poor imitation of my beloved terse output.

This change is motivated by noticing that the `zlog` move meant that the `clairctl` output was completely uncontrollable.