### PR TITLE
clairctl: don't use internal client

### DIFF
--- a/cmd/clairctl/export.go
+++ b/cmd/clairctl/export.go
@@ -120,7 +120,7 @@ func exportAction(c *cli.Context) error {
 	}
 
 	tr := http.DefaultTransport.(*http.Transport).Clone()
-	cl, _, err := httputil.Client(httputil.RateLimiter(tr), &commonClaim, cfg)
+	cl, _, err := httputil.Client(httputil.RateLimiter(tr), nil, cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This was causing issues with sending an `Authorization` header when not appropriate.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>