### PR TITLE
contrib: Wipe all the temporary files in the process of being fetched

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -55,7 +55,7 @@ objects:
               lifecycle:
                 postStart:
                   exec:
-                    command: ['sh', '-c', 'rm -rf /tmp/sha*']
+                    command: ['sh', '-c', 'rm -rf /tmp/sha* /tmp/fetch.*']
               command: ['clair']
               env:
                 - name: CLAIR_CONF


### PR DESCRIPTION
Currently when a container restarts the postStart will
wipe any dangling layers in the filesystem. This however doesn't
cover the files currently being downloaded that are prefixed with
`fetch.`, this change also takes care of them.

Signed-off-by: crozzy <joseph.crosland@gmail.com>