### PR TITLE
contrib: make indexer service headless

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -238,6 +238,7 @@ objects:
           protocol: TCP
           port: 8089
           targetPort: ${{INTROSPECTION_PORT}}
+      clusterIP: None
       selector:
         service: indexer
         app: clair


### PR DESCRIPTION
When using the default clusterIP values for a service
that is pointing to a statefulSet, the traffic is routed
to one pod. Using a headless service should allow traffic
to be evenly routed to all pods.

Signed-off-by: crozzy <joseph.crosland@gmail.com>