### PR TITLE
webhook: clone headers out of Config struct

### DIFF
--- a/notifier/webhook/deliverer.go
+++ b/notifier/webhook/deliverer.go
@@ -65,7 +65,7 @@ func (d *Deliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 
 	req := &http.Request{
 		URL:    d.conf.target,
-		Header: d.conf.Headers,
+		Header: d.conf.Headers.Clone(),
 		Body:   codec.JSONReader(&wh),
 		Method: http.MethodPost,
 	}


### PR DESCRIPTION
A re-org in main fixed this misuse of the API, this implements an
equivalent change.

Closes: PROJQUAY-3044
Signed-off-by: Hank Donnay <hdonnay@redhat.com>