### PR TITLE
chore: Remove windows 386 as a binary target for releases

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -110,7 +110,7 @@ jobs:
           - goos: darwin
             goarch: arm64
           - goos: windows
-            goarch: arm64
+            goarch: '386'
     env:
       GOOS: ${{matrix.goos}}
       GOARCH: ${{matrix.goarch}}
@@ -227,7 +227,7 @@ jobs:
           - goos: darwin
             goarch: arm64
           - goos: windows
-            goarch: arm64
+            goarch: '386'
     steps:
       - name: Fetch Archive
         uses: actions/download-artifact@v3


### PR DESCRIPTION
modernc.org/sqlite no longer (and apparently never did) support windows 386 as a build target:
https://gitlab.com/cznic/sqlite/-/issues/112. We can add windows-arm64 the targets.

Signed-off-by: crozzy <joseph.crosland@gmail.com>