### PR TITLE
Dockerfile: remove dumb-init, tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,11 @@ RUN go build \
 RUN go build\
   ./cmd/clairctl
 
+FROM registry.access.redhat.com/ubi8/ubi-minimal AS init
+RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos --enablerepo=ubi-8-appstream podman-catatonit
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS final
-RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos --enablerepo=ubi-8-appstream tar
-RUN case "$(uname -m)" in \
-		x86_64) export ARCH=amd64 ;; \
-		aarch64) export ARCH=arm64 ;; \
-	esac; \
-	curl -L -o /usr/local/bin/dumb-init "https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_${ARCH}" && \
-	chmod +x /usr/local/bin/dumb-init
-ENTRYPOINT ["/usr/local/bin/dumb-init", "--", "/bin/clair"]
+ENTRYPOINT ["/usr/local/bin/catatonit", "--", "/bin/clair"]
 VOLUME /config
 EXPOSE 6060
 WORKDIR /run
@@ -39,5 +35,6 @@ ENV CLAIR_CONF=/config/config.yaml CLAIR_MODE=combo
 ENV SSL_CERT_DIR="/etc/ssl/certs:/etc/pki/tls/certs:/var/run/certs"
 USER nobody:nobody
 
+COPY --from=init /usr/libexec/catatonit/catatonit /usr/local/bin/catatonit
 COPY --from=build /build/clair /bin/clair
 COPY --from=build /build/clairctl /bin/clairctl


### PR DESCRIPTION
This change removes tar from the final image (no longer used by
claircore) and replaces dumb-init with a copy of catatonit from podman.

More info about catatonit can be found at
https://github.com/openSUSE/catatonit/.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>