### PR TITLE
config: MarshalText on value receiver

### DIFF
--- a/config/auth.go
+++ b/config/auth.go
@@ -10,15 +10,15 @@ import (
 type Base64 []byte
 
 var (
-	_ encoding.TextMarshaler   = (*Base64)(nil)
+	_ encoding.TextMarshaler   = (Base64)(nil)
 	_ encoding.TextUnmarshaler = (*Base64)(nil)
 )
 
 // MarshalText implements encoding.TextMarshaler.
-func (b *Base64) MarshalText() ([]byte, error) {
-	sz := base64.StdEncoding.EncodedLen(len(*b))
+func (b Base64) MarshalText() ([]byte, error) {
+	sz := base64.StdEncoding.EncodedLen(len(b))
 	out := make([]byte, sz)
-	base64.StdEncoding.Encode(out, *b)
+	base64.StdEncoding.Encode(out, b)
 	return out, nil
 }
 

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -88,3 +88,18 @@ func TestAuthUnmarshal(t *testing.T) {
 		}
 	})
 }
+
+func TestAuthMarshal(t *testing.T) {
+	want := `{"key":"ZGVhZGJlZWZkZWFkYmVlZg==","iss":["iss"]}`
+	in := config.AuthPSK{
+		Key:    []byte("deadbeefdeadbeef"),
+		Issuer: []string{"iss"},
+	}
+	gotb, err := json.Marshal(in)
+	if err != nil {
+		t.Error(err)
+	}
+	if got := string(gotb); !cmp.Equal(got, want) {
+		t.Error(cmp.Diff(got, want))
+	}
+}


### PR DESCRIPTION
This change will allow the yaml.v3 encoder to see the method as it's
walking the struct. I added a json test to ensure this behavior.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>