### PR TITLE
chore: Update go-image version in docker-compose manifest

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ x-anchors:
   grafana: &grafana-image docker.io/grafana/grafana:8.0.3
   quay: &quay-image quay.io/projectquay/quay:latest
   redis: &redis-image docker.io/library/redis:6.2
-  go: &go-image quay.io/projectquay/golang:1.18
+  go: &go-image quay.io/projectquay/golang:1.20
   skopeo: &skopeo-image quay.io/skopeo/stable:latest
   activemq: &activemq-image docker.io/rmohr/activemq:5.15.9-alpine
   clair-service: &clair-service


### PR DESCRIPTION
We should be running the local dev setup on 1.20 due to https://github.com/golang/go/issues/33121

Signed-off-by: crozzy <joseph.crosland@gmail.com>