### PR TITLE
chore: updated nightly for s390x support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -86,7 +86,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ${{ runner.temp }}/build
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/s390x
           push: ${{ steps.setup.outputs.push && steps.novelty.outputs.cache-hit != 'true' }}
           tags: |
             quay.io/${{ steps.setup.outputs.repo }}:${{ steps.setup.outputs.tag }}


### PR DESCRIPTION
# Description
Support for s390x in nightly build 

## Changes Made

- Added `linux/s390x` platform in **nightly.yml** file 