### PR TITLE
Strict client

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -159,9 +159,9 @@ A key file for the TLS certificate. Encryption is not supported on the key.
 Indexer provides Clair Indexer node configuration.
 
 #### `$.indexer.airgap`
-Boolean.
-
-Disables scanners that have signaled they expect to talk to the Internet.
+Disables HTTP access to the Internet for indexers and fetchers.
+Private IPv4 and IPv6 addresses are allowed.
+Database connections are unaffected.
 
 #### `$.indexer.connstring`
 A Postgres connection string.

--- a/cmd/clairctl/client.go
+++ b/cmd/clairctl/client.go
@@ -18,13 +18,10 @@ import (
 	"github.com/quay/zlog"
 	"github.com/tomnomnom/linkheader"
 
+	"github.com/quay/clair/v4/cmd"
 	"github.com/quay/clair/v4/httptransport"
 	"github.com/quay/clair/v4/internal/codec"
 	"github.com/quay/clair/v4/internal/httputil"
-)
-
-const (
-	userAgent = `clairctl/1`
 )
 
 var (
@@ -50,7 +47,7 @@ func rt(ctx context.Context, ref string) (http.RoundTripper, error) {
 		return nil, err
 	}
 	rt := http.DefaultTransport
-	rt = transport.NewUserAgent(rt, userAgent)
+	rt = transport.NewUserAgent(rt, `clairctl/`+cmd.Version)
 	rt = transport.NewRetry(rt)
 	rt, err = transport.NewWithContext(ctx, repo.Registry, auth, rt, []string{repo.Scope(transport.PullScope)})
 	if err != nil {

--- a/cmd/clairctl/export.go
+++ b/cmd/clairctl/export.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -119,11 +118,11 @@ func exportAction(c *cli.Context) error {
 		}
 	}
 
-	tr := http.DefaultTransport.(*http.Transport).Clone()
-	cl, _, err := httputil.Client(httputil.RateLimiter(tr), nil, cfg)
+	cl, err := httputil.NewClient(ctx, false)
 	if err != nil {
 		return err
 	}
+	cl.Transport = httputil.RateLimiter(cl.Transport)
 
 	store, err := jsonblob.New()
 	if err != nil {

--- a/cmd/clairctl/import.go
+++ b/cmd/clairctl/import.go
@@ -55,7 +55,7 @@ func importAction(c *cli.Context) error {
 		return err
 	}
 
-	cl, _, err := httputil.Client(nil, &commonClaim, cfg)
+	cl, err := httputil.NewClient(ctx, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/clairctl/import.go
+++ b/cmd/clairctl/import.go
@@ -123,7 +123,7 @@ func openInput(ctx context.Context, c *http.Client, n string) (io.ReadCloser, er
 	}
 	u, uerr := url.Parse(n)
 	if uerr == nil {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/clairctl/manifest.go
+++ b/cmd/clairctl/manifest.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/quay/clair/v4/internal/codec"
+	"github.com/quay/clair/v4/internal/httputil"
 )
 
 var ManifestCmd = &cli.Command{
@@ -136,7 +137,7 @@ func Inspect(ctx context.Context, r string) (*claircore.Manifest, error) {
 		if err != nil {
 			return nil, err
 		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -126,21 +126,24 @@ func reportAction(c *cli.Context) error {
 	// Do we have a config?
 	fi, err := os.Stat(c.Path("config"))
 	useCfg := err == nil && !fi.IsDir()
-
-	var cc *Client
-	if useCfg {
-		cfg, e := loadConfig(c.Path("config"))
-		if e != nil {
-			return e
-		}
-		hc, _, e := httputil.Client(nil, &commonClaim, cfg)
-		if e != nil {
-			return e
-		}
-		cc, err = NewClient(hc, c.String("host"))
-	} else {
-		cc, err = NewClient(nil, c.String("host"))
+	ctx := c.Context
+	hc, err := httputil.NewClient(ctx, false)
+	if err != nil {
+		return err
 	}
+
+	var s *httputil.Signer
+	if useCfg {
+		cfg, err := loadConfig(c.Path("config"))
+		if err != nil {
+			return err
+		}
+		s, err = httputil.NewSigner(ctx, cfg, commonClaim)
+		if err != nil {
+			return err
+		}
+	}
+	cc, err := NewClient(hc, c.String("host"), s)
 	if err != nil {
 		return err
 	}

--- a/config/indexer.go
+++ b/config/indexer.go
@@ -35,8 +35,16 @@ type Indexer struct {
 	//
 	// Whether Indexer nodes handle migrations to their database.
 	Migrations bool `yaml:"migrations,omitempty" json:"migrations,omitempty"`
-	// Airgap disables scanners that have signaled they expect to talk to the
-	// Internet.
+	// Airgap disables HTTP access to the Internet. This affects both indexers and
+	// the layer fetcher. Database connections are unaffected.
+	//
+	// "Airgap" is a bit of a misnomer, as [RFC 4193] and [RFC 1918] addresses
+	// are always allowed. This means that setting this flag and also
+	// configuring a proxy on a private network does not prevent contact with
+	// the Internet.
+	//
+	// [RFC 1918]: https://datatracker.ietf.org/doc/html/rfc1918
+	// [RFC 4193]: https://datatracker.ietf.org/doc/html/rfc4193
 	Airgap bool `yaml:"airgap,omitempty" json:"airgap,omitempty"`
 }
 

--- a/health/readinesshandler_test.go
+++ b/health/readinesshandler_test.go
@@ -1,18 +1,21 @@
 package health_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/quay/clair/v4/health"
+	"github.com/quay/clair/v4/internal/httputil"
 )
 
 func TestReadinessHandler(t *testing.T) {
+	ctx := context.Background()
 	server := httptest.NewServer(health.ReadinessHandler())
 	client := server.Client()
 
-	req, err := http.NewRequest("GET", server.URL, nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}

--- a/httptransport/client/indexer.go
+++ b/httptransport/client/indexer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/quay/clair/v4/httptransport"
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/internal/codec"
+	"github.com/quay/clair/v4/internal/httputil"
 )
 
 var _ indexer.Service = (*HTTP)(nil)
@@ -27,7 +28,7 @@ func (s *HTTP) AffectedManifests(ctx context.Context, v []claircore.Vulnerabilit
 	}{
 		v,
 	})
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), rd)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, u.String(), rd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -70,7 +71,7 @@ func (s *HTTP) Index(ctx context.Context, manifest *claircore.Manifest) (*clairc
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), codec.JSONReader(manifest))
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, u.String(), codec.JSONReader(manifest))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -108,7 +109,7 @@ func (s *HTTP) IndexReport(ctx context.Context, manifest claircore.Digest) (*cla
 		return nil, false, fmt.Errorf("failed to create request: %v", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to create request: %v", err)
 	}
@@ -144,7 +145,7 @@ func (s *HTTP) State(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %v", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to create request: %v", err)
 	}
@@ -169,7 +170,7 @@ func (s *HTTP) DeleteManifests(ctx context.Context, d ...claircore.Digest) ([]cl
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), codec.JSONReader(d))
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodDelete, u.String(), codec.JSONReader(d))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %v", err)
 	}

--- a/httptransport/client/matcher.go
+++ b/httptransport/client/matcher.go
@@ -16,6 +16,7 @@ import (
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/httptransport"
 	"github.com/quay/clair/v4/internal/codec"
+	"github.com/quay/clair/v4/internal/httputil"
 	"github.com/quay/clair/v4/matcher"
 )
 
@@ -26,7 +27,7 @@ func (c *HTTP) Scan(ctx context.Context, ir *claircore.IndexReport) (*claircore.
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), codec.JSONReader(ir))
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, u.String(), codec.JSONReader(ir))
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +85,7 @@ func (c *HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) (in
 					errs[i] = err
 					return
 				}
-				req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
+				req, err := httputil.NewRequestWithContext(ctx, http.MethodDelete, u.String(), nil)
 				if err != nil {
 					errs[i] = err
 					return
@@ -109,7 +110,7 @@ func (c *HTTP) DeleteUpdateOperations(ctx context.Context, ref ...uuid.UUID) (in
 
 	var b strings.Builder
 	var errd bool
-	var deleted = int64(len(ref))
+	deleted := int64(len(ref))
 	for _, err := range errs {
 		if err != nil {
 			deleted--
@@ -142,7 +143,7 @@ func (c *HTTP) UpdateOperations(ctx context.Context, k driver.UpdateKind, update
 	v := url.Values{}
 	v.Add("kind", string(k))
 	u.RawQuery = v.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +161,7 @@ func (c *HTTP) LatestUpdateOperations(ctx context.Context, k driver.UpdateKind) 
 	v.Add("kind", string(k))
 	u.RawQuery = v.Encode()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +217,7 @@ func (c *HTTP) UpdateDiff(ctx context.Context, prev, cur uuid.UUID) (*driver.Upd
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/httptransport/concurrentlimit_test.go
+++ b/httptransport/concurrentlimit_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/quay/zlog"
 	"golang.org/x/sync/semaphore"
+
+	"github.com/quay/clair/v4/internal/httputil"
 )
 
 func TestConcurrentRequests(t *testing.T) {
@@ -39,7 +41,7 @@ func TestConcurrentRequests(t *testing.T) {
 	c := srv.Client()
 
 	done := make(chan struct{})
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +62,7 @@ func TestConcurrentRequests(t *testing.T) {
 	// Wait for the above goroutine to hit the handler.
 	<-ready
 	for i := 0; i < 10; i++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
 		if err != nil {
 			t.Errorf("%d: %v", i, err)
 		}

--- a/httptransport/indexer_v1_test.go
+++ b/httptransport/indexer_v1_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/internal/httputil"
 )
 
 func TestIndexReportBadLayer(t *testing.T) {
@@ -46,7 +47,7 @@ func TestIndexReportBadLayer(t *testing.T) {
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",` +
 				`"layers":[{}]}`
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -107,7 +108,7 @@ func TestIndexerV1(t *testing.T) {
 		ctx := zlog.Test(ctx, t)
 		const path = `/index_state`
 		t.Run("GET", func(t *testing.T) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -128,7 +129,7 @@ func TestIndexerV1(t *testing.T) {
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",` +
 				`"layers":[{}]}`
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -144,7 +145,7 @@ func TestIndexerV1(t *testing.T) {
 		})
 		t.Run("DELETE", func(t *testing.T) {
 			const body = `["sha256:0000000000000000000000000000000000000000000000000000000000000000"]`
-			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, srv.URL+path, strings.NewReader(body))
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodDelete, srv.URL+path, strings.NewReader(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -168,7 +169,7 @@ func TestIndexerV1(t *testing.T) {
 			}
 		})
 		t.Run("GET", func(t *testing.T) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -187,7 +188,7 @@ func TestIndexerV1(t *testing.T) {
 		ctx := zlog.Test(ctx, t)
 		const path = `/index_report/sha256:0000000000000000000000000000000000000000000000000000000000000000`
 		t.Run("DELETE", func(t *testing.T) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodDelete, srv.URL+path, nil)
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodDelete, srv.URL+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -202,7 +203,7 @@ func TestIndexerV1(t *testing.T) {
 			}
 		})
 		t.Run("GET", func(t *testing.T) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -222,7 +223,7 @@ func TestIndexerV1(t *testing.T) {
 		const path = `/internal/affected_manifest/`
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"vulnerabilities":[]}`
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodPost, srv.URL+path, strings.NewReader(body))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/httptransport/matcher_v1_test.go
+++ b/httptransport/matcher_v1_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/quay/clair/v4/indexer"
+	"github.com/quay/clair/v4/internal/httputil"
 	"github.com/quay/clair/v4/matcher"
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/zlog"
@@ -66,12 +67,12 @@ func testUpdateDiffMatcher(t *testing.T) {
 	q := url.Query()
 	q.Set("cur", "892737b2-a616-4113-a7a9-137139c8f91e")
 	url.RawQuery = q.Encode()
-
-	req := &http.Request{
-		URL:    url,
-		Method: http.MethodGet,
-	}
 	t.Log(url)
+
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		t.Fatalf("failed to construct request: %v", err)
+	}
 	resp, err := srvOK.Client().Do(req)
 	if err != nil {
 		t.Fatalf("failed to do request: %v", err)
@@ -96,10 +97,11 @@ func testUpdateDiffMatcher(t *testing.T) {
 	q = url.Query()
 	q.Set("cur", "892737b2-a616-4113-a7a9-137139c8f91e")
 	url.RawQuery = q.Encode()
+	t.Log(url)
 
-	req = &http.Request{
-		URL:    url,
-		Method: http.MethodGet,
+	req, err = httputil.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
+	if err != nil {
+		t.Fatalf("failed to construct request: %v", err)
 	}
 	resp, err = srvErr.Client().Do(req)
 	if err != nil {
@@ -174,9 +176,9 @@ func testUpdateDiffHandlerParams(t *testing.T) {
 			q.Set("prev", test.cur)
 			u.RawQuery = q.Encode()
 
-			req := &http.Request{
-				URL:    u,
-				Method: http.MethodGet,
+			req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+			if err != nil {
+				t.Fatalf("failed to construct request: %v", err)
 			}
 			resp, err := c.Do(req)
 			if err != nil {
@@ -224,7 +226,7 @@ func testUpdateDiffHandlerMethods(t *testing.T) {
 		http.MethodPut,
 		http.MethodTrace,
 	} {
-		req, err := http.NewRequest(m, u.String(), nil)
+		req, err := httputil.NewRequestWithContext(ctx, m, u.String(), nil)
 		if err != nil {
 			t.Fatalf("failed to create request: %v", err)
 		}
@@ -275,7 +277,7 @@ func testUpdateOperationHandlerErrors(t *testing.T) {
 	c := srv.Client()
 
 	// perform get with failing differ
-	req, err := http.NewRequest(http.MethodGet, srv.URL+path.Join("/", "internal", "update_operation"), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path.Join("/", "internal", "update_operation"), nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
@@ -289,7 +291,7 @@ func testUpdateOperationHandlerErrors(t *testing.T) {
 
 	// perform delete with failing differ
 	u := srv.URL + path.Join("/", "internal", "update_operation") + "/" + id
-	req, err = http.NewRequest(http.MethodDelete, u, nil)
+	req, err = httputil.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
@@ -324,7 +326,7 @@ func testUpdateOperationHandlerMethods(t *testing.T) {
 		http.MethodPut,
 		http.MethodTrace,
 	} {
-		req, err := http.NewRequest(m, srv.URL+path.Join("/", "internal", "update_operation"), nil)
+		req, err := httputil.NewRequestWithContext(ctx, m, srv.URL+path.Join("/", "internal", "update_operation"), nil)
 		if err != nil {
 			t.Fatalf("failed to create request: %v", err)
 		}
@@ -370,7 +372,7 @@ func testUpdateOperationHandlerGet(t *testing.T) {
 	c := srv.Client()
 
 	// get without latest param
-	req, err := http.NewRequest(http.MethodGet, srv.URL+path.Join("/", "internal", "update_operation"), nil)
+	req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path.Join("/", "internal", "update_operation"), nil)
 	if err != nil {
 		t.Fatalf("failed to create request: %v", err)
 	}
@@ -395,9 +397,10 @@ func testUpdateOperationHandlerGet(t *testing.T) {
 	q := u.Query()
 	q.Add("latest", "true")
 	u.RawQuery = q.Encode()
-	req = &http.Request{
-		URL:    u,
-		Method: http.MethodGet,
+
+	req, err = httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		t.Fatalf("failed to create request: %v", err)
 	}
 	resp, err = c.Do(req)
 	if err != nil {

--- a/httptransport/notification_v1_test.go
+++ b/httptransport/notification_v1_test.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/quay/clair/v4/internal/httputil"
 	"github.com/quay/clair/v4/notifier"
 	"github.com/quay/clair/v4/notifier/service"
 )
@@ -53,9 +54,9 @@ func testNotificationHandlerDelete(ctx context.Context) func(*testing.T) {
 		}
 		rr := httptest.NewRecorder()
 		u, _ := url.Parse("http://clair-notifier/notifier/api/v1/notification/" + noteID.String())
-		req := &http.Request{
-			URL:    u,
-			Method: http.MethodGet,
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			t.Error(err)
 		}
 
 		h.delete(rr, req)
@@ -104,9 +105,9 @@ func testNotificationHandlerGet(ctx context.Context) func(*testing.T) {
 		}
 		rr := httptest.NewRecorder()
 		u, _ := url.Parse("http://clair-notifier/notifier/api/v1/notification/" + noteID.String())
-		req := &http.Request{
-			URL:    u,
-			Method: http.MethodGet,
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			t.Error(err)
 		}
 
 		h.get(rr, req)
@@ -171,9 +172,9 @@ func testNotificationHandlerGetParams(ctx context.Context) func(*testing.T) {
 		v.Set("page_size", pageSizeParam)
 		v.Set("page", pageParam)
 		u.RawQuery = v.Encode()
-		req := &http.Request{
-			URL:    u,
-			Method: http.MethodGet,
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+		if err != nil {
+			t.Error(err)
 		}
 
 		h.get(rr, req)
@@ -215,7 +216,7 @@ func testNotificationsHandlerMethods(ctx context.Context) func(*testing.T) {
 			http.MethodPut,
 			http.MethodTrace,
 		} {
-			req, err := http.NewRequest(m, u, nil)
+			req, err := httputil.NewRequestWithContext(ctx, m, u, nil)
 			if err != nil {
 				t.Fatalf("failed to create request: %v", err)
 			}

--- a/internal/httputil/ratelimiter.go
+++ b/internal/httputil/ratelimiter.go
@@ -21,8 +21,8 @@ func RateLimiter(next http.RoundTripper) http.RoundTripper {
 // Ratelimiter implements the limiting by using a concurrent map and Limiter
 // structs.
 type ratelimiter struct {
-	rt http.RoundTripper
 	lm sync.Map
+	rt http.RoundTripper
 }
 
 const rateCap = 10

--- a/internal/httputil/signer.go
+++ b/internal/httputil/signer.go
@@ -1,0 +1,114 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/quay/clair/config"
+	"github.com/quay/zlog"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// NewSigner constructs a signer according to the provided Config and claim.
+//
+// The returned Signer only adds headers for the hosts specified in the
+// following spots:
+//
+//   - $.notifier.webhook.target
+//   - $.notifier.indexer_addr
+//   - $.notifier.matcher_addr
+//   - $.matcher.indexer_addr
+func NewSigner(ctx context.Context, cfg *config.Config, cl jwt.Claims) (*Signer, error) {
+	if cfg.Auth.PSK == nil {
+		zlog.Debug(ctx).
+			Str("component", "internal/httputil/NewSigner").
+			Msg("authentication disabled")
+		return new(Signer), nil
+	}
+	s := Signer{
+		use:   make(map[string]struct{}),
+		claim: cl,
+	}
+	if cfg.Notifier.Webhook != nil {
+		if err := s.Add(ctx, cfg.Notifier.Webhook.Target); err != nil {
+			return nil, err
+		}
+	}
+	if err := s.Add(ctx, cfg.Notifier.IndexerAddr); err != nil {
+		return nil, err
+	}
+	if err := s.Add(ctx, cfg.Notifier.MatcherAddr); err != nil {
+		return nil, err
+	}
+	if err := s.Add(ctx, cfg.Matcher.IndexerAddr); err != nil {
+		return nil, err
+	}
+
+	sk := jose.SigningKey{
+		Algorithm: jose.HS256,
+		Key:       []byte(cfg.Auth.PSK.Key),
+	}
+	signer, err := jose.NewSigner(sk, nil)
+	if err != nil {
+		return nil, err
+	}
+	s.signer = signer
+	if zlog.Debug(ctx).Enabled() {
+		as := make([]string, 0, len(s.use))
+		for a := range s.use {
+			as = append(as, a)
+		}
+		zlog.Debug(ctx).Strs("authorities", as).
+			Msg("enabling signing for authorities")
+	}
+	return &s, nil
+}
+
+// Add marks the authority in "uri" as one that expects signed requests.
+func (s *Signer) Add(ctx context.Context, uri string) error {
+	if uri == "" {
+		return nil
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	a := u.Host
+	s.use[a] = struct{}{}
+	return nil
+}
+
+// Signer signs requests.
+type Signer struct {
+	signer jose.Signer
+	use    map[string]struct{}
+	claim  jwt.Claims
+}
+
+// Sign modifies the passed [http.Request] as needed.
+func (s *Signer) Sign(ctx context.Context, req *http.Request) error {
+	if s == nil || s.signer == nil {
+		return nil
+	}
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	if _, ok := s.use[host]; !ok {
+		return nil
+	}
+	cl := s.claim
+	now := time.Now()
+	cl.IssuedAt = jwt.NewNumericDate(now)
+	cl.NotBefore = jwt.NewNumericDate(now.Add(-jwt.DefaultLeeway))
+	cl.Expiry = jwt.NewNumericDate(now.Add(jwt.DefaultLeeway))
+	h, err := jwt.Signed(s.signer).Claims(&cl).CompactSerialize()
+	if err != nil {
+		return err
+	}
+	req.Header.Add("authorization", "Bearer "+h)
+	return nil
+}

--- a/middleware/auth/httpauth_psk_test.go
+++ b/middleware/auth/httpauth_psk_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"math/rand"
@@ -13,6 +14,7 @@ import (
 	"testing/quick"
 	"time"
 
+	"github.com/quay/clair/v4/internal/httputil"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -88,6 +90,7 @@ func (tc *pskTestcase) Handler(t *testing.T) http.Handler {
 // Roundtrips returns a function suitable for passing to quick.Check.
 func roundtrips(t *testing.T) func(*pskTestcase) bool {
 	return func(tc *pskTestcase) bool {
+		ctx := context.Background()
 		t.Log(tc)
 		// Set up the jwt signer.
 		sk := jose.SigningKey{
@@ -122,7 +125,7 @@ func roundtrips(t *testing.T) func(*pskTestcase) bool {
 		defer srv.Close()
 
 		// Mint a request.
-		req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+		req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
 		if err != nil {
 			t.Error(err)
 			return false

--- a/notifier/service/notifier.go
+++ b/notifier/service/notifier.go
@@ -55,6 +55,7 @@ func (s *Notifier) DeleteNotifications(ctx context.Context, id uuid.UUID) error 
 type Opts struct {
 	Matcher          matcher.Service
 	Indexer          indexer.Service
+	Signer           webhook.Signer
 	Client           *http.Client
 	Webhook          *config.Webhook
 	AMQP             *config.AMQP
@@ -100,7 +101,7 @@ func New(ctx context.Context, store notifier.Store, locks notifier.Locker, opts 
 		zlog.Info(ctx).
 			Int("count", deliveries).
 			Msg("initializing webhook deliverers")
-		del, err = webhook.New(opts.Webhook, opts.Client)
+		del, err = webhook.New(opts.Webhook, opts.Client, opts.Signer)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create webhook deliverer: %v", err)
 		}

--- a/notifier/webhook/debug_server.go
+++ b/notifier/webhook/debug_server.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package main
@@ -131,7 +132,7 @@ func (h *Recv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var resp response
 	for next := new(uuid.UUID); next != nil; next = resp.Page.Next {
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, payload.Callback.String(), nil)
+		req, err := httputil.NewRequestWithContext(r.Context(), http.MethodGet, payload.Callback.String(), nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to create request: %v", err), http.StatusInternalServerError)
 			log.Println("E", "unable to create request:", err.Error())
@@ -188,7 +189,7 @@ func (h *Recv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Println(":", whid, n.ID, n.Manifest, n.Reason, n.Vulnerability.Name)
 		}
 	}
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodDelete, payload.Callback.String(), nil)
+	req, err := httputil.NewRequestWithContext(r.Context(), http.MethodDelete, payload.Callback.String(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/notifier/webhook/deliverer_test.go
+++ b/notifier/webhook/deliverer_test.go
@@ -54,7 +54,7 @@ func TestDeliverer(t *testing.T) {
 		Target:   server.URL,
 	}
 
-	d, err := New(&conf, server.Client())
+	d, err := New(&conf, server.Client(), nil)
 	if err != nil {
 		t.Fatalf("failed to create new webhook deliverer: %v", err)
 	}


### PR DESCRIPTION
This PR reworks the HTTP client framework inside of Clair.

It removes the `http.RoundTripper` that modified passing requests (a source of some previous data races and recommended against in the documentation) in favor of some helper functions.

- The signing is pulled out into a dedicated object that modifies requests, meaning the caller needs to have one and use it.
- The user-agent setting is pulled into a wrapper around `http.NewRequestWithContext`
  This also means that if we want to enforce additional defaults on Requests, it can be done here without needing to hunt down call sites.
- The client constructor now only cares about whether it should use a dialer that allows public networks or not.

Then all the packages are updated to use this new API surface as needed.
