### PR TITLE
docs: add dropins to prose documentation

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ x-anchors:
       clair-database:
         condition: service_healthy
     volumes:
-      - "./local-dev/clair/${CLAIR_CONFIG:-config.yaml}:/etc/clair.yaml:ro"
+      - "./local-dev/clair:/etc/clair:ro"
       - ".:/src"
     # Can't specify the config via environment because maps are not recursively
     # merged.
@@ -30,7 +30,7 @@ x-anchors:
       - run
       - .
       - -conf
-      - /etc/clair.yaml
+      - /etc/clair/${CLAIR_CONFIG:-config.yaml}
     restart: unless-stopped
     working_dir: /src/cmd/clair
 

--- a/local-dev/clair/config.yaml.d/.gitignore
+++ b/local-dev/clair/config.yaml.d/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/local-dev/clair/quay.yaml.d/.gitignore
+++ b/local-dev/clair/quay.yaml.d/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This change explains how to use the dropins and updates the local-dev config to do so.

Closes: #1783