### PR TITLE
deployment: Fix microdnf install inconsistencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go build\
   ./cmd/clairctl
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS final
-RUN microdnf install tar
+RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos --enablerepo=ubi-8-appstream tar
 RUN curl -L -o /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 && chmod +x /usr/local/bin/dumb-init 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "/bin/clair"]
 VOLUME /config


### PR DESCRIPTION
The microdnf generates `/etc/yum.repos.d/redhat.repo` file which
contains redhat rpm repositories. It seems that the content of the file
isn't always the same for every possible environment, which might cause
problems with the installation.

This commit guarantee that the `microdnf install` command is consistent
across all environments simply by restraining microdnf to selected ubi
repos.

Signed-off-by: Lukas Krajicek <lkrajice@redhat.com>