### PR TITLE
contrib: revert headless service

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -238,7 +238,6 @@ objects:
           protocol: TCP
           port: 8089
           targetPort: ${{INTROSPECTION_PORT}}
-      clusterIP: None
       selector:
         service: indexer
         app: clair


### PR DESCRIPTION
This was added when debugging request distribution.
Now it seems like this makes the indexer un-available
internally to the other components.

Signed-off-by: crozzy <joseph.crosland@gmail.com>