### PR TITLE
config: omit Authorization header for empty claims

### DIFF
--- a/cmd/clairctl/export.go
+++ b/cmd/clairctl/export.go
@@ -66,7 +66,7 @@ func exportAction(c *cli.Context) error {
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	cl, _, err := cfg.Client(httputil.RateLimiter(tr), commonClaim)
+	cl, _, err := cfg.Client(httputil.RateLimiter(tr), &commonClaim)
 	if err != nil {
 		return err
 	}

--- a/cmd/clairctl/import.go
+++ b/cmd/clairctl/import.go
@@ -35,7 +35,7 @@ func importAction(c *cli.Context) error {
 		return err
 	}
 
-	cl, _, err := cfg.Client(nil, commonClaim)
+	cl, _, err := cfg.Client(nil, &commonClaim)
 	if err != nil {
 		return err
 	}

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -121,7 +121,7 @@ func reportAction(c *cli.Context) error {
 		if e != nil {
 			return e
 		}
-		hc, _, e := cfg.Client(nil, commonClaim)
+		hc, _, e := cfg.Client(nil, &commonClaim)
 		if e != nil {
 			return e
 		}

--- a/httptransport/auth_test.go
+++ b/httptransport/auth_test.go
@@ -64,7 +64,7 @@ func (tc *authTestcase) Run(t *testing.T) {
 	}
 
 	// Create a client that has auth according to the config.
-	c, authed, err := tc.Config.Client(nil, *tc.Claims)
+	c, authed, err := tc.Config.Client(nil, tc.Claims)
 	if err != nil {
 		t.Error(err)
 	}

--- a/initialize/services.go
+++ b/initialize/services.go
@@ -141,7 +141,7 @@ func localIndexer(ctx context.Context, cfg *config.Config) (indexer.Service, err
 	// Use an empty claim because this shouldn't be talking to something that
 	// needs preconfigured authz. Callers should be providing credentials to the
 	// indexing process in the submitted manifest.
-	c, _, err := cfg.Client(tr, jwt.Claims{})
+	c, _, err := cfg.Client(tr, nil)
 	if err != nil {
 		return nil, mkErr(err)
 	}
@@ -167,7 +167,7 @@ func remoteIndexer(ctx context.Context, cfg *config.Config, addr string) (indexe
 
 func remoteClient(ctx context.Context, cfg *config.Config, claim jwt.Claims, addr string) (*client.HTTP, error) {
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	c, auth, err := cfg.Client(tr, claim)
+	c, auth, err := cfg.Client(tr, &claim)
 	switch {
 	case err != nil:
 		return nil, err
@@ -244,7 +244,7 @@ func localNotifier(ctx context.Context, cfg *config.Config, i indexer.Service, m
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	c, _, err := cfg.Client(tr, notifierClaim)
+	c, _, err := cfg.Client(tr, &notifierClaim)
 	if err != nil {
 		return nil, mkErr(err)
 	}


### PR DESCRIPTION
This change makes the HTTP client configuration method accept a Claims
pointer, and if `nil` is passed, omits the automatic signing that would
happen if a PSK was configured.

Fixes #1283.