### PR TITLE
ci: nightly flakes

### DIFF
--- a/notifier/amqp/doc.go
+++ b/notifier/amqp/doc.go
@@ -1,0 +1,5 @@
+// Package amqp implements a [Deliverer] over the AMQP protocol.
+//
+// Deprecated: This package will be removed in a future version. Users should
+// write a webhook to AMQP transducer.
+package amqp

--- a/notifier/stomp/deliverer.go
+++ b/notifier/stomp/deliverer.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Deliverer is a STOMP deliverer which publishes a notifier.Callback to the
-// the broker.
+// broker.
 type Deliverer struct {
 	callback    *url.URL
 	destination string

--- a/notifier/stomp/doc.go
+++ b/notifier/stomp/doc.go
@@ -1,0 +1,5 @@
+// Package stomp implements a [Deliverer] over the STOMP protocol.
+//
+// Deprecated: This package will be removed in a future version. Users should
+// write a webhook to STOMP transducer.
+package stomp

--- a/notifier/stomp/integration_test.go
+++ b/notifier/stomp/integration_test.go
@@ -88,7 +88,12 @@ func consumer(ctx context.Context, t *testing.T, dial string, opt []func(*stomp.
 					t.Logf("*stomp.Conn.Unsubscribe panicked (see https://github.com/go-stomp/stomp/pull/139):\n%v", r)
 				}
 			}()
-			if err := sub.Unsubscribe(); err != nil {
+			err := sub.Unsubscribe()
+			switch {
+			case err == nil:
+			case errors.Is(err, stomp.ErrUnsubscribeReceiptTimeout):
+				t.Logf("unsubscribing: %v (ignoring: can happen on slow hosts, doesn't affect correctness)", err)
+			default:
 				t.Errorf("unsubscribing: %v", err)
 			}
 		}()


### PR DESCRIPTION
This is the error that trips up slow, weird architectures in our testing. It shouldn't affect anything's correctness (it's harness code) to catch it and not error out.