### PR TITLE
grafana: Update dashboard with Notifier metrics

### DIFF
--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -26,7 +26,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "iteration": 1625647457882,
+      "iteration": 1635879789495,
       "links": [],
       "panels": [
         {
@@ -772,13 +772,223 @@ data:
           "type": "timeseries"
         },
         {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 34
+          },
+          "id": 36,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "rate(clair_notifier_created_total[$rate])",
+              "interval": "",
+              "legendFormat": "CreatedTotal: {{instance }}: {{ query }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "rate(clair_notifier_failed_total[$rate])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierFailed: {{instance }}: {{ query }}",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "rate(clair_notifier_putreceipt_total[$rate])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierPutReceipt: {{instance }}: {{ query }}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "rate(clair_notifier_receiptbyuoid_total[$rate])",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierReceiptByUOID: {{instance }}: {{ query }}",
+              "refId": "D"
+            }
+          ],
+          "title": "Database query count (notifier)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 34
+          },
+          "id": 38,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($dbquantile, rate(clair_notifier_created_duration_seconds_bucket[$rate]))",
+              "interval": "",
+              "legendFormat": "CreatedTotal: {{instance }}: {{ query }}",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($dbquantile, rate(clair_notifier_failed_duration_seconds_bucket[$rate]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierFailed: {{instance }}: {{ query }}",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($dbquantile, rate(clair_notifier_putreceipt_duration_seconds_bucket[$rate]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierPutReceipt: {{instance }}: {{ query }}",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($dbquantile, rate(clair_notifier_receiptbyuoid_duration_seconds_bucket[$rate]))",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "NotifierReceiptByUOID: {{instance }}: {{ query }}",
+              "refId": "D"
+            }
+          ],
+          "title": "Database query duration (notifier) (p$dbquantile)",
+          "type": "timeseries"
+        },
+        {
           "collapsed": false,
           "datasource": "$datasource",
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "id": 2,
           "panels": [],
@@ -841,7 +1051,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 4,
           "options": {
@@ -864,7 +1074,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Vulnerability Report Requests",
+          "title": "Vulnerability Report Requests / $rate",
           "type": "timeseries"
         },
         {
@@ -923,7 +1133,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 43
           },
           "id": 15,
           "options": {
@@ -1006,7 +1216,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 51
           },
           "id": 7,
           "options": {
@@ -1029,7 +1239,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Create Index Report Requests",
+          "title": "Create Index Report Requests / $rate",
           "type": "timeseries"
         },
         {
@@ -1089,7 +1299,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 51
           },
           "id": 14,
           "options": {
@@ -1171,7 +1381,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 59
           },
           "id": 6,
           "options": {
@@ -1194,7 +1404,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Indexer State Requests",
+          "title": "Indexer State Requests / $rate",
           "type": "timeseries"
         },
         {
@@ -1254,7 +1464,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 59
           },
           "id": 13,
           "options": {
@@ -1336,7 +1546,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 59
+            "y": 67
           },
           "id": 5,
           "options": {
@@ -1359,7 +1569,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Index Report Requests",
+          "title": "Index Report Requests / $rate",
           "type": "timeseries"
         },
         {
@@ -1418,7 +1628,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 59
+            "y": 67
           },
           "id": 16,
           "options": {
@@ -1445,13 +1655,341 @@ data:
           "type": "timeseries"
         },
         {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 75
+          },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by (code) (rate(clair_http_notifier_api_v1_notification_request_total{method=\"get\"}[$rate]))",
+              "instant": false,
+              "interval": "1",
+              "legendFormat": "Status {{ code }} ",
+              "refId": "A"
+            }
+          ],
+          "title": "Get Notifications Requests / $rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "Seconds",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 75
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($apiquantile, rate(clair_http_notifier_api_v1_notification_request_duration_seconds_bucket[$rate]))",
+              "instant": false,
+              "interval": "1",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Get Notification Request Latency (p$apiquantile)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 83
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum by (code) (rate(clair_http_notifier_api_v1_notification_request_total{method=\"delete\"}[$rate]))",
+              "instant": false,
+              "interval": "1",
+              "legendFormat": "Status {{ code }}",
+              "refId": "A"
+            }
+          ],
+          "title": "Delete Notification Requests / $rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "Seconds",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 30,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 83
+          },
+          "id": 42,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "histogram_quantile($apiquantile, rate(clair_http_notifier_api_v1_notification_request_duration_seconds_bucket[$rate]))",
+              "instant": false,
+              "interval": "1",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Delete Notification Request Latency (p$apiquantile)",
+          "type": "timeseries"
+        },
+        {
           "collapsed": false,
           "datasource": "$datasource",
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 67
+            "y": 91
           },
           "id": 9,
           "panels": [],
@@ -1514,7 +2052,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 92
           },
           "id": 11,
           "options": {
@@ -1596,7 +2134,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 92
           },
           "id": 12,
           "options": {
@@ -1753,9 +2291,9 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
-              "text": "0.95",
-              "value": "0.95"
+              "selected": true,
+              "text": "0.20",
+              "value": "0.20"
             },
             "description": null,
             "error": null,
@@ -1766,7 +2304,7 @@ data:
             "name": "apiquantile",
             "options": [
               {
-                "selected": true,
+                "selected": false,
                 "text": "0.95",
                 "value": "0.95"
               },
@@ -1781,7 +2319,7 @@ data:
                 "value": "0.5"
               },
               {
-                "selected": false,
+                "selected": true,
                 "text": "0.20",
                 "value": "0.20"
               },
@@ -1799,8 +2337,8 @@ data:
           {
             "current": {
               "selected": false,
-              "text": "app-sre-stage-01-prometheus",
-              "value": "app-sre-stage-01-prometheus"
+              "text": "Prometheus",
+              "value": "Prometheus"
             },
             "description": null,
             "error": null,
@@ -1827,6 +2365,6 @@ data:
       "timezone": "",
       "title": "Clair V4",
       "uid": "I1JBFlRnz",
-      "version": 1
+      "version": 2
     }
 

--- a/local-dev/grafana/provisioning/dashboards/dashboard.json
+++ b/local-dev/grafana/provisioning/dashboards/dashboard.json
@@ -15,7 +15,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1625647457882,
+  "iteration": 1635879789495,
   "links": [],
   "panels": [
     {
@@ -761,13 +761,223 @@
       "type": "timeseries"
     },
     {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 34
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "rate(clair_notifier_created_total[$rate])",
+          "interval": "",
+          "legendFormat": "CreatedTotal: {{instance }}: {{ query }}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(clair_notifier_failed_total[$rate])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierFailed: {{instance }}: {{ query }}",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(clair_notifier_putreceipt_total[$rate])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierPutReceipt: {{instance }}: {{ query }}",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "rate(clair_notifier_receiptbyuoid_total[$rate])",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierReceiptByUOID: {{instance }}: {{ query }}",
+          "refId": "D"
+        }
+      ],
+      "title": "Database query count (notifier)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 34
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($dbquantile, rate(clair_notifier_created_duration_seconds_bucket[$rate]))",
+          "interval": "",
+          "legendFormat": "CreatedTotal: {{instance }}: {{ query }}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($dbquantile, rate(clair_notifier_failed_duration_seconds_bucket[$rate]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierFailed: {{instance }}: {{ query }}",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($dbquantile, rate(clair_notifier_putreceipt_duration_seconds_bucket[$rate]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierPutReceipt: {{instance }}: {{ query }}",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($dbquantile, rate(clair_notifier_receiptbyuoid_duration_seconds_bucket[$rate]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "NotifierReceiptByUOID: {{instance }}: {{ query }}",
+          "refId": "D"
+        }
+      ],
+      "title": "Database query duration (notifier) (p$dbquantile)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 42
       },
       "id": 2,
       "panels": [],
@@ -830,7 +1040,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 35
+        "y": 43
       },
       "id": 4,
       "options": {
@@ -853,7 +1063,7 @@
           "refId": "A"
         }
       ],
-      "title": "Vulnerability Report Requests",
+      "title": "Vulnerability Report Requests / $rate",
       "type": "timeseries"
     },
     {
@@ -912,7 +1122,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 35
+        "y": 43
       },
       "id": 15,
       "options": {
@@ -995,7 +1205,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 51
       },
       "id": 7,
       "options": {
@@ -1018,7 +1228,7 @@
           "refId": "A"
         }
       ],
-      "title": "Create Index Report Requests",
+      "title": "Create Index Report Requests / $rate",
       "type": "timeseries"
     },
     {
@@ -1078,7 +1288,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 51
       },
       "id": 14,
       "options": {
@@ -1160,7 +1370,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 51
+        "y": 59
       },
       "id": 6,
       "options": {
@@ -1183,7 +1393,7 @@
           "refId": "A"
         }
       ],
-      "title": "Indexer State Requests",
+      "title": "Indexer State Requests / $rate",
       "type": "timeseries"
     },
     {
@@ -1243,7 +1453,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 51
+        "y": 59
       },
       "id": 13,
       "options": {
@@ -1325,7 +1535,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 67
       },
       "id": 5,
       "options": {
@@ -1348,7 +1558,7 @@
           "refId": "A"
         }
       ],
-      "title": "Index Report Requests",
+      "title": "Index Report Requests / $rate",
       "type": "timeseries"
     },
     {
@@ -1407,7 +1617,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 59
+        "y": 67
       },
       "id": 16,
       "options": {
@@ -1434,13 +1644,341 @@
       "type": "timeseries"
     },
     {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 75
+      },
+      "id": 41,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (code) (rate(clair_http_notifier_api_v1_notification_request_total{method=\"get\"}[$rate]))",
+          "instant": false,
+          "interval": "1",
+          "legendFormat": "Status {{ code }} ",
+          "refId": "A"
+        }
+      ],
+      "title": "Get Notifications Requests / $rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 40,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($apiquantile, rate(clair_http_notifier_api_v1_notification_request_duration_seconds_bucket[$rate]))",
+          "instant": false,
+          "interval": "1",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Get Notification Request Latency (p$apiquantile)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 39,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum by (code) (rate(clair_http_notifier_api_v1_notification_request_total{method=\"delete\"}[$rate]))",
+          "instant": false,
+          "interval": "1",
+          "legendFormat": "Status {{ code }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Notification Requests / $rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
+      "id": 42,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "histogram_quantile($apiquantile, rate(clair_http_notifier_api_v1_notification_request_duration_seconds_bucket[$rate]))",
+          "instant": false,
+          "interval": "1",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Delete Notification Request Latency (p$apiquantile)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": "$datasource",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 91
       },
       "id": 9,
       "panels": [],
@@ -1503,7 +2041,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 92
       },
       "id": 11,
       "options": {
@@ -1585,7 +2123,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 92
       },
       "id": 12,
       "options": {
@@ -1742,9 +2280,9 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": "0.95",
-          "value": "0.95"
+          "selected": true,
+          "text": "0.20",
+          "value": "0.20"
         },
         "description": null,
         "error": null,
@@ -1755,7 +2293,7 @@
         "name": "apiquantile",
         "options": [
           {
-            "selected": true,
+            "selected": false,
             "text": "0.95",
             "value": "0.95"
           },
@@ -1770,7 +2308,7 @@
             "value": "0.5"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "0.20",
             "value": "0.20"
           },
@@ -1788,8 +2326,8 @@
       {
         "current": {
           "selected": false,
-          "text": "app-sre-stage-01-prometheus",
-          "value": "app-sre-stage-01-prometheus"
+          "text": "Prometheus",
+          "value": "Prometheus"
         },
         "description": null,
         "error": null,
@@ -1816,5 +2354,5 @@
   "timezone": "",
   "title": "Clair V4",
   "uid": "I1JBFlRnz",
-  "version": 1
+  "version": 2
 }

--- a/local-dev/prometheus/prometheus.yml
+++ b/local-dev/prometheus/prometheus.yml
@@ -15,6 +15,11 @@ scrape_configs:
     static_configs:
       - targets: ['matcher:8089']
 
+  - job_name: notifier
+    metrics_path: "/metrics"
+    static_configs:
+      - targets: ['notifier:8089']
+
   - job_name: indexer-quay
     metrics_path: "/metrics"
     static_configs:


### PR DESCRIPTION
One outstanding component of Clair absent from the dashboard
was the notifier. This adds charts for API and DB requests
made by the notifier subsystem.

Signed-off-by: crozzy <joseph.crosland@gmail.com>