### PR TITLE
chore: Add back GIT_HASH as needed for image name

### DIFF
--- a/contrib/openshift/build_and_deploy.sh
+++ b/contrib/openshift/build_and_deploy.sh
@@ -3,6 +3,7 @@
 set -exv
 REPOSITORY="quay.io/app-sre"
 IMAGE="${REPOSITORY}/clair"
+GIT_HASH=`git rev-parse --short=7 HEAD`
 
 git archive HEAD|
 docker build -t clair-service:latest -


### PR DESCRIPTION
We need the short git hash for the image name.