### PR TITLE
local-dev: Remove updaters to ensure all run

### DIFF
--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -2,12 +2,6 @@
 log_level: debug-color
 introspection_addr: ":8089"
 http_listen_addr: ":6060"
-updaters:
-  sets:
-    - ubuntu
-    - debian
-    - rhel
-    - alpine
 auth:
   psk:
     key: 'c2VjcmV0'


### PR DESCRIPTION
Currently we only run 4 (types of) updaters, this change
removes an explit list meaning all will run.

Signed-off-by: crozzy <joseph.crosland@gmail.com>