### PR TITLE
updater: Extend default updater time to 6 hours

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -10,7 +10,7 @@ const (
 	// during the indexing process. Its name is a historical accident.
 	DefaultScanLockRetry = 1
 	// DefaultMatcherPeriod is the default interval for running updaters.
-	DefaultMatcherPeriod = 30 * time.Minute
+	DefaultMatcherPeriod = 6 * time.Hour
 	// DefaultUpdateRetention is the number of updates per vulnerability
 	// database to retain.
 	DefaultUpdateRetention = 10


### PR DESCRIPTION
Given the expense of updating and the lack of value to such a high frequency this change extends the default update period from 30 mins to 6 hours.