### PR TITLE
cmd: version for old gits

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -57,8 +57,10 @@ jobs:
           go: ${{ needs.config.outputs.build_go_version }}
       - name: Create Release Archive
         run: |
-          go mod vendor
+          # Fix the checkout action overwriting the tag: (see https://github.com/actions/checkout/issues/882)
+          git fetch origin "+${GITHUB_REF}:${GITHUB_REF}"
           git archive --prefix '${{ needs.config.outputs.tar_prefix }}' -o clair.tar "${GITHUB_REF}"
+          go mod vendor
           tar -rf clair.tar --transform 's,^,${{ needs.config.outputs.tar_prefix }},' vendor
           gzip clair.tar
           mv clair.tar.gz clair-${{ needs.config.outputs.version }}.tar.gz

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -39,7 +39,7 @@ func init() {
 		"claircore_version": "",
 		"goversion":         runtime.Version(),
 		"modified":          "",
-		"revision":          "",
+		"revision":          revision,
 		"version":           "",
 	}
 	info, infoOK := debug.ReadBuildInfo()
@@ -76,7 +76,9 @@ func init() {
 	switch {
 	case Version != "":
 		// Had our version injected at build: do nothing.
-	case len(describe) > 0 && describe[0] != '$':
+	case len(describe) > 0 && describe[0] != '$' && !strings.HasPrefix(describe, "%(describe:"):
+		// Some git versions apparently don't know about the describe format
+		// verb, so need to check that it's not just "%(describe..."
 		Version = describe
 	case revision[0] == '$':
 		Version = `(random source build)`


### PR DESCRIPTION
This also adds a workaround for actions/checkout#882 where the new tag get blasted away with a new, lightweight tag for the duration of the run.