### PR TITLE
contrib: need to have single braces for strings

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -83,7 +83,7 @@ objects:
                   mountPath: /tmp
           initContainers:
             - name: init-wipe-vpc
-              image: ${{UBI_IMAGE}}:${{UBI_IMAGE_TAG}}
+              image: ${UBI_IMAGE}:${UBI_IMAGE_TAG}
               command: ['sh', '-c', "rm -rf /tmp/*"]
               volumeMounts:
                 - name: indexer-layer-storage


### PR DESCRIPTION
Confirmed with AppSRE that strings need to be single
braces.

Signed-off-by: crozzy <joseph.crosland@gmail.com>