### PR TITLE
chore: better profiling support

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,17 +3,18 @@ version: "3.7"
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  postgres: &postgres-image docker.io/library/postgres:12
-  traefik: &traefik-image docker.io/library/traefik:v2.2
-  pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7
-  jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1.26
-  prom: &prom-image docker.io/prom/prometheus:v2.30.2
-  grafana: &grafana-image docker.io/grafana/grafana:8.0.3
-  quay: &quay-image quay.io/projectquay/quay:latest
-  redis: &redis-image docker.io/library/redis:6.2
   go: &go-image quay.io/projectquay/golang:1.20
-  skopeo: &skopeo-image quay.io/skopeo/stable:latest
+  grafana: &grafana-image docker.io/grafana/grafana:8.0.3
+  jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1.26
+  pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7
+  postgres: &postgres-image docker.io/library/postgres:12
+  prom: &prom-image docker.io/prom/prometheus:v2.30.2
+  pyroscope: &pyroscope-image docker.io/pyroscope/pyroscope:0.37.2
+  quay: &quay-image quay.io/projectquay/quay:latest
   rabbitmq: &rabbitmq-image docker.io/library/rabbitmq:3.11
+  redis: &redis-image docker.io/library/redis:6.2
+  skopeo: &skopeo-image quay.io/skopeo/stable:latest
+  traefik: &traefik-image docker.io/library/traefik:v2.2
   clair-service: &clair-service
     image: *go-image
     depends_on:
@@ -110,6 +111,18 @@ services:
       - '--web.external-url=http://localhost:8080/prom/'
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
+  pyroscope:
+    container_name: clair-pyroscope
+    profiles:
+      - debug
+    image: *pyroscope-image
+    volumes:
+      - ./local-dev/pyroscope:/etc/pyroscope/
+    command:
+      - server
+    environment:
+      PYROSCOPE_LOG_LEVEL: info
+      PYROSCOPE_WAIT_AFTER_STOP: 'true'
   grafana:
     container_name: clair-grafana
     profiles:
@@ -119,10 +132,12 @@ services:
     environment:
       GF_SERVER_ROOT_URL: /grafana
       GF_SERVER_SERVE_FROM_SUB_PATH: 'true'
+      GF_INSTALL_PLUGINS: 'pyroscope-datasource,pyroscope-panel'
     volumes:
       - ./local-dev/grafana/provisioning/:/etc/grafana/provisioning/
     depends_on:
       - prometheus
+      - pyroscope
 
   # Notifier services -- use profile 'notifier'
   notifier: &notifier

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/klauspost/compress v1.16.7
 	github.com/ldelossa/responserecorder v1.0.2-0.20210711162258-40bec93a9325
 	github.com/prometheus/client_golang v1.16.0
+	github.com/pyroscope-io/godeltaprof v0.1.1
 	github.com/quay/clair/config v1.3.0
 	github.com/quay/claircore v1.5.8
 	github.com/quay/zlog v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
+github.com/pyroscope-io/godeltaprof v0.1.1 h1:+Mmi+b9gR3s/qufuQSxOBjyXZR1fmvS/C12Q73PIPvw=
+github.com/pyroscope-io/godeltaprof v0.1.1/go.mod h1:psMITXp90+8pFenXkKIpNhrfmI9saQnPbba27VIaiQE=
 github.com/quay/alas v1.0.1 h1:MuFpGGXyZlDD7+F/hrnMZmzhS8P2bjRzX9DyGmyLA+0=
 github.com/quay/alas v1.0.1/go.mod h1:pseepSrG9pwry1joG7RO/RNRFJaWqiqx9qeoomeYwEk=
 github.com/quay/clair/config v1.3.0 h1:UqJIwvgHaWj6yTWrpVnYnlEIKcVYxJItlEF2EsCnw5s=

--- a/initialize/auto/auto.go
+++ b/initialize/auto/auto.go
@@ -13,6 +13,7 @@ var msgs = []func(context.Context){}
 func init() {
 	CPU()
 	Memory()
+	Profiling()
 }
 
 // PrintLogs uses zlog to report any messages queued up from the runs of

--- a/initialize/auto/profiling.go
+++ b/initialize/auto/profiling.go
@@ -1,0 +1,57 @@
+package auto
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/quay/zlog"
+)
+
+// Profiling enables block and mutex profiling.
+//
+// This function uses the magic environment variable "CLAIRDEBUG" to control the
+// values used. This escape hatch will go away in the future.
+func Profiling() {
+	// Catch contention at a granularity of 1 microsecond.
+	blockCur := 1000
+	// Catch 1/10 mutex contention events.
+	mutexCur := 10
+	fromEnv := false
+	if s, ok := os.LookupEnv(`CLAIRDEBUG`); ok {
+		var err error
+		for _, kv := range strings.Split(s, ",") {
+			k, v, ok := strings.Cut(kv, "=")
+			if !ok {
+				continue
+			}
+			switch k {
+			case "blockprofile":
+				fromEnv = true
+				blockCur, err = strconv.Atoi(v)
+			case "mutexprofile":
+				fromEnv = true
+				mutexCur, err = strconv.Atoi(v)
+			default:
+			}
+			if err != nil {
+				panic(err)
+			}
+		}
+	}
+
+	runtime.SetBlockProfileRate(blockCur)
+	mutexPrev := runtime.SetMutexProfileFraction(mutexCur)
+	msgs = append(msgs, func(ctx context.Context) {
+		zlog.Info(ctx).
+			Bool("from_env", fromEnv).
+			Dur("block_rate", time.Duration(blockCur)*time.Nanosecond).
+			Str("prev_mutex_frac", fmt.Sprintf("1/%d", mutexPrev)).
+			Str("cur_mutex_frac", fmt.Sprintf("1/%d", mutexCur)).
+			Msg("profiling rates configured")
+	})
+}

--- a/introspection/server.go
+++ b/introspection/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	deltapprof "github.com/pyroscope-io/godeltaprof/http/pprof"
 	"github.com/quay/clair/config"
 	"github.com/quay/zlog"
 	"go.opentelemetry.io/otel"
@@ -216,6 +217,9 @@ func (i *Server) withDiagnostics(_ context.Context) error {
 	i.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	i.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	i.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	i.HandleFunc("/debug/pprof/delta_heap", deltapprof.Heap)
+	i.HandleFunc("/debug/pprof/delta_block", deltapprof.Block)
+	i.HandleFunc("/debug/pprof/delta_mutex", deltapprof.Mutex)
 	return nil
 }
 

--- a/local-dev/grafana/provisioning/datasources/datasource.yml
+++ b/local-dev/grafana/provisioning/datasources/datasource.yml
@@ -1,3 +1,4 @@
+---
 # config file version
 apiVersion: 1
 
@@ -19,32 +20,15 @@ datasources:
   orgId: 1
   # <string> url
   url: http://clair-prometheus:9090/prom/
-  # <string> database password, if used
-  password:
-  # <string> database user, if used
-  user:
-  # <string> database name, if used
-  database:
-  # <bool> enable/disable basic auth
-  basicAuth: false
-  # <string> basic auth username, if used
-  basicAuthUser:
-  # <string> basic auth password, if used
-  basicAuthPassword:
-  # <bool> enable/disable with credentials headers
-  withCredentials:
   # <bool> mark as default datasource. Max one per org
   isDefault: true
-  # <map> fields that will be converted to json and stored in json_data
-  jsonData:
-     graphiteVersion: "1.1"
-     tlsAuth: false
-     tlsAuthWithCACert: false
-  # <string> json object of data that will be encrypted.
-  secureJsonData:
-    tlsCACert: "..."
-    tlsClientCert: "..."
-    tlsClientKey: "..."
   version: 1
-  # <bool> allow users to edit datasources from the UI.
+  editable: false
+- name: Pyroscope
+  type: pyroscope-datasource
+  access: proxy
+  orgId: 1
+  url: http://clair-pyroscope:4040/
+  jsonData:
+    path: http://clair-pyroscope:4040/
   editable: false

--- a/local-dev/pyroscope/server.yml
+++ b/local-dev/pyroscope/server.yml
@@ -1,0 +1,19 @@
+---
+analytics-opt-out: 'true'
+base-url: /pyroscope
+disable-pprof-endpoint: 'true'
+scrape-configs:
+- job-name: pyroscope
+  scrape-interval: 10s
+  scrape-timeout: 15s
+  enabled-profiles: [cpu, mem, goroutines, mutex, block]
+  use-delta-profiles: true
+  static-configs:
+  - application: clair-indexer
+    spy-name: gospy
+    targets:
+      - clair-indexer:8089
+  - application: clair-matcher
+    spy-name: gospy
+    targets:
+      - clair-matcher:8089

--- a/local-dev/traefik/config/pyroscope.yaml
+++ b/local-dev/traefik/config/pyroscope.yaml
@@ -1,0 +1,21 @@
+---
+http:
+  routers:
+    pyroscope:
+      entryPoints: [traefik]
+      rule: 'PathPrefix(`/pyroscope`)'
+      service: pyroscope
+      middlewares:
+      - pyroscope-stripprefix
+  middlewares:
+    pyroscope-stripprefix:
+      stripPrefix:
+        prefixes:
+        - /pyroscope
+  services:
+    pyroscope:
+      loadBalancer:
+        servers:
+        - url: "http://clair-pyroscope:4040/"
+        healthCheck:
+          path: /


### PR DESCRIPTION
These changes enable the "delta pprof" format supported by pyroscope, enables the mutex and blocking profiles by default, and adds pyroscope to the "debug" `docker-compose` profile.