### PR TITLE
backport: chore: update go version for release

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.20']
+        image: ['quay.io/projectquay/golang:1.21']
     container:
       image: ${{ matrix.image }}
     outputs:


### PR DESCRIPTION
The go directive including the patch version is supported since go1.21, this change updates the image used to build the release artifacts to avoid failing due to an unsupported version.