### PR TITLE
chore: Only ask dependabot to care about direct dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
+    allow:
+     - dependency-type: "direct"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/config"
+    allow:
+     - dependency-type: "direct"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
There is some confusion in the github docs about what the default is for gomod given all the direct and indirect deps are explicitly defined. This change attempts to only include the direct deps and let the indirect deps be resolved by their projects.