### PR TITLE
shutdown: introduce the new NotifyContext

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -53,7 +53,7 @@ jobs:
   release-binaries:
     name: Create Release Binaries
     runs-on: 'ubuntu-latest'
-    container: quay.io/projectquay/golang:1.15
+    container: quay.io/projectquay/golang:1.16
     needs: release-archive
     strategy:
       matrix:


### PR DESCRIPTION
As of Go 1.16 signal.NotifyContext ties the context to
the signal handling instead of having to do it manually.
This PR also bumps the Go version.

Signed-off-by: crozzy <joseph.crosland@gmail.com>