### PR TITLE
contrib: remove rpmscanner files on startup

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -56,7 +56,7 @@ objects:
               command:
                 - sh
                 - '-c'
-                - rm -rf /tmp/sha* /tmp/fetch.* && exec clair
+                - rm -rf /tmp/sha* /tmp/fetch.* /tmp/rpmscanner.* && exec clair
               env:
                 - name: CLAIR_CONF
                   value: '/etc/clair/config.yaml'


### PR DESCRIPTION
We should also wipe these files on start up to avoid
filling up the PVCs.

Signed-off-by: crozzy <joseph.crosland@gmail.com>