### PR TITLE
config: update minimum TLS version for server

### DIFF
--- a/config/tls.go
+++ b/config/tls.go
@@ -58,6 +58,7 @@ func (t *TLS) Config() (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to read x509 cert and key pair: %w", err)
 	}
 	cfg.Certificates = append(cfg.Certificates, cert)
+	cfg.MinVersion = tls.VersionTLS12
 
 	return &cfg, nil
 }


### PR DESCRIPTION
The config is used both when setting up the HTTP API and for the notifier's Deliverer.