### PR TITLE
clairctl: uniform import/export compression

### DIFF
--- a/Documentation/concepts/updatersandairgap.md
+++ b/Documentation/concepts/updatersandairgap.md
@@ -70,17 +70,17 @@ For example:
 
 ```sh
 # On a workstation, run:
-clairctl export-updaters updates.gz
+clairctl export-updaters updates.json.gz
 ```
 
 ```sh
 # Move the resulting file to a place reachable by the cluster:
-scp updates.gz internal-webserver:/var/www/
+scp updates.json.gz internal-webserver:/var/www/
 ```
 
 ```sh
 # On a pod inside the cluster, import the file:
-clairctl import-updaters http://web.svc/updates.gz
+clairctl import-updaters http://web.svc/updates.json.gz
 ```
 
 Note that a configuration file is needed to run these commands.

--- a/cmd/clairctl/export.go
+++ b/cmd/clairctl/export.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/libvuln/jsonblob"
 	"github.com/quay/claircore/libvuln/updates"
@@ -22,18 +25,32 @@ var ExportCmd = &cli.Command{
 	Name:      "export-updaters",
 	Action:    exportAction,
 	Usage:     "run updaters and export results",
-	ArgsUsage: "[out]",
+	ArgsUsage: "[out[.gz|.zst]]",
 	Flags: []cli.Flag{
 		// Strict can be used to check that updaters still work.
 		&cli.BoolFlag{
 			Name:  "strict",
 			Usage: "Return non-zero exit when updaters report errors.",
 		},
+		&cli.BoolFlag{
+			Name:    "gzip",
+			Aliases: []string{"g"},
+			Usage:   "Compress output with gzip.",
+		},
+		&cli.BoolFlag{
+			Name:    "zstd",
+			Aliases: []string{"z"},
+			Usage:   "Compress output with zstd.",
+		},
 	},
 	Description: `Run configured exporters and export to a file.
 
-   A configuration file is needed to run this command, see 'clairctl help'
-   for how to specify one.`, // NB this has spaces, not tabs.
+If a file name is supplied and ends with ".gz" or ".zst" and neither the
+"z" or "g" flag have been supplied, output will be compressed with gzip
+or zstd compression, respectively.
+
+A configuration file is needed to run this command, see 'clairctl help'
+for how to specify one.`,
 }
 
 func exportAction(c *cli.Context) error {
@@ -52,8 +69,37 @@ func exportAction(c *cli.Context) error {
 		}
 		defer f.Close()
 		out = f
+		switch {
+		case c.IsSet("zstd") || c.IsSet("gzip"):
+			break
+		case strings.HasSuffix(args.First(), ".zst"):
+			c.Set("zstd", "true")
+		case strings.HasSuffix(args.First(), ".gz"):
+			c.Set("gzip", "true")
+		}
 	default:
 		return errors.New("too many arguments (wanted at most one)")
+	}
+	switch {
+	case c.Bool("zstd"):
+		enc, err := zstd.NewWriter(out)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if err := enc.Close(); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
+		}()
+		out = enc
+	case c.Bool("gzip"):
+		enc := gzip.NewWriter(out)
+		defer func() {
+			if err := enc.Close(); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
+		}()
+		out = enc
 	}
 
 	// Read and process the config file.


### PR DESCRIPTION
Clairctl's import and export functionality got out-of-sync such that
"import" couldn't handle "export" output unchanged. This change brings
them in-line and has them behave similarly, with similar flags.

Closes: PROJQUAY-2367
Signed-off-by: Hank Donnay <hdonnay@redhat.com>