### PR TITLE
chore: Bump claircore v1.4.1 -> 1.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ldelossa/responserecorder v1.0.2-0.20210711162258-40bec93a9325
 	github.com/prometheus/client_golang v1.12.2
 	github.com/quay/clair/config v1.0.0
-	github.com/quay/claircore v1.4.1
+	github.com/quay/claircore v1.4.2
 	github.com/quay/zlog v1.1.3
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.26.1

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/claircore v1.4.1 h1:xoMpdLCIo2ohqVzQNKyGqwIZgxIUlPepjANTg/B5tBU=
-github.com/quay/claircore v1.4.1/go.mod h1:CxlF+cUo1f52KiCIFVR65SZn1x5q3ElDKZZ1Ygdud+o=
+github.com/quay/claircore v1.4.2 h1:Z86aSphhICC34m+I9iyse5nVYV3YOgMK00u1RnJZ3UY=
+github.com/quay/claircore v1.4.2/go.mod h1:CxlF+cUo1f52KiCIFVR65SZn1x5q3ElDKZZ1Ygdud+o=
 github.com/quay/goval-parser v0.8.6 h1:h1Xg3SZR/6I7UVa1LcsQZvQft/q7sJbosmFrjzSmdqE=
 github.com/quay/goval-parser v0.8.6/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/quay/zlog v1.1.0/go.mod h1:szs9k88lsac48+Wm6QTnpObO67tu0oMr/p5V6qmPEIw=


### PR DESCRIPTION
Bump the core library to include patches for rhcc
and crda.

Signed-off-by: crozzy <joseph.crosland@gmail.com>