### PR TITLE
contrib: correct position of startupProbe spec

### DIFF
--- a/contrib/openshift/manifests/manifests.yaml
+++ b/contrib/openshift/manifests/manifests.yaml
@@ -77,8 +77,8 @@ objects:
                 httpGet:
                   path: ${{READY_PATH}}
                   port: ${{HEALTH_PORT}}
-                  failureThreshold: 400
-                  periodSeconds: 10
+                failureThreshold: 400
+                periodSeconds: 10
               volumeMounts:
                 - name: clair-config
                   mountPath: /etc/clair
@@ -146,8 +146,8 @@ objects:
                 httpGet:
                   path: ${{READY_PATH}}
                   port: ${{HEALTH_PORT}}
-                  failureThreshold: 400
-                  periodSeconds: 10
+                failureThreshold: 400
+                periodSeconds: 10
               volumeMounts:
                 - name: clair-config
                   mountPath: /etc/clair
@@ -212,8 +212,8 @@ objects:
                 httpGet:
                   path: ${{READY_PATH}}
                   port: ${{HEALTH_PORT}}
-                  failureThreshold: 400
-                  periodSeconds: 10
+                failureThreshold: 400
+                periodSeconds: 10
               volumeMounts:
                 - name: clair-config
                   mountPath: /etc/clair


### PR DESCRIPTION
This has been the same since the creation on the service and has only just been noticed now that we have a slightly more involved migration to get through.