### PR TITLE
httptransport: fix request_id logging

### DIFF
--- a/httptransport/indexer_v1.go
+++ b/httptransport/indexer_v1.go
@@ -56,6 +56,7 @@ var _ http.Handler = (*IndexerV1)(nil)
 func (h *IndexerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	wr := responserecorder.NewResponseRecorder(w)
+	r = withRequestID(r)
 	defer func() {
 		if f, ok := wr.(http.Flusher); ok {
 			f.Flush()
@@ -68,7 +69,7 @@ func (h *IndexerV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, withRequestID(r))
+	h.inner.ServeHTTP(wr, r)
 }
 
 func (h *IndexerV1) indexReport(w http.ResponseWriter, r *http.Request) {

--- a/httptransport/matcher_v1.go
+++ b/httptransport/matcher_v1.go
@@ -64,6 +64,7 @@ var _ http.Handler = (*MatcherV1)(nil)
 func (h *MatcherV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	wr := responserecorder.NewResponseRecorder(w)
+	r = withRequestID(r)
 	defer func() {
 		if f, ok := wr.(http.Flusher); ok {
 			f.Flush()
@@ -76,7 +77,7 @@ func (h *MatcherV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, withRequestID(r))
+	h.inner.ServeHTTP(wr, r)
 }
 
 func (h *MatcherV1) vulnerabilityReport(w http.ResponseWriter, r *http.Request) {

--- a/httptransport/notification_v1.go
+++ b/httptransport/notification_v1.go
@@ -56,6 +56,7 @@ func NewNotificationV1(_ context.Context, prefix string, srv notifier.Service, t
 func (h *NotificationV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	start := time.Now()
 	wr := responserecorder.NewResponseRecorder(w)
+	r = withRequestID(r)
 	defer func() {
 		if f, ok := wr.(http.Flusher); ok {
 			f.Flush()
@@ -68,7 +69,7 @@ func (h *NotificationV1) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Dur("duration", time.Since(start)).
 			Msg("handled HTTP request")
 	}()
-	h.inner.ServeHTTP(wr, withRequestID(r))
+	h.inner.ServeHTTP(wr, r)
 }
 
 func (h *NotificationV1) serveHTTP(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
The final HTTP status message was getting an earlier Context which was missing the request_id key.

Signed-off-by: Hank Donnay <hdonnay@redhat.com>