### PR TITLE
chore: Update zlog dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/quay/clair/config v1.0.0
 	github.com/quay/claircore v1.3.1
-	github.com/quay/zlog v1.1.1
+	github.com/quay/zlog v1.1.3
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.26.0
 	github.com/streadway/amqp v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -820,8 +820,8 @@ github.com/quay/claircore v1.3.1/go.mod h1:Y237zhvAdUfoe0LpJx182P1+WZSt0bVd3YvKb
 github.com/quay/goval-parser v0.8.6 h1:h1Xg3SZR/6I7UVa1LcsQZvQft/q7sJbosmFrjzSmdqE=
 github.com/quay/goval-parser v0.8.6/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/quay/zlog v1.1.0/go.mod h1:szs9k88lsac48+Wm6QTnpObO67tu0oMr/p5V6qmPEIw=
-github.com/quay/zlog v1.1.1 h1:6Xhcxeo+rhhz8rXIJ1qLb/U7hgs+pgpkKPiAIPv5Fcg=
-github.com/quay/zlog v1.1.1/go.mod h1:szs9k88lsac48+Wm6QTnpObO67tu0oMr/p5V6qmPEIw=
+github.com/quay/zlog v1.1.3 h1:3N9PFFe4ugIyHN+Ed0qOyFTWB61dBeSqg2wEb3g4+ks=
+github.com/quay/zlog v1.1.3/go.mod h1:szs9k88lsac48+Wm6QTnpObO67tu0oMr/p5V6qmPEIw=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319/go.mod h1:rhSvwcijY9wfmrBYrfCvapX8/xOTV46NAUjBRgUyJqc=


### PR DESCRIPTION
Update from v1.1.1 to v1.1.3 (skipping the ill-fated v1.1.2).

Signed-off-by: crozzy <joseph.crosland@gmail.com>