### PR TITLE
database: add mapping for newer Ubuntu versions

### DIFF
--- a/database/namespace_mapping.go
+++ b/database/namespace_mapping.go
@@ -51,4 +51,9 @@ var UbuntuReleasesMapping = map[string]string{
 	"disco":   "19.04",
 	"eoan":    "19.10",
 	"focal":   "20.04",
+	"groovy":  "20.10",
+	"hirsute": "21.04",
+	"impish":  "21.10",
+	"jammy":   "22.04",
+	"kinetic": "22.10",
 }


### PR DESCRIPTION
Add mapping for Ubuntu Groovy, Hirsute, Impish, Jammy and Kinetic.
This is needed to support newer Ubuntu versions.