### PR TITLE
docs: add OTLP configuration to prose documentation

### DIFF
--- a/Documentation/reference_test.go
+++ b/Documentation/reference_test.go
@@ -53,6 +53,12 @@ func walk(ws *[]string, path string, t reflect.Type) error {
 	if t.Kind() == reflect.Struct {
 		for i, lim := 0, t.NumField(); i < lim; i++ {
 			f := t.Field(i)
+			if f.Anonymous {
+				if err := walk(ws, path, t.Field(i).Type); err != nil {
+					return err
+				}
+				continue
+			}
 			var n string
 			switch t := f.Tag.Get("json"); t {
 			case "-", "":

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/klauspost/compress v1.17.4
 	github.com/prometheus/client_golang v1.18.0
-	github.com/quay/clair/config v1.3.0
+	github.com/quay/clair/config v1.4.0
 	github.com/quay/claircore v1.5.20
 	github.com/quay/zlog v1.1.7
 	github.com/rabbitmq/amqp091-go v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -185,8 +185,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
-github.com/quay/clair/config v1.3.0 h1:UqJIwvgHaWj6yTWrpVnYnlEIKcVYxJItlEF2EsCnw5s=
-github.com/quay/clair/config v1.3.0/go.mod h1:XrxQFjAt0W+TUk5GkkSjNPxu1QgfycdRJr/+GVqUxBw=
+github.com/quay/clair/config v1.4.0 h1:jLveqMKEAZmyKjhGeWBkdQmCoGRbdUh4oTYVgaoFBQs=
+github.com/quay/clair/config v1.4.0/go.mod h1:c2/sfLoPdFRXpMtpD/UCi1gNm4uUFmdseqhqeQkKVbY=
 github.com/quay/claircore v1.5.20 h1:pR4lKRgdznk9wBqTXHSmYJPdYAPMRQTtSMzi6P3Vg9s=
 github.com/quay/claircore v1.5.20/go.mod h1:vz6VeOwzk2QLWGWAWrzjmPlUPkL9WwdeV3myHOwGwvA=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=


### PR DESCRIPTION
~~Needs a config module update and release.~~
This uses the latest release and brings the documentation into line with it.
The actual implementation for the things described is not done;
I can do that first if you'd rather.

See-also: #1870