### PR TITLE
docker: reflect quay Dockerfile updates

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -222,7 +222,7 @@ services:
     image: quay.io/projectquay/quay:latest
     privileged: true
     volumes:
-      - "./local-dev/quay:/conf/stack"
+      - "./local-dev/quay:/quay-registry/conf/stack"
     ports:
       - "8080:8080" 
     environment:


### PR DESCRIPTION
The working directory for quay inside the container
was updated from `/` to `/quay-registry` so the config
needs to be volumed in there.

Signed-off-by: crozzy <joseph.crosland@gmail.com>