### PR TITLE
contrib: simplify openshift/pr_check.sh

### DIFF
--- a/contrib/openshift/pr_check.sh
+++ b/contrib/openshift/pr_check.sh
@@ -1,33 +1,4 @@
-#!/bin/bash
-
+#!/bin/sh
 set -e
-# set_root roots this script to the clair repository
-set_root() {
-    # the repo directory we are trying to root at
-    repo="clair"
-    # the file system root which indicates search for repo dir failed
-    fs_root="/"
-
-    # root yourself at dir containing this script
-    p=$(realpath "$0")
-    cd $(dirname $p)
-
-    # use basename to walk paths backwards searching for clair
-    basename=$(basename `pwd`)
-    while [[ $basename != $repo && $basename != $fs_root ]]; do
-        cd $(dirname `pwd`)
-        basename=$(basename `pwd`)
-    done
-
-    # if basename is not clair, we couldn't find the repository root
-    if [[ $basename != $repo ]]; then
-        return 1
-    fi
-    return 0
-}
-if [ ! set_root ]; then
-    echo "could not set root to clair repository"
-    exit 1
-fi
-
-make container-build
+# If anything specific for the quay.io Clair instance needs to happen, add that here.
+exit 0


### PR DESCRIPTION
~~We should look into how this is exactly used; I think it's a requirement from the pipeline driving the quay.io instance. If there's nothing specific this needs to do for that environment, consider making this script a no-op.~~

We do the CI in our CI, so just make this a no-op.