### PR TITLE
chore: group some dependencies to avoid excessive PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,36 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     allow:
-     - dependency-type: "direct"
+      - dependency-type: "direct"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      otel:
+        patterns:
+          - "go.opentelemetry.io/otel/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
   - package-ecosystem: "gomod"
     directory: "/config"
     allow:
-     - dependency-type: "direct"
+      - dependency-type: "direct"
     schedule:
       interval: "weekly"
+    reviewers:
+      - "quay/babysitters"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      otel:
+        patterns:
+          - "go.opentelemetry.io/otel/*"
+      golang-x:
+        patterns:
+          - "golang.org/x/*"


### PR DESCRIPTION
Taken from the Claircore dependabot.yaml file, this change groups the golang.org/x/* and go.opentelemetry.io/otel/*" dependency PRs.