### PR TITLE
chore: Update go version in Dockerfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.18", "1.19"]' >> "$GITHUB_OUTPUT"
+          echo 'go_versions=["1.18", "1.19", "1.20"]' >> "$GITHUB_OUTPUT"
 
   commit-check:
     name: Commit Check

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.20
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build/
 ADD . /build/


### PR DESCRIPTION
Making the default go version 1.20 in the Dockerfile.

Signed-off-by: crozzy <joseph.crosland@gmail.com>