### PR TITLE
chore: Add buildvsc=false flag when building

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           tar -xz -f ${{steps.download.outputs.download-path}}/clair-${{ needs.config.outputs.version }}.tar.gz --strip-components=1
           go build\
-            -trimpath -ldflags="-s -w"\
+            -trimpath -ldflags="-s -w" -buildvcs=false\
             -o "clairctl-${{matrix.goos}}-${{matrix.goarch}}"\
             ./cmd/clairctl
       - name: Upload


### PR DESCRIPTION
There appears to have been some change in the default behaviour between 1.18 and 1.20 where 1.20 will by default try to stamp the created binary with VSC information, for us the .git/ dir is no present so it's failing. See https://github.com/golang/go/issues/51748.