### PR TITLE
chore: Update go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.18
+go 1.20
 
 require (
 	github.com/go-stomp/stomp v2.0.8+incompatible


### PR DESCRIPTION
Some of the go detection logic was prone to this bug: https://github.com/golang/go/issues/33121 in the go debug library. As 1.20 includes the fix we deem it required to avoid panics originating in claircore.