### PR TITLE
Support compressed response from RHEL servers

### DIFF
--- a/ext/vulnsrc/rhel/rhel.go
+++ b/ext/vulnsrc/rhel/rhel.go
@@ -135,6 +135,10 @@ func (u *updater) Update(datastore database.Datastore) (resp vulnsrc.UpdateRespo
 		switch r.Header.Get("Content-Type") {
 		case "application/gzip":
 			reader, _ = gzip.NewReader(r.Body)
+			if err != nil {
+				log.WithError(err).Error("could not decompress RHEL's XML with Gzip")
+				return resp, err
+			}
 		case "application/x-bzip2":
 			reader = bzip2.NewReader(r.Body)
 		default:


### PR DESCRIPTION
ext/vulnsrc/rhel: support compressed response from https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL%d.xml

Fixes #1454

Signed-off-by: Muzaffar Mahkamov <muzaffar@mahkamov.com>