### PR TITLE
contrib: Changes to grafana dashboard

### DIFF
--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -34,7 +34,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "iteration": 1646408105440,
+      "id": 1,
+      "iteration": 1656528217394,
       "links": [],
       "panels": [
         {
@@ -1128,13 +1129,118 @@ data:
           "yBucketSize": null
         },
         {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 33
+          },
+          "id": 63,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "pgxpool_idle_conns{job=\"indexer\"}",
+              "interval": "",
+              "legendFormat": "idle",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_max_conns{job=\"indexer\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "max",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_total_conns{job=\"indexer\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "total",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_acquired_conns{job=\"indexer\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "acquired",
+              "refId": "D"
+            }
+          ],
+          "title": "Connections (Indexer)",
+          "type": "timeseries"
+        },
+        {
           "collapsed": false,
           "datasource": null,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 41
           },
           "id": 50,
           "panels": [],
@@ -1197,7 +1303,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 42
           },
           "id": 21,
           "options": {
@@ -1272,7 +1378,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 0,
-            "y": 41
+            "y": 49
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1336,7 +1442,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 4,
-            "y": 41
+            "y": 49
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1400,7 +1506,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 8,
-            "y": 41
+            "y": 49
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1464,7 +1570,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 12,
-            "y": 41
+            "y": 49
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1528,7 +1634,7 @@ data:
             "h": 8,
             "w": 4,
             "x": 16,
-            "y": 41
+            "y": 49
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1630,7 +1736,7 @@ data:
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 57
           },
           "id": 43,
           "options": {
@@ -1657,6 +1763,111 @@ data:
           "type": "timeseries"
         },
         {
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 64
+          },
+          "id": 64,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "pgxpool_idle_conns{job=\"matcher\"}",
+              "interval": "",
+              "legendFormat": "idle",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_max_conns{job=\"matcher\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "max",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_total_conns{job=\"matcher\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "total",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "pgxpool_acquired_conns{job=\"matcher\"}",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "acquired",
+              "refId": "D"
+            }
+          ],
+          "title": "Connections (Matcher)",
+          "type": "timeseries"
+        },
+        {
           "cards": {
             "cardPadding": null,
             "cardRound": null
@@ -1674,7 +1885,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 72
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1738,7 +1949,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 72
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -1791,7 +2002,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 80
           },
           "id": 61,
           "panels": [
@@ -2016,7 +2227,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 65
+            "y": 81
           },
           "id": 2,
           "panels": [],
@@ -2079,7 +2290,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 82
           },
           "id": 4,
           "options": {
@@ -2123,7 +2334,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 66
+            "y": 82
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2227,7 +2438,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 74
+            "y": 90
           },
           "id": 7,
           "options": {
@@ -2272,7 +2483,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 90
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2374,7 +2585,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 98
           },
           "id": 6,
           "options": {
@@ -2419,7 +2630,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 98
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2521,7 +2732,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 106
           },
           "id": 5,
           "options": {
@@ -2566,7 +2777,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 106
           },
           "heatmap": {},
           "hideZeroBuckets": true,
@@ -2668,7 +2879,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 114
           },
           "id": 41,
           "options": {
@@ -2750,7 +2961,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 114
           },
           "id": 40,
           "options": {
@@ -2832,7 +3043,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 122
           },
           "id": 39,
           "options": {
@@ -2914,7 +3125,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 122
           },
           "id": 42,
           "options": {
@@ -2947,7 +3158,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 114
+            "y": 130
           },
           "id": 9,
           "panels": [],
@@ -3010,7 +3221,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 115
+            "y": 131
           },
           "id": 11,
           "options": {
@@ -3092,7 +3303,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 115
+            "y": 131
           },
           "id": 12,
           "options": {

--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -2497,7 +2497,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(increase(clair_http_indexerv1_request_duration_seconds_bucket{method=\"post\", handler=\"/indexer/api/v1/index_report\"} [5m])) by (le)",
+              "expr": "sum(increase(clair_http_indexerv1_request_duration_seconds_bucket{method=\"post\", handler=\"/indexer/api/v1/index_report\", code=\"201\"} [5m])) by (le)",
               "format": "heatmap",
               "instant": false,
               "interval": "1",

--- a/local-dev/grafana/provisioning/dashboards/dashboard.json
+++ b/local-dev/grafana/provisioning/dashboards/dashboard.json
@@ -2484,7 +2484,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(increase(clair_http_indexerv1_request_duration_seconds_bucket{method=\"post\", handler=\"/indexer/api/v1/index_report\"} [5m])) by (le)",
+          "expr": "sum(increase(clair_http_indexerv1_request_duration_seconds_bucket{method=\"post\", handler=\"/indexer/api/v1/index_report\", code=\"201\"} [5m])) by (le)",
           "format": "heatmap",
           "instant": false,
           "interval": "1",

--- a/local-dev/grafana/provisioning/dashboards/dashboard.json
+++ b/local-dev/grafana/provisioning/dashboards/dashboard.json
@@ -21,7 +21,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1646408105440,
+  "id": 1,
+  "iteration": 1656528217394,
   "links": [],
   "panels": [
     {
@@ -1115,13 +1116,118 @@
       "yBucketSize": null
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 63,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgxpool_idle_conns{job=\"indexer\"}",
+          "interval": "",
+          "legendFormat": "idle",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_max_conns{job=\"indexer\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "max",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_total_conns{job=\"indexer\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "total",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_acquired_conns{job=\"indexer\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "acquired",
+          "refId": "D"
+        }
+      ],
+      "title": "Connections (Indexer)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 33
+        "y": 41
       },
       "id": 50,
       "panels": [],
@@ -1184,7 +1290,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 34
+        "y": 42
       },
       "id": 21,
       "options": {
@@ -1259,7 +1365,7 @@
         "h": 8,
         "w": 4,
         "x": 0,
-        "y": 41
+        "y": 49
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1323,7 +1429,7 @@
         "h": 8,
         "w": 4,
         "x": 4,
-        "y": 41
+        "y": 49
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1387,7 +1493,7 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 41
+        "y": 49
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1451,7 +1557,7 @@
         "h": 8,
         "w": 4,
         "x": 12,
-        "y": 41
+        "y": 49
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1515,7 +1621,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 41
+        "y": 49
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1617,7 +1723,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 49
+        "y": 57
       },
       "id": 43,
       "options": {
@@ -1644,6 +1750,111 @@
       "type": "timeseries"
     },
     {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 64,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "pgxpool_idle_conns{job=\"matcher\"}",
+          "interval": "",
+          "legendFormat": "idle",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_max_conns{job=\"matcher\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "max",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_total_conns{job=\"matcher\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "total",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "pgxpool_acquired_conns{job=\"matcher\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "acquired",
+          "refId": "D"
+        }
+      ],
+      "title": "Connections (Matcher)",
+      "type": "timeseries"
+    },
+    {
       "cards": {
         "cardPadding": null,
         "cardRound": null
@@ -1661,7 +1872,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 56
+        "y": 72
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1725,7 +1936,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 56
+        "y": 72
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1778,7 +1989,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 64
+        "y": 80
       },
       "id": 61,
       "panels": [
@@ -2003,7 +2214,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 65
+        "y": 81
       },
       "id": 2,
       "panels": [],
@@ -2066,7 +2277,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 82
       },
       "id": 4,
       "options": {
@@ -2110,7 +2321,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 82
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -2214,7 +2425,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 74
+        "y": 90
       },
       "id": 7,
       "options": {
@@ -2259,7 +2470,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 74
+        "y": 90
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -2361,7 +2572,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 82
+        "y": 98
       },
       "id": 6,
       "options": {
@@ -2406,7 +2617,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 82
+        "y": 98
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -2508,7 +2719,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 106
       },
       "id": 5,
       "options": {
@@ -2553,7 +2764,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 106
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -2655,7 +2866,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 98
+        "y": 114
       },
       "id": 41,
       "options": {
@@ -2737,7 +2948,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 98
+        "y": 114
       },
       "id": 40,
       "options": {
@@ -2819,7 +3030,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 106
+        "y": 122
       },
       "id": 39,
       "options": {
@@ -2901,7 +3112,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 106
+        "y": 122
       },
       "id": 42,
       "options": {
@@ -2934,7 +3145,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 130
       },
       "id": 9,
       "panels": [],
@@ -2997,7 +3208,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 115
+        "y": 131
       },
       "id": 11,
       "options": {
@@ -3079,7 +3290,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 115
+        "y": 131
       },
       "id": 12,
       "options": {


### PR DESCRIPTION
We now have prometheus metrics derived from pgxpool.Stat()
values for the indexer and matcher DBs, this PR adds two
charts to the dashboard describing max, idle, total and acquired.

Right now the metrics are being thrown off by the fact that 500s will
return very fast. This will ensure only latency for successful requests
is considered.


Signed-off-by: crozzy <joseph.crosland@gmail.com>