### PR TITLE
chore: update go version to 1.22

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.21']
+        image: ['quay.io/projectquay/golang:1.22']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,5 +1,5 @@
 module github.com/quay/clair/config
 
-go 1.21.9
+go 1.22
 
 require github.com/google/go-cmp v0.6.0

--- a/contrib/openshift/build_and_deploy.sh
+++ b/contrib/openshift/build_and_deploy.sh
@@ -26,6 +26,7 @@ done
 GIT_HASH="$(git rev-parse --short=7 HEAD)"
 tags=("${IMAGE}:latest" "${IMAGE}:${GIT_HASH}")
 trap 'rm -rf clair-v*.{tar*,oci} ' ERR
+export GOTOOLCHAIN=auto # have any local invocations of go use the correct version magically
 
 patch_source() {
 	in=$1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.7"
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  go: &go-image quay.io/projectquay/golang:1.21
+  go: &go-image quay.io/projectquay/golang:1.22
   grafana: &grafana-image docker.io/grafana/grafana:8.0.3
   jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1.26
   pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.21.9
+go 1.22
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Update all go.mod files to use 1.22, and update the peripherals (release workflow, docker files).