### PR TITLE
change clairctl default logout

### DIFF
--- a/cmd/clairctl/main.go
+++ b/cmd/clairctl/main.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	logout = zerolog.New(&zerolog.ConsoleWriter{
-		Out:        os.Stderr,
+		Out:        os.Stdout,
 		TimeFormat: time.RFC3339,
 	}).Level(zerolog.InfoLevel).
 		With().


### PR DESCRIPTION
When using k8s remotecommand to execute the command clairctl import-updaters in the Clair container, data cannot be read from stdout. The default output of the source code for clairctl is os.Stderr. Should it be changed to os.Stdout?