### PR TITLE
admin: add command to update go packages with norm_version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/quay/clair/v4
 go 1.20
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/evanphx/json-patch/v5 v5.7.0
 	github.com/go-jose/go-jose/v3 v3.0.1
 	github.com/go-stomp/stomp/v3 v3.0.5
@@ -37,7 +38,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect


### PR DESCRIPTION
There are a number of Go packages in the `package` table that do not have the needed norm_version which is required for Go matching.

This looks up the potential Go packages from the `matcher.vuln` table, the difficultly doing this is entirely in the indexer DB is how to identify that these packages came from the gobin scanner. Trying to use the `package_scanartifact` (joining to the `scanners` table is prohibitively expensive as the query path is not accounted for in the index (i.e. we're always expecting the first clause to the the layer_id).