### PR TITLE
chore: Add the osv updater to the local-dev config

### DIFF
--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -8,6 +8,7 @@ updaters:
     - debian
     - rhel
     - alpine
+    - osv
 auth:
   psk:
     key: 'c2VjcmV0'


### PR DESCRIPTION
As osv will be an integral part of a couple of ecosystems, it's be nice to have it enabled by default in the dev environment.