### PR TITLE
chore: update production manifest with new tmp dir

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -56,7 +56,7 @@ objects:
               command:
                 - sh
                 - '-c'
-                - rm -rf /tmp/sha* /tmp/fetch.* /tmp/rpmscanner.* && exec clair
+                - rm -rf /var/tmp/sha* /var/tmp/fetch.* /var/tmp/rpmscanner.* && exec clair
               env:
                 - name: CLAIR_CONF
                   value: '/etc/clair/config.yaml'
@@ -86,7 +86,7 @@ objects:
                 - name: clair-config
                   mountPath: /etc/clair
                 - name: indexer-layer-storage
-                  mountPath: /tmp
+                  mountPath: /var/tmp
 
   #
   # matcher deployment

--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -53,10 +53,7 @@ objects:
                 requests:
                   cpu: ${{INDEXER_CPU_REQS}}
                   memory: ${{INDEXER_MEM_REQS}}
-              command:
-                - sh
-                - '-c'
-                - rm -rf /var/tmp/sha* /var/tmp/fetch.* /var/tmp/rpmscanner.* && exec clair
+              command: [clair]
               env:
                 - name: CLAIR_CONF
                   value: '/etc/clair/config.yaml'


### PR DESCRIPTION
Since https://github.com/quay/clair/pull/2019 clair will now use /var/tmp instead of /tmp by default to store the manifest layers. This PR updates where the PVC is mounted in order to concide with the new default.