### PR TITLE
contrib: First wipe anything that might be left before starting clair indexers

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -53,11 +53,10 @@ objects:
                 requests:
                   cpu: ${{INDEXER_CPU_REQS}}
                   memory: ${{INDEXER_MEM_REQS}}
-              lifecycle:
-                postStart:
-                  exec:
-                    command: ['sh', '-c', 'rm -rf /tmp/sha* /tmp/fetch.*']
-              command: ['clair']
+              command:
+                - sh
+                - '-c'
+                - rm -rf /tmp/sha* /tmp/fetch.* && exec clair
               env:
                 - name: CLAIR_CONF
                   value: '/etc/clair/config.yaml'


### PR DESCRIPTION
We have observed that the postStart command is not consistently
wiping the /tmp dir as it appears like there is a race
condition as the PVC is not guaranteed to be mounted when it is
run.

Signed-off-by: crozzy <joseph.crosland@gmail.com>