### PR TITLE
httptransport: add a `request_id` to logs

### DIFF
--- a/httptransport/indexer_v1.go
+++ b/httptransport/indexer_v1.go
@@ -68,7 +68,7 @@ func (h *IndexerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, r)
+	h.inner.ServeHTTP(wr, withRequestID(r))
 }
 
 func (h *IndexerV1) indexReport(w http.ResponseWriter, r *http.Request) {

--- a/httptransport/matcher_v1.go
+++ b/httptransport/matcher_v1.go
@@ -76,7 +76,7 @@ func (h *MatcherV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, r)
+	h.inner.ServeHTTP(wr, withRequestID(r))
 }
 
 func (h *MatcherV1) vulnerabilityReport(w http.ResponseWriter, r *http.Request) {

--- a/httptransport/notification_v1.go
+++ b/httptransport/notification_v1.go
@@ -68,7 +68,7 @@ func (h *NotificationV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, r)
+	h.inner.ServeHTTP(wr, withRequestID(r))
 }
 
 func (h *NotificationV1) serveHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This re-uses any trace ID that OpenTelemetry supports, or generates a weakly random one based on some request features.

Closes: #1547
Signed-off-by: Hank Donnay <hdonnay@redhat.com>