### PR TITLE
all: remove jzelinskie from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@quentin-m @jzelinskie @keyboardnerd @ldelossa @hdonnay @alecmerdler
+*	@quentin-m @keyboardnerd @ldelossa @hdonnay @alecmerdler


### PR DESCRIPTION
I haven't been active in a super long time and this GitHub integration really spams my notifications.
I think it'd be better if I wasn't listed in CODEOWNERs, that way if you do need me too look at something you can mention me and I'll actually see the notification.