### PR TITLE
metrics: matcher add status code label to matcher latency metric

### DIFF
--- a/middleware/introspection/instrumentedhandler.go
+++ b/middleware/introspection/instrumentedhandler.go
@@ -54,7 +54,7 @@ func InstrumentedHandler(endpoint string, traceOpts othttp.Option, next http.Han
 				Subsystem: Subsystem,
 				Name:      endpoint + "_request_duration_seconds",
 				Help:      "Distribution of request durations for the given path",
-			}, []string{},
+			}, []string{"code"},
 		)
 	)
 	prometheus.MustRegister(RequestCount, RequestSize, ResponseSize, RequestDuration)


### PR DESCRIPTION
This is something that is needed as a hotfix in order to
honor the production SLO.

Signed-off-by: crozzy <joseph.crosland@gmail.com>