### PR TITLE
contrib: use a real target for generating configMap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,14 +162,11 @@ docs-build:
 	rsync --recursive --delete-after --exclude 'v4.*' --exclude .git\
 		./book/ $(DOCS_DIR)/
 
-CONTRIB_DIR ?= contrib/openshift
-# Updates the contrib grafana with the contents of the local-dev version to 
-# avoid maintaining two versions
-.PHONY: grafana-configmap-gen
-grafana-configmap-gen:
-	sed "s/GRAFANA_MANIFEST/$$(sed -e 's/[\&/]/\\&/g' -e 's/$$/\\n/' -e 's/^/    /' local-dev/grafana/provisioning/dashboards/dashboard.json | tr -d '\n')/" \
-	$(CONTRIB_DIR)/grafana/dashboard-clair.configmap.yaml.tpl \
-	> $(CONTRIB_DIR)/grafana/dashboards/dashboard-clair.configmap.yaml
+contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml: local-dev/grafana/provisioning/dashboards/dashboard.json contrib/openshift/grafana/dashboard-clair.configmap.yaml.tpl
+	sed "s/GRAFANA_MANIFEST/$$(sed -e 's/[\&/]/\\&/g' -e 's/$$/\\n/' -e 's/^/    /' $< | tr -d '\n')/" \
+	$(word 2,$^) \
+	> $@
+
 
 # runs unit tests
 .PHONY: unit

--- a/contrib/openshift/grafana/dashboard-clair.configmap.yaml.tpl
+++ b/contrib/openshift/grafana/dashboard-clair.configmap.yaml.tpl
@@ -1,3 +1,5 @@
+# WARNING: This is generated from local-dev/grafana/data/dashboards/dashboard.json
+# please modify there and run make contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -1,3 +1,5 @@
+# WARNING: This is generated from local-dev/grafana/data/dashboards/dashboard.json
+# please modify there and run make contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
As we're actually make-ing a file, use make as intended.

Signed-off-by: crozzy <joseph.crosland@gmail.com>