### PR TITLE
chore: Remove 1.19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - id: config
         run: |
-          echo 'go_versions=["1.20","1.19"]' >> "$GITHUB_OUTPUT"
+          echo 'go_versions=["1.20"]' >> "$GITHUB_OUTPUT"
 
   commit-check:
     name: Commit Check


### PR DESCRIPTION
Updating the go version CI matrix as we bumped the go.mod's go directive to 1.20 and are relying on some 1.20 features for upcoming changes.