### PR TITLE
logger: add request id to log context for traceability

### DIFF
--- a/httptransport/indexer_v1.go
+++ b/httptransport/indexer_v1.go
@@ -55,6 +55,8 @@ var _ http.Handler = (*IndexerV1)(nil)
 // ServeHTTP implements http.Handler.
 func (h *IndexerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
+	ctx := zlog.ContextWithValues(r.Context(), "request_id", r.Header.Get("x-request-id"))
+	r = r.WithContext(ctx)
 	wr := responserecorder.NewResponseRecorder(w)
 	defer func() {
 		if f, ok := wr.(http.Flusher); ok {

--- a/middleware/introspection/instrumentedhandler.go
+++ b/middleware/introspection/instrumentedhandler.go
@@ -66,6 +66,8 @@ func InstrumentedHandler(endpoint string, traceOpts othttp.Option, next http.Han
 	h = promhttp.InstrumentHandlerResponseSize(ResponseSize, h)
 	h = promhttp.InstrumentHandlerTimeToWriteHeader(RequestDuration, h)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := zlog.ContextWithValues(r.Context(), "request_id", r.Header.Get("x-request-id"))
+		r = r.WithContext(ctx)
 		recorder := rr.NewResponseRecorder(w)
 		h.ServeHTTP(recorder, r)
 		zlog.Info(r.Context()).


### PR DESCRIPTION
this allows requests to be traced through the logs

Fixes #1547