### PR TITLE
otel-collector: add otel-collector config and Makefile

### DIFF
--- a/contrib/openshift/otel-collector/.gitignore
+++ b/contrib/openshift/otel-collector/.gitignore
@@ -1,0 +1,2 @@
+_build
+otelcollector

--- a/contrib/openshift/otel-collector/Makefile
+++ b/contrib/openshift/otel-collector/Makefile
@@ -1,0 +1,7 @@
+otelcollector: builder.yaml
+	go run go.opentelemetry.io/collector/cmd/builder@v0.109.0 --config=builder.yaml
+	cp _build/otelcollector .
+
+.PHONY: clean
+clean:
+	rm -rf _build otelcollector

--- a/contrib/openshift/otel-collector/builder.yaml
+++ b/contrib/openshift/otel-collector/builder.yaml
@@ -1,0 +1,24 @@
+dist:
+  name: otelcollector
+  description: Clair-flavored OpenTelemetry Collector binary
+  output_path: ./_build
+  version: '0.1.0'
+exporters:
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsxrayexporter v0.109.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter v0.109.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.109.0
+- gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sentryexporter v0.109.0
+- gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.109.0
+
+receivers:
+- gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.109.0
+
+processors:
+- gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.109.0
+
+providers:
+- gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.15.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.15.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v0.109.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.109.0
+- gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.109.0


### PR DESCRIPTION
This adds a config for building an `opentelemetry-collector` binary and a small `Makefile` to document its use.