### PR TITLE
docker-compose: Deduplicate container names

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -199,6 +199,7 @@ services:
     image: *redis-image
   quay-notifier:
     <<: *notifier
+    container_name: clair-notifier-quay
     profiles:
       - quay
     environment:


### PR DESCRIPTION
On Docker Compose version 2.24.7 it fails with error: 
`"services.quay-notifier": container name "clair-notifier" is already in use by "services.notifier": invalid compose project`