### PR TITLE
contrib: stop unneeded vendoring

### DIFF
--- a/contrib/openshift/pr_check.sh
+++ b/contrib/openshift/pr_check.sh
@@ -30,5 +30,4 @@ if [ ! set_root ]; then
     exit 1
 fi
 
-go mod vendor
 make container-build


### PR DESCRIPTION
go build is getting confused when attempting to
vendor the dependencies before building the
binary, it shouldn't be necessary.

Signed-off-by: crozzy <joseph.crosland@gmail.com>