### PR TITLE
docker: remove version line from docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: "3.7"
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:


### PR DESCRIPTION
This option is depricated/obsolete https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete.

Closes https://github.com/quay/clair/issues/2176