### PR TITLE
contrib: update build script to use podman

### DIFF
--- a/contrib/openshift/build_and_deploy.sh
+++ b/contrib/openshift/build_and_deploy.sh
@@ -3,17 +3,15 @@ set -exuo pipefail
 
 : "${QUAY_USER:?Missing QUAY_USER variable.}"
 : "${QUAY_TOKEN:?Missing QUAY_TOKEN variable.}"
-: "${REPOSITORY:=quay.io/app-sre}"
+: "${REGISTRY:=quay.io}"
+: "${REPOSITORY:=${REGISTRY}/app-sre}"
 : "${IMAGE:=${REPOSITORY}/clair}"
 GIT_HASH="$(git rev-parse --short=7 HEAD)"
 
 git archive HEAD |
-	docker build -t clair-service:latest -
+	podman build -t clair-service:latest -
 
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-service:latest" \
-    "docker://${IMAGE}:latest"
+podman login -u="${QUAY_USER}" -p="${QUAY_TOKEN}" "${REGISTRY}"
 
-skopeo copy --dest-creds "${QUAY_USER}:${QUAY_TOKEN}" \
-    "docker-daemon:clair-service:latest" \
-    "docker://${IMAGE}:${GIT_HASH}"
+podman push clair-service:latest docker://${IMAGE}:latest
+podman push clair-service:latest docker://${IMAGE}:${GIT_HASH}


### PR DESCRIPTION
There is an issue in the app-sre runners that mean skopeo is no longer working due to the docker version being update and requiring a minimum client version that the skopeo version in the runner doesn't have.