### PR TITLE
HTTP caching

### DIFF
--- a/config/matcher.go
+++ b/config/matcher.go
@@ -46,6 +46,12 @@ type Matcher struct {
 	//
 	// A value of 0 disables GC.
 	UpdateRetention int `yaml:"update_retention" json:"update_retention"`
+	// CacheAge controls how long clients should be hinted to cache responses
+	// for.
+	//
+	// If empty, the duration set in "Period" will be used. This means client
+	// may cache "stale" results for 2(Period) - 1 seconds.
+	CacheAge time.Duration `yaml:"cache_age,omitempty" json:"cache_age,omitempty"`
 }
 
 func (m *Matcher) Validate(combo bool) error {
@@ -61,6 +67,9 @@ func (m *Matcher) Validate(combo bool) error {
 	}
 	if m.UpdateRetention == 1 || m.UpdateRetention < 0 {
 		m.UpdateRetention = DefaultRetention
+	}
+	if m.CacheAge == 0 {
+		m.CacheAge = m.Period
 	}
 	if !combo {
 		if m.IndexerAddr == "" {

--- a/httptransport/auth_test.go
+++ b/httptransport/auth_test.go
@@ -2,10 +2,12 @@ package httptransport
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,93 +15,99 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/quay/clair/v4/config"
+	"github.com/quay/zlog"
 )
 
 type authTestcase struct {
-	Name       string
-	Config     config.Config
-	ShouldFail bool
-	ConfigMod  func(*testing.T, *config.Config)
 	Claims     *jwt.Claims
+	ConfigMod  func(*testing.T, *config.Config)
+	Config     config.Config
+	Name       string
+	ShouldFail bool
 }
 
 var defaultClaims = jwt.Claims{
 	Issuer: IntraserviceIssuer,
 }
 
-func (tc *authTestcase) Run(t *testing.T) {
-	// Generate a nonce to return upon request.
-	b := make([]byte, 16)
-	if _, err := io.ReadFull(rand.Reader, b); err != nil {
-		t.Fatal(err)
-	}
-	nonce := hex.EncodeToString(b)
-
-	// Return the nonce when called.
-	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if a := r.Header.Get("authorization"); a != "" {
-			t.Logf("Authorization: %s", a)
+func (tc *authTestcase) Run(ctx context.Context) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := zlog.Test(ctx, t)
+		// Generate a nonce to return upon request.
+		b := make([]byte, 16)
+		if _, err := io.ReadFull(rand.Reader, b); err != nil {
+			t.Fatal(err)
 		}
-		fmt.Fprint(w, nonce)
-	})
+		nonce := hex.EncodeToString(b)
 
-	// Create a handler that has auth according to the config.
-	h, err := authHandler(&tc.Config, next)
-	if err != nil {
-		t.Error(err)
-	}
+		// Return the nonce when called.
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if a := r.Header.Get("authorization"); a != "" {
+				t.Logf("Authorization: %s", a)
+			}
+			fmt.Fprint(w, nonce)
+		})
 
-	// Wire up the handler to a test server.
-	srv := httptest.NewServer(h)
-	defer srv.Close()
+		// Create a handler that has auth according to the config.
+		h, err := authHandler(&tc.Config, next)
+		if err != nil {
+			t.Error(err)
+		}
 
-	// Modify the config, if present
-	if f := tc.ConfigMod; f != nil {
-		f(t, &tc.Config)
-	}
+		// Wire up the handler to a test server.
+		srv := httptest.NewUnstartedServer(h)
+		srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
+		srv.Start()
+		defer srv.Close()
 
-	// Use a default intraservice claim if not set.
-	if tc.Claims == nil {
-		tc.Claims = &defaultClaims
-	}
+		// Modify the config, if present
+		if f := tc.ConfigMod; f != nil {
+			f(t, &tc.Config)
+		}
 
-	// Create a client that has auth according to the config.
-	c, authed, err := tc.Config.Client(nil, tc.Claims)
-	if err != nil {
-		t.Error(err)
-	}
-	t.Logf("authed: %v", authed)
+		// Use a default intraservice claim if not set.
+		if tc.Claims == nil {
+			tc.Claims = &defaultClaims
+		}
 
-	// Make the request.
-	res, err := c.Get(srv.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer res.Body.Close()
-	wantStatus := http.StatusOK
-	if tc.ShouldFail {
-		wantStatus = http.StatusUnauthorized
-	}
-	t.Logf("status code: %v", res.StatusCode)
-	if res.StatusCode != wantStatus {
-		t.Fail()
-	}
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, res.Body); err != nil {
-		t.Error(err)
-	}
+		// Create a client that has auth according to the config.
+		c, authed, err := tc.Config.Client(nil, tc.Claims)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("authed: %v", authed)
 
-	// Compare the nonce.
-	got, want := buf.String(), nonce
-	t.Logf("http request, got: %q want: %q", got, want)
-	if got != want && !tc.ShouldFail {
-		t.Fail()
+		// Make the request.
+		res, err := c.Get(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer res.Body.Close()
+		wantStatus := http.StatusOK
+		if tc.ShouldFail {
+			wantStatus = http.StatusUnauthorized
+		}
+		t.Logf("status code: %v", res.StatusCode)
+		if res.StatusCode != wantStatus {
+			t.Fail()
+		}
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, res.Body); err != nil {
+			t.Error(err)
+		}
+
+		// Compare the nonce.
+		got, want := buf.String(), nonce
+		t.Logf("http request, got: %q want: %q", got, want)
+		if got != want && !tc.ShouldFail {
+			t.Fail()
+		}
 	}
 }
 
 // TestAuth tests configuring both http server and client.
 func TestAuth(t *testing.T) {
-	var fakeKey = []byte("deadbeef")
+	fakeKey := []byte("deadbeef")
 	tt := []authTestcase{
 		{Name: "None"},
 		{
@@ -147,7 +155,7 @@ func TestAuth(t *testing.T) {
 				},
 			},
 			ShouldFail: true,
-			ConfigMod:  func(t *testing.T, cfg *config.Config) { cfg.Auth.PSK.Key = []byte("badbeef") },
+			ConfigMod:  func(_ *testing.T, cfg *config.Config) { cfg.Auth.PSK.Key = []byte("badbeef") },
 		},
 		{
 			Name: "FakeKeyserverFail",
@@ -160,7 +168,7 @@ func TestAuth(t *testing.T) {
 				},
 			},
 			ShouldFail: true,
-			ConfigMod:  func(t *testing.T, cfg *config.Config) { cfg.Auth.Keyserver = nil },
+			ConfigMod:  func(_ *testing.T, cfg *config.Config) { cfg.Auth.Keyserver = nil },
 		},
 		{
 			Name: "PSKFail",
@@ -173,11 +181,12 @@ func TestAuth(t *testing.T) {
 				},
 			},
 			ShouldFail: true,
-			ConfigMod:  func(t *testing.T, cfg *config.Config) { cfg.Auth.PSK = nil },
+			ConfigMod:  func(_ *testing.T, cfg *config.Config) { cfg.Auth.PSK = nil },
 		},
 	}
 
+	ctx := zlog.Test(context.Background(), t)
 	for _, tc := range tt {
-		t.Run(tc.Name, tc.Run)
+		t.Run(tc.Name, tc.Run(ctx))
 	}
 }

--- a/httptransport/server.go
+++ b/httptransport/server.go
@@ -39,8 +39,7 @@ const (
 	OpenAPIV1Path           = "/openapi/v1"
 )
 
-// Server is the primary http server
-// Clair exposes it's functionality on.
+// Server is the primary http server Clair exposes its functionality on.
 type Server struct {
 	// Server embeds a http.Server and http.ServeMux.
 	// The http.Server will be configured with the ServeMux on successful
@@ -57,8 +56,8 @@ type Server struct {
 func New(ctx context.Context, conf config.Config, indexer indexer.Service, matcher matcher.Service, notifier notifier.Service) (*Server, error) {
 	serv := &http.Server{
 		Addr: conf.HTTPListenAddr,
-		// use the passed in global context as the base context
-		// for all http requests handled by this server
+		// use the passed in global context as the base context for all http
+		// requests handled by this server
 		BaseContext: func(net.Listener) context.Context { return ctx },
 	}
 	mux := http.NewServeMux()
@@ -108,7 +107,7 @@ func New(ctx context.Context, conf config.Config, indexer indexer.Service, match
 	// attach HttpTransport to server, this works because we embed http.ServeMux
 	t.Server.Handler = t
 
-	// add endpoint authentication if configured add auth. must happen after
+	// Add endpoint authentication if configured to add auth. Must happen after
 	// mux was configured for given mode.
 	if conf.Auth.Any() {
 		err := t.configureWithAuth(ctx)
@@ -122,16 +121,15 @@ func New(ctx context.Context, conf config.Config, indexer indexer.Service, match
 	return t, nil
 }
 
-// configureDiscovery() creates a discovery handler
-// for serving the v1 open api specification
+// ConfigureDiscovery creates a discovery handler for serving the v1 OpenAPI
+// specification.
 func (t *Server) configureDiscovery(_ context.Context) error {
 	t.Handle(OpenAPIV1Path,
 		intromw.InstrumentedHandler(OpenAPIV1Path, t.traceOpt, DiscoveryHandler()))
 	return nil
 }
 
-// configureDevMode configures the HttpTrasnport for
-// ComboMode.
+// ConfigureComboMode configures the HttpTransport for ComboMode.
 //
 // This mode runs both Indexer and Matcher in a single process.
 func (t *Server) configureComboMode(ctx context.Context) error {
@@ -158,7 +156,7 @@ func (t *Server) configureComboMode(ctx context.Context) error {
 	return nil
 }
 
-// configureIndexerMode configures the HttpTransport for IndexerMode.
+// ConfigureIndexerMode configures the HttpTransport for IndexerMode.
 //
 // This mode runs only an Indexer in a single process.
 func (t *Server) configureIndexerMode(_ context.Context) error {
@@ -184,7 +182,9 @@ func (t *Server) configureIndexerMode(_ context.Context) error {
 	return nil
 }
 
-// configureMatcherMode configures HttpTransport
+// ConfigureMatcherMode configures HttpTransport for MatcherMode.
+//
+// This mode runs only a Matcher in a single process.
 func (t *Server) configureMatcherMode(_ context.Context) error {
 	// requires both an indexer and matcher service. indexer service
 	// is assumed to be a remote call over the network
@@ -204,7 +204,9 @@ func (t *Server) configureMatcherMode(_ context.Context) error {
 	return nil
 }
 
-// configureMatcherMode configures HttpTransport
+// ConfigureNotifierMode configures HttpTransport for NotifierMode.
+//
+// This mode runs only a Notifier in a single process.
 func (t *Server) configureNotifierMode(ctx context.Context) error {
 	// requires both an indexer and matcher service. indexer service
 	// is assumed to be a remote call over the network
@@ -228,10 +230,10 @@ func (t *Server) configureNotifierMode(ctx context.Context) error {
 // mint its own JWTs.
 const IntraserviceIssuer = `clair-intraservice`
 
-// configureWithAuth will take the current serve mux and wrap it
-// in an Auth middleware handler.
+// ConfigureWithAuth will take the current serve mux and wrap it in an Auth
+// middleware handler.
 //
-// must be ran after the config*Mode method of choice.
+// Must be ran after the config*Mode method of choice.
 func (t *Server) configureWithAuth(_ context.Context) error {
 	h, err := authHandler(&t.conf, t.Server.Handler)
 	if err != nil {
@@ -253,7 +255,7 @@ func unmodified(r *http.Request, v string) bool {
 	return false
 }
 
-// writerError is a helper that closes over an error that may be returned after
+// WriterError is a helper that closes over an error that may be returned after
 // writing a response body starts.
 //
 // The normal error flow can't be used, because the HTTP status code will have

--- a/httptransport/vulnerabilityreporthandler.go
+++ b/httptransport/vulnerabilityreporthandler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptrace"
 	"path"
+	"time"
 
 	"github.com/quay/claircore"
 	je "github.com/quay/claircore/pkg/jsonerr"
@@ -16,91 +17,98 @@ import (
 	"github.com/quay/clair/v4/matcher"
 )
 
-// VulnerabilityReportHandler utilizes a Service to serialize
-// and return a claircore.VulnerabilityReport
-func VulnerabilityReportHandler(service matcher.Service, indexer indexer.Service) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodGet {
-			resp := &je.Response{
-				Code:    "method-not-allowed",
-				Message: "endpoint only allows GET",
-			}
-			je.Error(w, resp, http.StatusMethodNotAllowed)
-			return
-		}
-		ctx, done := context.WithCancel(r.Context())
-		defer done()
-		ctx = httptrace.WithClientTrace(ctx, oteltrace.NewClientTrace(ctx))
+// VulnerabilityReportHandler produces VulnerabilityReports.
+type VulnerabilityReportHandler struct {
+	Matcher matcher.Service
+	Indexer indexer.Service
+	Cache   time.Duration
+}
 
-		manifestStr := path.Base(r.URL.Path)
-		if manifestStr == "" {
-			resp := &je.Response{
-				Code:    "bad-request",
-				Message: "malformed path. provide a single manifest hash",
-			}
-			je.Error(w, resp, http.StatusBadRequest)
-			return
-		}
-		manifest, err := claircore.ParseDigest(manifestStr)
-		if err != nil {
-			resp := &je.Response{
-				Code:    "bad-request",
-				Message: "malformed path: " + err.Error(),
-			}
-			je.Error(w, resp, http.StatusBadRequest)
-			return
-		}
+var _ http.Handler = (*VulnerabilityReportHandler)(nil)
 
-		initd, err := service.Initialized(ctx)
-		if err != nil {
-			resp := &je.Response{
-				Code:    "internal-server-error",
-				Message: err.Error(),
-			}
-			je.Error(w, resp, http.StatusInternalServerError)
-			return
+// ServeHTTP implements http.Handler.
+func (h *VulnerabilityReportHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		resp := &je.Response{
+			Code:    "method-not-allowed",
+			Message: "endpoint only allows GET",
 		}
-		if !initd {
-			w.WriteHeader(http.StatusAccepted)
-			return
-		}
-
-		indexReport, ok, err := indexer.IndexReport(ctx, manifest)
-		// check err first
-		if err != nil {
-			resp := &je.Response{
-				Code:    "internal-server-error",
-				Message: fmt.Sprintf("experienced a server side error: %v", err),
-			}
-			je.Error(w, resp, http.StatusInternalServerError)
-			return
-		}
-		// now check bool only after confirming no err
-		if !ok {
-			resp := &je.Response{
-				Code:    "not-found",
-				Message: fmt.Sprintf("index report for manifest %q not found", manifest.String()),
-			}
-			je.Error(w, resp, http.StatusNotFound)
-			return
-
-		}
-
-		vulnReport, err := service.Scan(ctx, indexReport)
-		if err != nil {
-			resp := &je.Response{
-				Code:    "match-error",
-				Message: fmt.Sprintf("failed to start scan: %v", err),
-			}
-			je.Error(w, resp, http.StatusInternalServerError)
-			return
-		}
-
-		w.Header().Set("content-type", "application/json")
-
-		defer writerError(w, &err)()
-		enc := codec.GetEncoder(w)
-		defer codec.PutEncoder(enc)
-		err = enc.Encode(vulnReport)
+		je.Error(w, resp, http.StatusMethodNotAllowed)
+		return
 	}
+	ctx, done := context.WithCancel(r.Context())
+	defer done()
+	ctx = httptrace.WithClientTrace(ctx, oteltrace.NewClientTrace(ctx))
+
+	manifestStr := path.Base(r.URL.Path)
+	if manifestStr == "" {
+		resp := &je.Response{
+			Code:    "bad-request",
+			Message: "malformed path. provide a single manifest hash",
+		}
+		je.Error(w, resp, http.StatusBadRequest)
+		return
+	}
+	manifest, err := claircore.ParseDigest(manifestStr)
+	if err != nil {
+		resp := &je.Response{
+			Code:    "bad-request",
+			Message: "malformed path: " + err.Error(),
+		}
+		je.Error(w, resp, http.StatusBadRequest)
+		return
+	}
+
+	initd, err := h.Matcher.Initialized(ctx)
+	if err != nil {
+		resp := &je.Response{
+			Code:    "internal-server-error",
+			Message: err.Error(),
+		}
+		je.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
+	if !initd {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	indexReport, ok, err := h.Indexer.IndexReport(ctx, manifest)
+	// check err first
+	if err != nil {
+		resp := &je.Response{
+			Code:    "internal-server-error",
+			Message: fmt.Sprintf("experienced a server side error: %v", err),
+		}
+		je.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
+	// now check bool only after confirming no err
+	if !ok {
+		resp := &je.Response{
+			Code:    "not-found",
+			Message: fmt.Sprintf("index report for manifest %q not found", manifest.String()),
+		}
+		je.Error(w, resp, http.StatusNotFound)
+		return
+
+	}
+
+	vulnReport, err := h.Matcher.Scan(ctx, indexReport)
+	if err != nil {
+		resp := &je.Response{
+			Code:    "match-error",
+			Message: fmt.Sprintf("failed to start scan: %v", err),
+		}
+		je.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	setCacheControl(w, h.Cache)
+
+	defer writerError(w, &err)()
+	enc := codec.GetEncoder(w)
+	defer codec.PutEncoder(enc)
+	err = enc.Encode(vulnReport)
 }

--- a/httptransport/vulnerabilityreporthandler_test.go
+++ b/httptransport/vulnerabilityreporthandler_test.go
@@ -16,21 +16,21 @@ import (
 func TestInitialized(t *testing.T) {
 	var initd bool
 	digest := claircore.MustParseDigest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	h := VulnerabilityReportHandler(
-		&matcher.Mock{
+	h := &VulnerabilityReportHandler{
+		Matcher: &matcher.Mock{
 			Initialized_: func(_ context.Context) (bool, error) {
 				return initd, nil
 			},
 		},
-		&indexer.Mock{
-			IndexReport_: func(ctx context.Context, d claircore.Digest) (*claircore.IndexReport, bool, error) {
+		Indexer: &indexer.Mock{
+			IndexReport_: func(_ context.Context, d claircore.Digest) (*claircore.IndexReport, bool, error) {
 				if got, want := d.String(), digest.String(); got != want {
 					return nil, false, fmt.Errorf("unexpected digest: %v", got)
 				}
 				return nil, false, nil
 			},
 		},
-	)
+	}
 	srv := httptest.NewServer(h)
 	defer srv.Close()
 	c := srv.Client()


### PR DESCRIPTION
@crozzy and I discussed adding caching metadata to vulnerability report responses to reduce load and response churn.
This PR implements that as best as I can tell from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching), and some cleanups I noticed while doing it.