### PR TITLE
chore: update references to rhel updater to rhel-vex updater

### DIFF
--- a/config/updaters.go
+++ b/config/updaters.go
@@ -27,7 +27,7 @@ type Updaters struct {
 	// "osv"
 	// "photon"
 	// "rhcc"
-	// "rhel"
+	// "rhel-vex"
 	// "suse"
 	// "ubuntu"
 	Sets []string `yaml:"sets,omitempty" json:"sets,omitempty"`

--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -6,7 +6,7 @@ updaters:
   sets:
     - ubuntu
     - debian
-    - rhel
+    - rhel-vex
     - alpine
     - osv
 auth:


### PR DESCRIPTION
Claircore no longer has the 'rhel' updater and in its place sits the rhel-vex updater, this change updates clair to reference the new updater.