### PR TITLE
chore: allow podman to relabel files objects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ FROM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \
 	--mount=type=cache,target=/go/pkg/mod \
-	--mount=type=bind,source=go.mod,target=go.mod \
-	--mount=type=bind,source=go.sum,target=go.sum \
+	--mount=type=bind,source=go.mod,target=go.mod,z \
+	--mount=type=bind,source=go.sum,target=go.sum,z \
 	go mod download
 COPY . .
 ARG CLAIR_VERSION=""


### PR DESCRIPTION
Currently there is an issue when attempting to bind mount certain files during the container build process. This appears to be a combination of podman and SELinux conspiring to lead to the cryptic error: 
```
go: no modules specified (see 'go help mod download')
```
Which logically leads to something going wrong mounting the go.mod / go.sum files.

https://ci.ext.devshift.net/job/quay-clair-gh-build-main/460/console