### PR TITLE
chore: remove alecmerdler from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*	@quentin-m @keyboardnerd @ldelossa @hdonnay @alecmerdler
+*	@quentin-m @keyboardnerd @ldelossa @hdonnay


### PR DESCRIPTION
Signed-off-by: Alec Merdler <alecmerdler@gmail.com>