### PR TITLE
client: Add the passed host to the signer

### DIFF
--- a/cmd/clairctl/delete.go
+++ b/cmd/clairctl/delete.go
@@ -58,6 +58,10 @@ func deleteAction(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		if err = s.Add(ctx, c.String("host")); err != nil {
+			return err
+		}
+
 	}
 	cc, err := NewClient(hc, c.String("host"), s)
 	if err != nil {

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -142,6 +142,9 @@ func reportAction(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
+		if err = s.Add(ctx, c.String("host")); err != nil {
+			return err
+		}
 	}
 	cc, err := NewClient(hc, c.String("host"), s)
 	if err != nil {


### PR DESCRIPTION
Currently the request will only be signed if it's to one of the components' addresses (intra-component comms). We also need to allow external requests by clairctl to be signed using the key they pass implicitly from the config.

Signed-off-by: crozzy <joseph.crosland@gmail.com>