### PR TITLE
cicd: update go versions

### DIFF
--- a/.github/script/nightly-module.sh
+++ b/.github/script/nightly-module.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -e
 : ${CLAIRCORE_BRANCH:=main}
-: ${GO_VERSION:=1.18}
+: ${GO_VERSION:=1.20}
 test "${#GO_VERSION}" -gt 4 && GO_VERSION=${GO_VERSION%.*}
 
 cd $(git rev-parse --show-toplevel)

--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.18", "1.19"]' >> "$GITHUB_OUTPUT"
+          echo 'go_versions=["1.20", "1.19"]' >> "$GITHUB_OUTPUT"
 
   commit-check: 
     name: Commit Check

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.18']
+        image: ['quay.io/projectquay/golang:1.20']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.18", "1.19", "1.20"]' >> "$GITHUB_OUTPUT"
+          echo 'go_versions=["1.20","1.19"]' >> "$GITHUB_OUTPUT"
 
   commit-check:
     name: Commit Check

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
         # nicer workflow inputs so that the cron trigger works.
         run: |
           br=$(test -n "${{github.event.inputs.branch}}" && echo "${{github.event.inputs.branch}}" || echo main)
-          gv=$(test -n "${{github.event.inputs.go_version}}" && echo "${{github.event.inputs.go_version}}" || echo 1.18)
+          gv=$(test -n "${{github.event.inputs.go_version}}" && echo "${{github.event.inputs.go_version}}" || echo 1.20)
           : "${repo:=$GITHUB_REPOSITORY}"
           test "${repo%%/*}" = quay && repo="projectquay/${repo##*/}" ||:
           cat <<. >>$GITHUB_OUTPUT


### PR DESCRIPTION
Claircore now requires 1.20, so update all the CI chores to use it.