### PR TITLE
cicd: add scripts to build images for app-SRE

### DIFF
--- a/app-sre/build_and_deploy.sh
+++ b/app-sre/build_and_deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# AppSRE team CD
+
+set -exv
+
+CURRENT_DIR=$(dirname $0)
+
+BASE_IMG="clair"
+CLAIR_IMAGE="quay.io/app-sre/${BASE_IMG}"
+IMG="${BASE_IMG}:latest"
+
+GIT_HASH=`git rev-parse --short=7 HEAD`
+
+# build the image
+docker build -t ${IMG} .
+
+# push the image
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${CLAIR_IMAGE}:latest"
+
+skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
+    "docker-daemon:${IMG}" \
+    "docker://${CLAIR_IMAGE}:${GIT_HASH}"

--- a/app-sre/pr_check.sh
+++ b/app-sre/pr_check.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -exv
+
+make unit
+make container-build


### PR DESCRIPTION
The Red Hat SRE team require these two scripts to
exist in onboarded repos in order to trigger jenkins
to run them on PRs and after main is updated.

Signed-off-by: crozzy <joseph.crosland@gmail.com>