### PR TITLE
cmd: version injection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+cmd/build.go export-subst
+*.go diff=golang

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           tar -xz -f ${{steps.download.outputs.download-path}}/clair-${{ needs.config.outputs.version }}.tar.gz --strip-components=1
           go build\
-            -trimpath -ldflags="-s -w -X github.com/quay/clair/v4/cmd.Version=${{ needs.config.outputs.version }}"\
+            -trimpath -ldflags="-s -w"\
             -o "clairctl-${{matrix.goos}}-${{matrix.goarch}}"\
             ./cmd/clairctl
       - name: Upload
@@ -196,8 +196,6 @@ jobs:
       - name: Build Container
         uses: docker/build-push-action@v3
         with:
-          build-args: |
-            CLAIR_VERSION=${{ needs.config.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{ runner.temp }}/build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,14 +71,16 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_TOKEN }}
+      - name: Export
+        # This exports the current state of the main branch, and appends our modified go module files.
+        run: 'git archive -o clair.tar --add-file=go.mod --add-file=go.sum "main"'
       - uses: docker/build-push-action@v3
         with:
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
-            CLAIR_VERSION=${{ steps.mod.outputs.clair_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          context: .
+          context: clair.tar
           platforms: linux/amd64,linux/arm64
           push: ${{ steps.setup.outputs.push && steps.novelty.outputs.cache-hit != 'true' }}
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ ARG GO_VERSION=1.18
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build/
 ADD . /build/
-ARG CLAIR_VERSION=dev
+ARG CLAIR_VERSION=""
 RUN for cmd in clair clairctl; do\
 	go build \
-	-trimpath -ldflags="-s -w -X github.com/quay/clair/v4/cmd.Version=${CLAIR_VERSION}" \
+	-trimpath -ldflags="-s -w$(test -n "$CLAIR_VERSION" && printf " -X 'github.com/quay/clair/v4/cmd.Version=%s (user)'" "${CLAIR_VERSION}")" \
 	./cmd/$cmd; done
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS init

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,11 @@ vendor/modules.txt: go.mod
 
 .PHONY: container-build
 container-build:
+ifneq ($(file < .git/HEAD),)
+	$(docker) build "--build-arg=CLAIR_VERSION=$$(git describe --match 'v4.*')" -t clair-local:latest .
+else
 	$(docker) build -t clair-local:latest .
+endif
 
 DOCS_DIR ?= ../clair-doc
 .PHONY: docs-build

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,40 +5,63 @@ import (
 	"bytes"
 	"context"
 	"os/exec"
+	"runtime/debug"
 	"time"
 )
 
-// This is a helper for development. In production, we shouldn't assume that the
-// process is running in a git repository or that git is installed. Our build
-// system does this for release builds.
+// Injected via git-export(1). See that man page and gitattributes(5).
+const (
+	// Needs a length check because GitHub zipballs/tarballs don't do the
+	// describe and just strip the pattern.
+	describe = `$Format:%(describe:match=v4.*)$`
+	revision = `$Format:%h (%cI)$`
+)
 
 func init() {
-	defer func() {
-		if Version == "" {
-			Version = `???`
-		}
-	}()
-	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
-	defer done()
-	if Version != "" {
+	switch {
+	case Version != "":
 		// Had our version injected at build: do nothing.
-		return
+	case len(describe) > 0 && describe[0] != '$':
+		Version = describe
+	case revision[0] == '$':
+		// This is a helper for development. In production, we shouldn't assume
+		// that the process is running in a git repository or that git is
+		// installed. This is quite possibly wrong if run from the wrong working
+		// directory.
+		Version = `(random source build)`
+		ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+		defer done()
+		if _, err := exec.LookPath("git"); err != nil {
+			// Couldn't find a git binary: do nothing.
+			break
+		}
+		if err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Run(); err != nil {
+			// Couldn't find a git repository: do nothing.
+			break
+		}
+		out, err := exec.CommandContext(ctx, "git", "describe").Output()
+		if err != nil {
+			// Couldn't describe the current commit: do nothing.
+			break
+		}
+		Version = string(bytes.TrimSpace(out))
+	default:
+		Version = revision
 	}
-	if _, err := exec.LookPath("git"); err != nil {
-		// Couldn't find a git binary: do nothing.
-		return
+
+	// If we can read out the current binary's debug info, append the claircore
+	// version if there was a replacement.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, m := range info.Deps {
+			if m.Path != "github.com/quay/claircore" {
+				continue
+			}
+			if m.Replace != nil && m.Replace.Version != m.Version {
+				Version += " (claircore " + m.Replace.Version + ")"
+			}
+		}
 	}
-	if err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Run(); err != nil {
-		// Couldn't find a git repository: do nothing.
-		return
-	}
-	out, err := exec.CommandContext(ctx, "git", "describe").Output()
-	if err != nil {
-		// Couldn't describe the current commit: do nothing.
-		return
-	}
-	Version = string(bytes.TrimSpace(out))
 }
 
-// Version is a version string, injected at build time for release builds.
+// Version is a version string, injected at release time for release builds.
 var Version string


### PR DESCRIPTION
These changes use git to inject the `git describe` information into the common version information. This is what our release process and the go module proxy use for their archives. In addition, the `Version` setting function gained some logic to detect if the underlying `claircore` has been swapped out and report on its version as well, if so.

The second commit then cleans up various build spots and the Dockerfile. 