### PR TITLE
contrib: update secrets path

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -41,9 +41,9 @@ objects:
           volumes:
             - name: clair-config
               secret:
-                secretName: ${{CLAIR_SECRET}}
+                secretName: config
                 items:
-                  - key: config
+                  - key: ${{CLAIR_SECRET}}
                     path: clair.conf
           containers:
             - name: clair-indexer
@@ -110,9 +110,9 @@ objects:
           volumes:
             - name: clair-config
               secret:
-                secretName: ${{CLAIR_SECRET}}
+                secretName: config
                 items:
-                  - key: config
+                  - key: ${{CLAIR_SECRET}}
                     path: clair.conf
           containers:
             - name: clair-matcher
@@ -176,9 +176,9 @@ objects:
           volumes:
             - name: clair-config
               secret:
-                secretName: ${{CLAIR_SECRET}}
+                secretName: config
                 items:
-                  - key: config
+                  - key: ${{CLAIR_SECRET}}
                     path: clair.conf
           containers:
             - name: clair-notifier


### PR DESCRIPTION
It's easier from an organization perspective to keep the
path constant and the key variable.

Signed-off-by: crozzy <joseph.crosland@gmail.com>