### PR TITLE
cicd: don't upload workspace on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,8 +120,3 @@ jobs:
           go test
           -tags integration
           ${{ inputs.package_expr }}
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: workspace-${{matrix.go}}
-          path: ${{ github.workspace }}


### PR DESCRIPTION
This was largely unused, and the checkout action embeds short-lived tokens in the workspace which end up in the artifact.