### PR TITLE
chore: added s390x support

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -104,7 +104,7 @@ jobs:
     needs: [config, release-archive]
     strategy:
       matrix:
-        goarch: ['arm64', 'amd64', '386', 'ppc64le']
+        goarch: ['arm64', 'amd64', '386', 'ppc64le', 's390x']
         goos: ['linux', 'windows', 'darwin']
         exclude:
           - goos: darwin
@@ -117,6 +117,10 @@ jobs:
             goarch: 'ppc64le'
           - goos: darwin
             goarch: 'ppc64le'
+          - goos: windows
+            goarch: 's390x'
+          - goos: darwin
+            goarch: 's390x'
     env:
       GOOS: ${{matrix.goos}}
       GOARCH: ${{matrix.goarch}}
@@ -205,7 +209,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{ runner.temp }}/build
-          platforms: linux/amd64,linux/arm64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             quay.io/${{ needs.config.outputs.image_repo }}:${{ needs.config.outputs.image_tag }}
@@ -226,7 +230,7 @@ jobs:
     needs: [release-archive, release]
     strategy:
       matrix:
-        goarch: ['arm64', 'amd64', '386', 'ppc64le']
+        goarch: ['arm64', 'amd64', '386', 'ppc64le', 's390x']
         goos: ['linux', 'windows', 'darwin']
         exclude:
           - goos: darwin
@@ -239,6 +243,10 @@ jobs:
             goarch: ppc64le
           - goos: windows
             goarch: ppc64le
+          - goos: windows
+            goarch: 's390x'
+          - goos: darwin
+            goarch: 's390x'
     steps:
       - name: Fetch Archive
         uses: actions/download-artifact@v3

--- a/.github/workflows/nightly-ci.yaml
+++ b/.github/workflows/nightly-ci.yaml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         go: ${{ fromJSON(needs.config.outputs.go_versions) }}
         # Put non-amd64 platforms that should run tests here:
-        platform: ['linux/arm64', 'linux/ppc64le']
+        platform: ['linux/arm64', 'linux/ppc64le', 'linux/s390x']
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/go-cache


### PR DESCRIPTION
# Description
Added support for IBM/Z [s390x arch]

## Tests that have been done

- Built a Clair image with `make container-build`,  used that image in the quay docker-compose file, and was able to bring up the quay along with Clair using `make local-dev-up-with-clair`
- Successfully pushed the image into the **quay repository** in the local environment and verify the security vulnerability scan of the image in the repository with all possibilities. 
- Verified the changes done in the workflow file in GitHub Actions with the test branch and inside the lpar with Quay

## Changes that have been done

- Added s390x architecture in the required workflow files