### PR TITLE
chore: Remove dogstatsd variable and references

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -103,8 +103,6 @@ metrics:
     name: ""
     prometheus:
         endpoint: null
-    dogstatsd:
-        url: ""
 ```
 
 Note: the above just lists every key for completeness. Copy-pasting the above as

--- a/introspection/server.go
+++ b/introspection/server.go
@@ -24,7 +24,6 @@ import (
 const (
 	Prom                     = "prometheus"
 	DefaultPromEndpoint      = "/metrics"
-	DogStatsD                = "dogstatsd"
 	Stdout                   = "stdout"
 	Jaeger                   = "jaeger"
 	HealthEndpoint           = "/healthz"


### PR DESCRIPTION
This came up as we have this field in the documentation but clairctl will error out if it's used when invoking any command.