### PR TITLE
services: disable transport compression in updaters

### DIFF
--- a/initialize/services.go
+++ b/initialize/services.go
@@ -187,6 +187,9 @@ func localMatcher(ctx context.Context, cfg *config.Config) (matcher.Service, err
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
+	// Some servers return weak validators when the Content-Encoding is not
+	// "identity". Setting this prevents automatically negotiating up to "gzip".
+	tr.DisableCompression = true
 	jar, err := cookiejar.New(&cookiejar.Options{
 		PublicSuffixList: publicsuffix.List,
 	})


### PR DESCRIPTION
Some servers (e.g. Github) return weak HTTP validators when the
Content-Encoding is not "identity". This disables automatically
negotiating compression, which breaks Updaters' conditional requests.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>