### PR TITLE
Chore: Bump claircore to v1.4.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/ldelossa/responserecorder v1.0.2-0.20210711162258-40bec93a9325
 	github.com/prometheus/client_golang v1.12.2
 	github.com/quay/clair/config v1.0.0
-	github.com/quay/claircore v1.4.3
+	github.com/quay/claircore v1.4.4
 	github.com/quay/zlog v1.1.3
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.26.1

--- a/go.sum
+++ b/go.sum
@@ -833,8 +833,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
-github.com/quay/claircore v1.4.3 h1:QTs48kLoAEXQ/DKAvt7wjajDURDUoajHIYL+xwGCf0E=
-github.com/quay/claircore v1.4.3/go.mod h1:CxlF+cUo1f52KiCIFVR65SZn1x5q3ElDKZZ1Ygdud+o=
+github.com/quay/claircore v1.4.4 h1:Wl8Yd5Y0vRfgYJynHlZD8+EKgccpQpjZTHStpvy1Cio=
+github.com/quay/claircore v1.4.4/go.mod h1:CxlF+cUo1f52KiCIFVR65SZn1x5q3ElDKZZ1Ygdud+o=
 github.com/quay/goval-parser v0.8.6 h1:h1Xg3SZR/6I7UVa1LcsQZvQft/q7sJbosmFrjzSmdqE=
 github.com/quay/goval-parser v0.8.6/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
 github.com/quay/zlog v1.1.0/go.mod h1:szs9k88lsac48+Wm6QTnpObO67tu0oMr/p5V6qmPEIw=


### PR DESCRIPTION
Update Claircore version from v1.4.3 to v1.4.4

Signed-off-by: crozzy <joseph.crosland@gmail.com>