### PR TITLE
chore: add gomod ecosystems to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/config"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Similar to claircore, add the go.mod files in the project to dependabot.