### PR TITLE
contrib: add set podManagementPolicy to Parallel

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -17,6 +17,7 @@ objects:
         service: indexer
         app: clair
     spec:
+      podManagementPolicy: Parallel
       replicas: ${{INDEXER_DEPLOYMENT_REPLICAS}}
       selector:
         matchLabels:


### PR DESCRIPTION
This allows all the pods to be launched / terminated in parallel.

Signed-off-by: crozzy <joseph.crosland@gmail.com>