### PR TITLE
chore: update go version to specific patch

### DIFF
--- a/config/go.mod
+++ b/config/go.mod
@@ -1,5 +1,5 @@
 module github.com/quay/clair/config
 
-go 1.22
+go 1.22.0
 
 require github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
go mod tidy will modify the go directive to the minimum needed for the project's dependencies (including the patch). This causes the CI to fail.