### PR TITLE
matcher: default garbage collection on

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -216,7 +216,8 @@ constraints.
 
 Defaults to 10.
 
-If a value of 0 is provided, GC is disabled.
+If a value less than 0 is provided, GC is disabled. 2 is the minimum value to
+ensure updates can be compared for notifications. 
 
 ### `$.matchers`
 Matchers provides configuration for the in-tree Matchers and RemoteMatchers.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,6 +70,102 @@ func Test_Config_Validate_Failure(t *testing.T) {
 	}
 }
 
+func TestConfigUpateRetention(t *testing.T) {
+	var table = []struct {
+		name              string
+		conf              config.Config
+		expectedRetention int
+	}{
+		{
+			name:              "Retention less than 0",
+			expectedRetention: 0,
+			conf: config.Config{
+				Mode:           config.ComboMode,
+				HTTPListenAddr: "localhost:8080",
+				Indexer: config.Indexer{
+					ConnString: "example@example/db",
+				},
+				Notifier: config.Notifier{
+					ConnString: "example@example/db",
+				},
+				Matcher: config.Matcher{
+					ConnString:      "example@example/db",
+					IndexerAddr:     "example@example/db",
+					UpdateRetention: -1,
+				},
+			},
+		},
+		{
+			name:              "Retention of 0",
+			expectedRetention: 10,
+			conf: config.Config{
+				Mode:           config.ComboMode,
+				HTTPListenAddr: "localhost:8080",
+				Indexer: config.Indexer{
+					ConnString: "example@example/db",
+				},
+				Notifier: config.Notifier{
+					ConnString: "example@example/db",
+				},
+				Matcher: config.Matcher{
+					ConnString:      "example@example/db",
+					IndexerAddr:     "example@example/db",
+					UpdateRetention: 0,
+				},
+			},
+		},
+		{
+			name:              "Retention less than 2",
+			expectedRetention: 10,
+			conf: config.Config{
+				Mode:           config.ComboMode,
+				HTTPListenAddr: "localhost:8080",
+				Indexer: config.Indexer{
+					ConnString: "example@example/db",
+				},
+				Notifier: config.Notifier{
+					ConnString: "example@example/db",
+				},
+				Matcher: config.Matcher{
+					ConnString:      "example@example/db",
+					IndexerAddr:     "example@example/db",
+					UpdateRetention: 1,
+				},
+			},
+		},
+		{
+			name:              "Retention of 2",
+			expectedRetention: 2,
+			conf: config.Config{
+				Mode:           config.ComboMode,
+				HTTPListenAddr: "localhost:8080",
+				Indexer: config.Indexer{
+					ConnString: "example@example/db",
+				},
+				Notifier: config.Notifier{
+					ConnString: "example@example/db",
+				},
+				Matcher: config.Matcher{
+					ConnString:      "example@example/db",
+					IndexerAddr:     "example@example/db",
+					UpdateRetention: 2,
+				},
+			},
+		},
+	}
+	for _, tab := range table {
+		t.Run(tab.name, func(t *testing.T) {
+			err := config.Validate(&tab.conf)
+			if err != nil {
+				log.Fatalf("expected no errors but got: %s, for test case: %s", err, tab.name)
+			}
+			if tab.conf.Matcher.UpdateRetention != tab.expectedRetention {
+				t.Fatalf("expected UpdateRetention of %d but got %d", tab.expectedRetention, tab.conf.Matcher.UpdateRetention)
+			}
+		})
+	}
+}
+
 func TestConfigDisableUpdaters(t *testing.T) {
 	var table = []struct {
 		name string

--- a/config/matcher.go
+++ b/config/matcher.go
@@ -65,7 +65,12 @@ func (m *Matcher) Validate(combo bool) error {
 	if m.Period == 0 {
 		m.Period = DefaultPeriod
 	}
-	if m.UpdateRetention == 1 || m.UpdateRetention < 0 {
+	switch {
+	case m.UpdateRetention < 0:
+		// Less than 0 means GC is off.
+		m.UpdateRetention = 0
+	case m.UpdateRetention < 2:
+		// Anything less than 2 gets the default.
 		m.UpdateRetention = DefaultRetention
 	}
 	if m.CacheAge == 0 {


### PR DESCRIPTION
Change the GC logic to reflect the docs and
also update the docs with more details.
```
< 0 == GC off
0 or unspecified == GC on w/ default retention
< 2 == GC on w/ default retention
>= 2 == GC on w/ specified value
```

Signed-off-by: crozzy <joseph.crosland@gmail.com>