### PR TITLE
contrib: Set the version when building the service image

### DIFF
--- a/contrib/openshift/build_and_deploy.sh
+++ b/contrib/openshift/build_and_deploy.sh
@@ -4,13 +4,13 @@ set -exv
 REPOSITORY="quay.io/app-sre"
 IMAGE="${REPOSITORY}/clair"
 
-make container-build
+docker build --build-arg CLAIR_VERSION=${GIT_HASH} -t clair-service:latest .
 
 GIT_HASH=`git rev-parse --short=7 HEAD`
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-local:latest" \
+    "docker-daemon:clair-service:latest" \
     "docker://${IMAGE}:latest"
 
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-local:latest" \
+    "docker-daemon:clair-service:latest" \
     "docker://${IMAGE}:${GIT_HASH}"


### PR DESCRIPTION
As the image for the service is build in jenkins with limited git context (only the short and long hashes) then set the CLAIR_VERSION to the short git hash when building. It seemed better to stop using the makefile rather than add this specific use-case.

Signed-off-by: crozzy <joseph.crosland@gmail.com>