### PR TITLE
cmd: unify version information

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,10 @@ FROM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build/
 ADD . /build/
 ARG CLAIR_VERSION=dev
-RUN go build \
-  -trimpath -ldflags="-s -w -X main.Version=${CLAIR_VERSION}" \
-  ./cmd/clair
-RUN go build -trimpath \
-  ./cmd/clairctl
+RUN for cmd in clair clairctl; do\
+	go build \
+	-trimpath -ldflags="-s -w -X github.com/quay/clair/v4/cmd.Version=${CLAIR_VERSION}" \
+	./cmd/$cmd; done
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS init
 RUN microdnf install --disablerepo=* --enablerepo=ubi-8-baseos-rpms --enablerepo=ubi-8-appstream-rpms podman-catatonit

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,4 +1,5 @@
-package main
+// Package cmd provides some common information to clair's binaries.
+package cmd // import "github.com/quay/clair/v4/cmd"
 
 import (
 	"bytes"
@@ -12,6 +13,11 @@ import (
 // system does this for release builds.
 
 func init() {
+	defer func() {
+		if Version == "" {
+			Version = `???`
+		}
+	}()
 	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
 	defer done()
 	if Version != "" {
@@ -33,3 +39,6 @@ func init() {
 	}
 	Version = string(bytes.TrimSpace(out))
 }
+
+// Version is a version string, injected at build time for release builds.
+var Version string

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -18,15 +18,13 @@ import (
 	"golang.org/x/sync/errgroup"
 	yaml "gopkg.in/yaml.v3"
 
+	"github.com/quay/clair/v4/cmd"
 	"github.com/quay/clair/v4/health"
 	"github.com/quay/clair/v4/httptransport"
 	"github.com/quay/clair/v4/initialize"
 	"github.com/quay/clair/v4/initialize/auto"
 	"github.com/quay/clair/v4/introspection"
 )
-
-// Version is a version string, injected at build time for release builds.
-var Version string
 
 const (
 	envConfig = `CLAIR_CONF`
@@ -98,7 +96,7 @@ func main() {
 	}
 	ctx = zlog.ContextWithValues(ctx, "component", "main")
 	zlog.Info(ctx).
-		Str("version", Version).
+		Str("version", cmd.Version).
 		Msg("starting")
 	for _, w := range ws {
 		zlog.Info(ctx).
@@ -181,7 +179,7 @@ func main() {
 		}
 	}()
 
-	zlog.Info(ctx).Str("version", Version).Msg("ready")
+	zlog.Info(ctx).Str("version", cmd.Version).Msg("ready")
 	if err := srvs.Wait(); err != nil {
 		zlog.Error(ctx).Err(err).Msg("fatal error")
 		fail = true

--- a/cmd/clairctl/main.go
+++ b/cmd/clairctl/main.go
@@ -10,6 +10,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/square/go-jose.v2/jwt"
+
+	"github.com/quay/clair/v4/cmd"
 )
 
 var (
@@ -32,7 +34,7 @@ func main() {
 
 	app := &cli.App{
 		Name:                 "clairctl",
-		Version:              "0.2.0",
+		Version:              cmd.Version,
 		Usage:                "interact with a clair API",
 		Description:          "A command-line tool for clair v4.",
 		EnableBashCompletion: true,


### PR DESCRIPTION
This change makes `clair` and `clairctl` report the same version. The version information is moved from `cmd/clair` to `cmd` and then used from there.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>