### PR TITLE
chore: Use our dedicated metric for the go version

### DIFF
--- a/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
+++ b/contrib/openshift/grafana/dashboards/dashboard-clair.configmap.yaml
@@ -34,7 +34,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "iteration": 1675963111894,
+      "iteration": 1675970678069,
       "links": [],
       "panels": [
         {
@@ -256,10 +256,10 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum (go_info) by (job, version)",
+              "expr": "sum (clair_cmd_version_info) by (job, goversion)",
               "hide": false,
               "interval": "",
-              "legendFormat": "{{job}} - {{version}}",
+              "legendFormat": "{{job}} - {{goversion}}",
               "refId": "B"
             },
             {
@@ -3541,6 +3541,6 @@ data:
       "timezone": "",
       "title": "Clair V4",
       "uid": "I1JBFlRnz",
-      "version": 1
+      "version": 4
     }
 

--- a/local-dev/grafana/provisioning/dashboards/dashboard.json
+++ b/local-dev/grafana/provisioning/dashboards/dashboard.json
@@ -21,7 +21,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 1,
-  "iteration": 1675963111894,
+  "iteration": 1675970678069,
   "links": [],
   "panels": [
     {
@@ -243,10 +243,10 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum (go_info) by (job, version)",
+          "expr": "sum (clair_cmd_version_info) by (job, goversion)",
           "hide": false,
           "interval": "",
-          "legendFormat": "{{job}} - {{version}}",
+          "legendFormat": "{{job}} - {{goversion}}",
           "refId": "B"
         },
         {
@@ -3528,5 +3528,5 @@
   "timezone": "",
   "title": "Clair V4",
   "uid": "I1JBFlRnz",
-  "version": 1
+  "version": 4
 }


### PR DESCRIPTION
When using the go runtime metrics to surface the go version in multi-tenent environments you get a whole load of information you don't want from unreleated applications. We can filter down but the label values are not necessarily canonical across environments which complicates things.

Signed-off-by: crozzy <joseph.crosland@gmail.com>