### PR TITLE
auto: fall back to root cgroup

### DIFF
--- a/initialize/auto/cpu_linux_test.go
+++ b/initialize/auto/cpu_linux_test.go
@@ -72,6 +72,19 @@ func TestCPUDetection(t *testing.T) {
 				},
 				Want: 1,
 			},
+			{
+				Name: "RootFallback",
+				In: fstest.MapFS{
+					"proc/self/cgroup": &fstest.MapFile{Data: []byte(cgmap)},
+					"sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us": &fstest.MapFile{
+						Data: []byte("100000\n"),
+					},
+					"sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us": &fstest.MapFile{
+						Data: []byte("100000\n"),
+					},
+				},
+				Want: 1,
+			},
 		}
 		ctx := zlog.Test(ctx, t)
 		for _, tc := range tt {


### PR DESCRIPTION
It seems that some container runtimes mount things such that paths
reported from procfs don't line up in sysfs. This falls back to
examining the root cgroup if a specific one doesn't exist; as noted in
the code, if this isn't actually the process' cgroup, it'll be the root
cgroup and end up matching the default GOMAXPROCS guess.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>