### PR TITLE
Revert "cicd: exclude darwin/arm64"

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -111,8 +111,6 @@ jobs:
         exclude:
           - goos: darwin
             goarch: '386'
-          - goos: darwin
-            goarch: arm64
           - goos: windows
             goarch: '386'
           - goos: windows
@@ -232,8 +230,6 @@ jobs:
         exclude:
           - goos: darwin
             goarch: '386'
-          - goos: darwin
-            goarch: arm64
           - goos: windows
             goarch: '386'
           - goos: darwin


### PR DESCRIPTION
This reverts commit 96909bf3bfca47c8ea1ce0b53d9d5b7e9897b55e.