### PR TITLE
cicd: add `/fast-forward` command

### DIFF
--- a/.github/workflows/check-fast-forward.yml
+++ b/.github/workflows/check-fast-forward.yml
@@ -1,0 +1,22 @@
+---
+name: Check Fast Forward
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  check-fast-forward:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      # We appear to need write permission for both pull-requests and
+      # issues in order to post a comment to a pull request.
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checking if fast forwarding is possible
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: false
+          comment: on-error

--- a/.github/workflows/fast-forward.yml
+++ b/.github/workflows/fast-forward.yml
@@ -1,0 +1,38 @@
+---
+name: Fast Forward
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review:
+    types: [submitted]
+jobs:
+  #debug:
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - run: |
+  #        jq . "${GITHUB_EVENT_PATH}"
+  fast-forward:
+    # Only run if the comment or approval contains the /fast-forward command,
+    # or if it was a dependabot PR.
+    if: >-
+      ${{
+      ( github.event.issue.pull_request && contains(github.event.comment.body, '/fast-forward')) ||
+      (
+        github.event.review && github.event.review.state == 'approved' && (
+          github.event.pull_request.user.url == 'https://api.github.com/users/dependabot%5Bbot%5D' ||
+          contains(github.event.review.body, '/fast-forward')
+        ))
+      }}
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Fast forwarding
+        uses: sequoia-pgp/fast-forward@v1
+        with:
+          merge: true
+          comment: on-error


### PR DESCRIPTION
This is used and beloved in `claircore`, and I keep forgetting it's not set up over here.