### PR TITLE
local-dev: deterministic postgres port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,8 +71,8 @@ services:
     ports:
       - '6060:6060'
       - '8080:8080'
+      - '5432:5432'
       - '8443'
-      - '5432'
     volumes:
       - './local-dev/traefik/:/etc/traefik/:ro'
 


### PR DESCRIPTION
It's nice if you're using database tool to have a
predetermined port to avoid having to change
connection configs.

Signed-off-by: crozzy <joseph.crosland@gmail.com>