### PR TITLE
introspection: use the response recorder

### DIFF
--- a/middleware/introspection/instrumentedhandler.go
+++ b/middleware/introspection/instrumentedhandler.go
@@ -67,7 +67,7 @@ func InstrumentedHandler(endpoint string, traceOpts othttp.Option, next http.Han
 	h = promhttp.InstrumentHandlerTimeToWriteHeader(RequestDuration, h)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		recorder := rr.NewResponseRecorder(w)
-		h.ServeHTTP(w, r)
+		h.ServeHTTP(recorder, r)
 		zlog.Info(r.Context()).
 			Str("remote_addr", r.RemoteAddr).
 			Str("method", r.Method).


### PR DESCRIPTION
Previously the logs were showing only 200 responses, passing
the ResponseRecorder to the handler in place of the http.ResponseWriter
should ensure that when Write() and WriteHeader() are called, the
ResponseRecorder logs information about the http response.

Signed-off-by: crozzy <joseph.crosland@gmail.com>