### PR TITLE
contrib: different directories for template and configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ CONTRIB_DIR ?= contrib/openshift
 grafana-configmap-gen:
 	sed "s/GRAFANA_MANIFEST/$$(sed -e 's/[\&/]/\\&/g' -e 's/$$/\\n/' -e 's/^/    /' local-dev/grafana/provisioning/dashboards/dashboard.json | tr -d '\n')/" \
 	$(CONTRIB_DIR)/grafana/dashboard-clair.configmap.yaml.tpl \
-	> $(CONTRIB_DIR)/grafana/dashboard-clair.configmap.yaml
+	> $(CONTRIB_DIR)/grafana/dashboards/dashboard-clair.configmap.yaml
 
 # runs unit tests
 .PHONY: unit

--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -1829,3 +1829,4 @@ data:
       "uid": "I1JBFlRnz",
       "version": 1
     }
+


### PR DESCRIPTION
Apparently, due to the limitations of github API and the fact
app interface is using Get repository content call and trying to
parse everything in that directory, the configMap needs to be
in it's own dir.

Signed-off-by: crozzy <joseph.crosland@gmail.com>