### PR TITLE
Dockerfile: add `GOTOOLCHAIN`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG GOTOOLCHAIN=local
 ARG GO_VERSION=1.21
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build


### PR DESCRIPTION
Changes in go1.21 means the build recipe here was doing the wrong thing. This should restore the expected behavior of using the toolchain present in the container.