### PR TITLE
chore: use the merge-multiple directive when downloading binaries

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -250,6 +250,7 @@ jobs:
         id: download
         with:
           pattern: clairctl-*
+          merge-multiple: true
       - name: Publish clairctl-${{matrix.goos}}-${{matrix.goarch}}
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
From the docs: When multiple artifacts are matched, this changes the behavior of the destination directories. If true, the downloaded artifacts will be in the same directory specified by path. If false, the downloaded artifacts will be extracted into individual named directories within the specified path.

So essentially, the artifacts were being downloaded into individual dirs and hence the release failure.

https://github.com/quay/clair/actions/runs/8912316665