### PR TITLE
httptransort: fix http metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/cli v24.0.0+incompatible // indirect
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v24.0.0+incompatible // indirect

--- a/httptransport/error.go
+++ b/httptransport/error.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"runtime"
 
 	"github.com/quay/zlog"
 )
@@ -42,7 +41,7 @@ func apiError(ctx context.Context, w http.ResponseWriter, code int, f string, v 
 	if disconnect {
 		// Exit immediately if there's no client to read the response, anyway.
 		w.WriteHeader(statusClientClosedRequest)
-		runtime.Goexit()
+		panic(http.ErrAbortHandler)
 	}
 
 	h := w.Header()
@@ -86,5 +85,5 @@ func apiError(ctx context.Context, w http.ResponseWriter, code int, f string, v 
 			Err(err).
 			Msg("unable to flush http response")
 	}
-	runtime.Goexit()
+	panic(http.ErrAbortHandler)
 }

--- a/httptransport/instrumentation.go
+++ b/httptransport/instrumentation.go
@@ -21,7 +21,12 @@ type wrapper struct {
 	InFlight        *prometheus.GaugeVec
 }
 
-func (m *wrapper) init(name string) {
+// InitRegisterer registers with the provided [prometheus.Registerer].
+//
+// The [*wrapper.init] method is short for
+//
+//	(*wrapper).initRegisterer(name, prometheus.DefaultRegisterer)
+func (m *wrapper) initRegisterer(name string, reg prometheus.Registerer) {
 	if m.RequestCount == nil {
 		m.RequestCount = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -77,7 +82,11 @@ func (m *wrapper) init(name string) {
 			[]string{"handler"},
 		)
 	}
-	prometheus.MustRegister(m.RequestCount, m.RequestSize, m.ResponseSize, m.RequestDuration, m.InFlight)
+	reg.MustRegister(m.RequestCount, m.RequestSize, m.ResponseSize, m.RequestDuration, m.InFlight)
+}
+
+func (m *wrapper) init(name string) {
+	m.initRegisterer(name, prometheus.DefaultRegisterer)
 }
 
 func (m *wrapper) wrap(tag string, h http.Handler) http.Handler {

--- a/httptransport/instrumentation_test.go
+++ b/httptransport/instrumentation_test.go
@@ -1,0 +1,67 @@
+package httptransport
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/quay/zlog"
+)
+
+func TestMetric(t *testing.T) {
+	ctx := zlog.Test(context.Background(), t)
+	want := strings.NewReader(`
+# HELP clair_http_test_request_total A total count of http requests for the given path
+# TYPE clair_http_test_request_total counter
+clair_http_test_request_total{code="200",handler="ok",method="get"} 1
+clair_http_test_request_total{code="504",handler="err",method="get"} 1
+clair_http_test_request_total{code="500",handler="err",method="get"} 1
+`)
+
+	reg := prometheus.NewRegistry()
+	var wr wrapper
+	wr.initRegisterer("test", reg)
+	m := http.NewServeMux()
+	m.Handle("/ok",
+		wr.wrapFunc("ok", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, "ok")
+		})))
+	m.Handle("/err",
+		wr.wrapFunc("err", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				panic(err)
+			}
+			if r.Form.Has("panic") {
+				panic("we're just normal men")
+			}
+			apiError(r.Context(), w, http.StatusGatewayTimeout, "expected error")
+		})))
+
+	srv := httptest.NewUnstartedServer(m)
+	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
+	srv.Start()
+	defer srv.Close()
+
+	c := srv.Client()
+	for _, p := range []string{"ok", "err", "err?panic=1"} {
+		u := srv.URL + "/" + p
+		t.Logf("making request: %q", u)
+		res, err := c.Get(u)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("got status: %q", res.Status)
+	}
+
+	if err := testutil.GatherAndCompare(reg, want, "clair_http_test_request_total"); err != nil {
+		t.Error(err)
+	} else {
+		t.Log("metrics OK")
+	}
+}

--- a/internal/httputil/responserecorder_test.go
+++ b/internal/httputil/responserecorder_test.go
@@ -7,21 +7,45 @@ import (
 )
 
 func TestResponseRecorder(t *testing.T) {
-	var status int
-	var length int64
+	t.Run("OK", func(t *testing.T) {
+		var status int
+		var length int64
 
-	rec := httptest.NewRecorder()
-	w := ResponseRecorder(&status, &length, rec)
+		rec := httptest.NewRecorder()
+		w := ResponseRecorder(&status, &length, rec)
 
-	sz := 512
-	if n, err := w.Write(make([]byte, sz)); err != nil || n != sz {
-		t.Errorf("unexpected Write return: (%v, %v)", n, err)
-	}
-	t.Logf("wrote %d bytes, status %q", length, http.StatusText(status))
-	if got, want := status, http.StatusOK; got != want {
-		t.Errorf("bad status; got: %d, want: %d", got, want)
-	}
-	if got, want := length, int64(sz); got != want {
-		t.Errorf("bad length; got: %d, want: %d", got, want)
-	}
+		sz := 512
+		if n, err := w.Write(make([]byte, sz)); err != nil || n != sz {
+			t.Errorf("unexpected Write return: (%v, %v)", n, err)
+		}
+		t.Logf("wrote %d bytes, status %q", length, http.StatusText(status))
+		if got, want := status, http.StatusOK; got != want {
+			t.Errorf("bad status; got: %d, want: %d", got, want)
+		}
+		if got, want := length, int64(sz); got != want {
+			t.Errorf("bad length; got: %d, want: %d", got, want)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		var status int
+		var length int64
+		sc := http.StatusInternalServerError
+
+		rec := httptest.NewRecorder()
+		w := ResponseRecorder(&status, &length, rec)
+
+		sz := 512
+		w.WriteHeader(sc)
+		if n, err := w.Write(make([]byte, sz)); err != nil || n != sz {
+			t.Errorf("unexpected Write return: (%v, %v)", n, err)
+		}
+		t.Logf("wrote %d bytes, status %q", length, http.StatusText(status))
+		if got, want := status, sc; got != want {
+			t.Errorf("bad status; got: %d, want: %d", got, want)
+		}
+		if got, want := length, int64(sz); got != want {
+			t.Errorf("bad length; got: %d, want: %d", got, want)
+		}
+	})
 }


### PR DESCRIPTION
The `runtime.Goexit` usage messes with the `prometheus` metrics, so this inserts a handler to catch unwinds using the documented `http.ErrAbortHandler`.