### PR TITLE
cicd: inject version into built `clairctl` binaries

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -128,7 +128,10 @@ jobs:
       - name: Unpack and Build
         run: |
           tar -xz -f ${{steps.download.outputs.download-path}}/clair-${{ needs.config.outputs.version }}.tar.gz --strip-components=1
-          go build -o "clairctl-${{matrix.goos}}-${{matrix.goarch}}" ./cmd/clairctl
+          go build\
+            -trimpath -ldflags="-s -w -X github.com/quay/clair/v4/cmd.Version=${{ needs.config.outputs.version }}"\
+            -o "clairctl-${{matrix.goos}}-${{matrix.goarch}}"\
+            ./cmd/clairctl
       - name: Upload
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Thanks [@leiqi96](https://github.com/leiqi96) for catching this and figuring it out.

Closes: #1649
Signed-off-by: Hank Donnay <hdonnay@redhat.com>