### PR TITLE
cicd: fix nightly connection strings

### DIFF
--- a/.github/workflows/config-ci.yml
+++ b/.github/workflows/config-ci.yml
@@ -57,24 +57,11 @@ jobs:
         with:
           go: ${{ matrix.go }}
           dir: ./config
-  test:
-    name: Test
+
+  tests:
     needs: ['config']
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go: ${{ fromJSON(needs.config.outputs.go_versions) }}
-    steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go }}
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/go-cache
-        with:
-          go: ${{ matrix.go }}
-      - run: cd config && go test ./...
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: workspace-${{matrix.go}}
-          path: ${{ github.workspace }}
+    uses: ./.github/workflows/tests.yml
+    with:
+      cd: config
+      package_expr: ./...
+      go_versions: ${{ needs.config.outputs.go_versions }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,8 +112,8 @@ jobs:
           docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl await_startup
           docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stomp
           docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins disable rabbitmq_management_agent rabbitmq_prometheus rabbitmq_web_dispatch
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_vhost '::1'
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p '::1' guest '.*' '.*' '.*'
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_vhost 'localhost'
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p 'localhost' guest '.*' '.*' '.*'
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,54 +77,8 @@ jobs:
           publish: false
 
   tests:
-    name: Integration Tests
     needs: ['config']
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: docker.io/library/postgres:11
-        env:
-          POSTGRES_DB: "clair"
-          POSTGRES_INITDB_ARGS: "--no-sync"
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: "clair"
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432
-      rabbitmq:
-        image: docker.io/library/rabbitmq:3
-        env:
-          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: '-rabbit vm_memory_high_watermark 0.85'
-        ports:
-          - 5672
-          - 61613
-
-    strategy:
-      matrix:
-        go: ${{ fromJSON(needs.config.outputs.go_versions) }}
-    steps:
-      - name: Configure RabbitMQ
-        run: |
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl await_startup
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stomp
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins disable rabbitmq_management_agent rabbitmq_prometheus rabbitmq_web_dispatch
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_vhost 'localhost'
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p 'localhost' guest '.*' '.*' '.*'
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ matrix.go }}
-      - run: go test -tags integration ./...
-        env:
-          POSTGRES_CONNECTION_STRING: "host=localhost port=${{ job.services.postgres.ports[5432] }} user=clair dbname=clair password=password sslmode=disable"
-          RABBITMQ_CONNECTION_STRING: "amqp://guest:guest@localhost:${{ job.services.rabbitmq.ports[5672] }}/"
-          STOMP_CONNECTION_STRING: "stomp://guest:guest@localhost:${{ job.services.rabbitmq.ports[61613] }}/"
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: workspace-${{matrix.go}}
-          path: ${{ github.workspace }}
+    uses: ./.github/workflows/tests.yml
+    with:
+      package_expr: ./...
+      go_versions: ${{ needs.config.outputs.go_versions }}

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -5,90 +5,51 @@ on:
   schedule:
     - cron: '30 4 * * *'
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      package_expr:
+        required: false
+        type: string
+        description: 'Package expression(s) passed to `go test`'
+      go_versions:
+        required: false
+        type: string
+        description: 'JSON array of go versions to use for tests'
+      platforms:
+        required: false
+        type: string
+        description: 'JSON array of platforms to test'
 
 jobs:
-  config:
+  defaults:
     runs-on: ubuntu-latest
     outputs:
+      package_expr: ${{ steps.config.outputs.package_expr }}
       go_versions: ${{ steps.config.outputs.go_versions }}
-    steps:
-      - id: config
-        run: |
-          echo 'go_versions=["1.20"]' >> "$GITHUB_OUTPUT"
-
-  tests:
-    name: Integration Tests
-    needs: ['config']
-    runs-on: ubuntu-latest
-    services:
-      # These will be used by a container on the same docker network, so no need to expose ports.
-      postgres:
-        image: docker.io/library/postgres:11
-        env:
-          POSTGRES_DB: "clair"
-          POSTGRES_INITDB_ARGS: "--no-sync"
-          POSTGRES_PASSWORD: password
-          POSTGRES_USER: "clair"
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      rabbitmq:
-        image: docker.io/library/rabbitmq:3
-        env:
-          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: '-rabbit vm_memory_high_watermark 0.85'
-
-    strategy:
-      matrix:
-        go: ${{ fromJSON(needs.config.outputs.go_versions) }}
-        # Put non-amd64 platforms that should run tests here:
-        platform: ['arm64', 'ppc64le', 's390x']
+      platforms: ${{ steps.config.outputs.platforms }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.go }}-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: linux/${{ matrix.platform }}
-      - name: Make directories on cache miss
-        run: mkdir -p "$(go env GOMODCACHE)" "$(go env GOCACHE)"
-        if: ${{ ! steps.cache.outputs.cache-hit }}
-      - name: Configure RabbitMQ
+      - id: config
         run: |
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl await_startup
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stomp
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins disable rabbitmq_management_agent rabbitmq_prometheus rabbitmq_web_dispatch
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_vhost '::1'
-          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p '::1' guest '.*' '.*' '.*'
-      - name: Run integration tests
-        run: >-
-          docker run
-          --rm
-          --network ${{ job.container.network }}
-          --platform linux/${{ matrix.platform }}
-          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod"
-          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build"
-          --mount "type=bind,src=$(pwd),dst=/build"
-          --env "POSTGRES_CONNECTION_STRING=host=postgres port=5432 user=clair dbname=clair sslmode=disable"
-          --env "RABBITMQ_CONNECTION_STRING=amqp://guest:guest@clair-rabbitmq:5672/"
-          --env "STOMP_CONNECTION_STRING=stomp://guest:guest@clair-activemq:61613/"
-          -w /build
-          quay.io/projectquay/golang:${{ matrix.go }}
-          go test
-          -tags integration
-          $(go list -m github.com/quay/clair{core,}/... | awk '{printf("%s/... ",$1)}')
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: workspace-${{matrix.go}}-${{matrix.platform}}
-          path: ${{ github.workspace }}
+          if test -n "${{ inputs.package_expr }}"; then
+            printf 'package_expr=%s\n' '${{ inputs.package_expr }}' >> "$GITHUB_OUTPUT"
+          else
+            printf 'package_expr=%s\n' "$(go list -m github.com/quay/clair{core,}/... | awk '{printf("%s/... ",$1)}')" >> "$GITHUB_OUTPUT"
+          fi
+          if test -n "${{ inputs.go_versions }}"; then
+            printf 'go_versions=%s\n' '${{ inputs.go_versions }}' >> "$GITHUB_OUTPUT"
+          else
+            printf 'go_versions=["1.20"]\n' >> "$GITHUB_OUTPUT"
+          fi
+          if test -n "${{ inputs.platforms }}"; then
+            printf 'platforms=%s\n' '${{ inputs.platforms }}' >> "$GITHUB_OUTPUT"
+          else
+            printf 'platforms=["linux/arm64", "linux/ppc64le", "linux/s390x"]\n' >> "$GITHUB_OUTPUT"
+          fi
+
+  tests:
+    needs: ['defaults']
+    uses: ./.github/workflows/tests.yml
+    with:
+      package_expr: ${{ needs.defaults.outputs.package_expr }}
+      go_versions: ${{ needs.defaults.outputs.go_versions }}
+      platforms: ${{ needs.defaults.outputs.platforms }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,127 @@
+---
+name: Tests
+
+on:
+  workflow_call:
+    inputs:
+      package_expr:
+        required: true
+        type: string
+        description: 'Package expression(s) passed to `go test`'
+      go_versions:
+        required: false
+        type: string
+        default: |
+          ["1.20"]
+        description: 'JSON array of go versions to use for tests'
+      platforms:
+        required: false
+        type: string
+        default: |
+          ["linux/amd64"]
+        description: 'JSON array of platforms to test'
+      cd:
+        required: false
+        type: string
+        default: ""
+        description: 'Change to this directory before running tests'
+
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ${{ fromJSON(inputs.go_versions) }}
+        platform: ${{ fromJSON(inputs.platforms) }}
+      fail-fast: false
+    services:
+      postgres:
+        image: docker.io/library/postgres:11
+        env:
+          POSTGRES_DB: "clair"
+          POSTGRES_INITDB_ARGS: "--no-sync"
+          POSTGRES_PASSWORD: password
+          POSTGRES_USER: "clair"
+        options: >-
+          --health-cmd "pg_isready -U clair"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432
+      rabbitmq:
+        image: docker.io/library/rabbitmq:3
+        env:
+          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: '-rabbit vm_memory_high_watermark 0.85'
+        ports:
+          - 5672
+          - 61613
+
+    steps:
+      - name: Configure RabbitMQ
+        run: |
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl await_startup
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_stomp
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins disable rabbitmq_management_agent rabbitmq_prometheus rabbitmq_web_dispatch
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_vhost 'rabbitmq'
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p 'rabbitmq' guest '.*' '.*' '.*'
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl add_user clair password
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p '/' clair '.*' '.*' '.*'
+          docker exec ${{ job.services.rabbitmq.id }} rabbitmqctl set_permissions -p 'rabbitmq' clair '.*' '.*' '.*'
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          cache: false  # Set up with a finer-grained cache key below.
+          go-version: ${{ matrix.go }}
+      - name: Check host
+        id: host
+        run:
+          printf 'platform=%s\n' "$(go env GOOS GOARCH | paste -s -d /)" >> "$GITHUB_OUTPUT"
+      - name: Cache go artifacts
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.go }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.platform }}-${{ matrix.go }}-
+      - name: Warm the cache on miss
+        # This is faster to run outside the container, but the module cache
+        # can't easily be shared between runs because GOOS and GOARCH influence
+        # the dependency graph.
+        if: ${{ ! steps.cache.outputs.cache-hit }}
+        run: |
+          go env -w $(echo ${{ matrix.platform}} | awk -F / '{print "GOOS="$1, "GOARCH="$2}')
+          go mod download
+          go build -v std
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        if: ${{ steps.host.outputs.platform != matrix.platform }}
+        with:
+          platforms: ${{ matrix.platform }}
+      - name: Tests
+        run: >-
+          docker run
+          --rm
+          --network ${{ job.container.network }}
+          --platform ${{ matrix.platform }}
+          --mount "type=bind,src=$(go env GOMODCACHE),dst=/go/pkg/mod"
+          --mount "type=bind,src=$(go env GOCACHE),dst=/root/.cache/go-build"
+          --mount "type=bind,src=$(pwd),dst=/build"
+          --env "POSTGRES_CONNECTION_STRING=host=postgres port=5432 user=clair dbname=clair password=password sslmode=disable"
+          --env "RABBITMQ_CONNECTION_STRING=amqp://clair:password@rabbitmq:5672/"
+          --env "STOMP_CONNECTION_STRING=stomp://clair:password@rabbitmq:61613/"
+          -w "/build/${{ inputs.cd }}"
+          "quay.io/projectquay/golang:${{ matrix.go }}"
+          go test
+          -tags integration
+          ${{ inputs.package_expr }}
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: workspace-${{matrix.go}}
+          path: ${{ github.workspace }}

--- a/notifier/amqp/deliverer_integration_test.go
+++ b/notifier/amqp/deliverer_integration_test.go
@@ -47,6 +47,7 @@ func TestDeliverer(t *testing.T) {
 	if uri == "" {
 		uri = defaultRabbitMQURI
 	}
+	t.Logf("using uri: %q", uri)
 
 	conf.URIs = []string{
 		// give a few bogus URIs to confirm failover mechanisms are working

--- a/notifier/amqp/directdeliverer_integration_test.go
+++ b/notifier/amqp/directdeliverer_integration_test.go
@@ -79,6 +79,7 @@ func TestDirectDeliverer(t *testing.T) {
 	if uri == "" {
 		uri = defaultRabbitMQURI
 	}
+	t.Logf("using uri: %q", uri)
 	conn, err := samqp.Dial(uri)
 	if err != nil {
 		t.Fatalf("failed to connect to broker at %v: %v", uri, err)

--- a/notifier/stomp/deliverer.go
+++ b/notifier/stomp/deliverer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"time"
 
 	gostomp "github.com/go-stomp/stomp/v3"
 	"github.com/google/uuid"
@@ -32,6 +33,10 @@ func New(conf *config.STOMP) (*Deliverer, error) {
 }
 
 func (d *Deliverer) load(cfg *config.STOMP) error {
+	d.fo.timeout = 30 * time.Second
+	// TODO(hank) Wire up the "host" and "timeout" config somehow -- probably
+	// just make the config URIs strings actual URIs and parse them out with
+	// query parameters.
 	var err error
 	if cfg.TLS != nil {
 		d.fo.tls, err = cfg.TLS.Config()
@@ -46,8 +51,8 @@ func (d *Deliverer) load(cfg *config.STOMP) error {
 		}
 	}
 
-	d.fo.uris = make([]string, len(cfg.URIs))
-	copy(d.fo.uris, cfg.URIs)
+	d.fo.addrs = make([]string, len(cfg.URIs))
+	copy(d.fo.addrs, cfg.URIs)
 	d.destination = cfg.Destination
 	d.rollup = cfg.Rollup
 	return nil


### PR DESCRIPTION
This fixes the nightly CI through some changes to the stomp package and moving the actual test job into a common workflow. The common workflow didn't exist or was new enough that I didn't know about it when the nightly CI was added.