### PR TITLE
contrib: add initContainer to wipe VPC on startup

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -81,6 +81,14 @@ objects:
                   mountPath: /etc/clair
                 - name: indexer-layer-storage
                   mountPath: /tmp
+          initContainers:
+            - name: init-wipe-vpc
+              image: ${{UBI_IMAGE}}:${{UBI_IMAGE_TAG}}
+              command: ['sh', '-c', "rm -rf /tmp/*"]
+              volumeMounts:
+                - name: indexer-layer-storage
+                  mountPath: /tmp
+
 
   #
   # matcher deployment


### PR DESCRIPTION
In unexpected situations the indexer can crash and
not clean up it's layers. When using a statefulSet this
means those layers are always hanging around. This adds
an initContainer to flush the VPC before starting the
indexer pod.

Signed-off-by: crozzy <joseph.crosland@gmail.com>