### PR TITLE
chore: Update outdated docs and comment with default update period.

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -256,7 +256,7 @@ A time.ParseDuration parseable string.
 
 Determines how often updates for new security advisories will take place.
 
-Defaults to 30 minutes.
+Defaults to 6 hours.
 
 #### `$.matcher.disable_updaters`
 A boolean value.

--- a/config/matcher.go
+++ b/config/matcher.go
@@ -21,7 +21,7 @@ type Matcher struct {
 	IndexerAddr string `yaml:"indexer_addr" json:"indexer_addr"`
 	// Period controls how often updaters are run.
 	//
-	// The default is 30 minutes.
+	// The default is 6 hours.
 	Period Duration `yaml:"period,omitempty" json:"period,omitempty"`
 	// UpdateRetention controls the number of updates to retain between
 	// garbage collection periods.


### PR DESCRIPTION
This was missed when we changed the default updating period.