### PR TITLE
contrib: Set the version when building the service image

### DIFF
--- a/contrib/openshift/build_and_deploy.sh
+++ b/contrib/openshift/build_and_deploy.sh
@@ -4,13 +4,13 @@ set -exv
 REPOSITORY="quay.io/app-sre"
 IMAGE="${REPOSITORY}/clair"
 
-make container-build
+git archive HEAD|
+docker build -t clair-service:latest -
 
-GIT_HASH=`git rev-parse --short=7 HEAD`
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-local:latest" \
+    "docker-daemon:clair-service:latest" \
     "docker://${IMAGE}:latest"
 
 skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-local:latest" \
+    "docker-daemon:clair-service:latest" \
     "docker://${IMAGE}:${GIT_HASH}"


### PR DESCRIPTION
Pipe the output of the git archive command to docker build to include
the version context. It seemed better to stop using the makefile
rather than add this specific use-case.

Signed-off-by: crozzy <joseph.crosland@gmail.com>