### PR TITLE
docker-compose: remove -mod=vendor flag

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,6 @@ x-anchors:
     command:
       - go
       - run
-      - -mod=vendor
       - .
       - -conf
       - /etc/clair.yaml


### PR DESCRIPTION
Having the flag causes go run to look for and use a pre-created
vendor directory, removing it will make sure the deps are pulled
down during the run execution process and bring the docs back in
line with the functionality.

Signed-off-by: crozzy <joseph.crosland@gmail.com>