### PR TITLE
logging: split stderr from stdout

### DIFF
--- a/initialize/logging.go
+++ b/initialize/logging.go
@@ -2,6 +2,7 @@ package initialize
 
 import (
 	"context"
+	"io"
 	"os"
 	"strings"
 
@@ -12,14 +13,43 @@ import (
 	"github.com/quay/clair/v4/config"
 )
 
+var (
+	stdOut zerolog.LevelWriter = &stdErrWriter{os.Stderr}
+	stdErr zerolog.LevelWriter = &stdOutWriter{os.Stdout}
+)
+
+type stdOutWriter struct {
+	io.Writer
+}
+
+func (sow stdOutWriter) WriteLevel(l zerolog.Level, p []byte) (n int, err error) {
+	if l != zerolog.ErrorLevel && l != zerolog.PanicLevel {
+		return sow.Write(p)
+	}
+	return len(p), nil
+}
+
+type stdErrWriter struct {
+	io.Writer
+}
+
+func (sew stdErrWriter) WriteLevel(l zerolog.Level, p []byte) (n int, err error) {
+	if l == zerolog.ErrorLevel || l == zerolog.PanicLevel {
+		return sew.Write(p)
+	}
+	return len(p), nil
+}
+
 // Logging configures zlog according to the provided configuration.
 func Logging(ctx context.Context, cfg *config.Config) error {
-	l := zerolog.New(os.Stderr)
+	writers := zerolog.MultiLevelWriter(stdOut, stdErr)
+
+	l := zerolog.New(writers)
 	switch strings.ToLower(cfg.LogLevel) {
 	case "debug-color":
 		// set logger to use ConsoleWriter for colorized output
 		l = l.Level(zerolog.DebugLevel).
-			Output(zerolog.ConsoleWriter{Out: os.Stderr})
+			Output(zerolog.ConsoleWriter{Out: os.Stdout})
 	case "debug":
 		l = l.Level(zerolog.DebugLevel)
 	case "info":


### PR DESCRIPTION
At the moment all the logs go to stderr, this PR changes
the logging behaviour to send error and panic logs to stderr
and the rest to stdout. Note: when using debug-color they all
get sent to stdout regardless of level.

Signed-off-by: crozzy <joseph.crosland@gmail.com>