### PR TITLE
chore: update go version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
   tidy:
     name: Tidy
     runs-on: ubuntu-latest
-    container: quay.io/projectquay/golang:1.15
+    container: quay.io/projectquay/golang:1.16
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -94,7 +94,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.15', '1.16']
+        go: ['1.16', '1.17']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/projectquay/golang:1.15 AS build
+FROM quay.io/projectquay/golang:1.16 AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,7 +74,7 @@ services:
       
   notifier:
     container_name: clair-notifier
-    image: quay.io/projectquay/golang:1.15
+    image: quay.io/projectquay/golang:1.16
     volumes:
       - "./:/src/clair/"
     environment:
@@ -93,7 +93,7 @@ services:
   # this should only be created and deleted via the make target "local-dev-notifier-test"
   notifier-test-mode:
     container_name: clair-notifier
-    image: quay.io/projectquay/golang:1.15
+    image: quay.io/projectquay/golang:1.16
     volumes:
       - "./:/src/clair/"
     environment:
@@ -112,7 +112,7 @@ services:
 
   indexer:
     container_name: clair-indexer
-    image: quay.io/projectquay/golang:1.15
+    image: quay.io/projectquay/golang:1.16
     volumes:
       - "./:/src/clair/"
     environment:
@@ -134,7 +134,7 @@ services:
   ## allows layer fetching over localhost
   indexer-quay:
     container_name: clair-indexer
-    image: quay.io/projectquay/golang:1.15
+    image: quay.io/projectquay/golang:1.16
     volumes:
       - "./:/src/clair/"
     environment:
@@ -152,10 +152,11 @@ services:
       - "traefik.http.services.indexer.loadbalancer.server.port=6000"
     depends_on:
       - quay
+      - clair-db
 
   matcher:
     container_name: clair-matcher
-    image: quay.io/projectquay/golang:1.15
+    image: quay.io/projectquay/golang:1.16
     volumes:
       - "./:/src/clair/"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.15
+go 1.16
 
 require (
 	github.com/docker/docker v1.13.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -215,7 +215,6 @@ github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dp
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stomp/stomp v2.0.6+incompatible h1:4arQsMXdczrQtVOkhY7Rzt0AIDPs3yheg7vvmWEobSA=
@@ -1013,7 +1012,6 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
-google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=


### PR DESCRIPTION
Updating the default version to 1.16 and
adding 1.17 to supported. Dropping 1.15

Signed-off-by: crozzy <joseph.crosland@gmail.com>