### PR TITLE
 chore: update local-dev tracing configs to fix errors

### DIFF
--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -52,11 +52,7 @@ trace:
 #  probability: 1
   otlp:
     http:
-      endpoint: "clair-jaeger:6831"
+      endpoint: "clair-jaeger:4318"
       insecure: true
-  jaeger:
-    agent:
-      endpoint: "clair-jaeger:6831"
-    service_name: "clair"
 metrics:
   name: "prometheus"

--- a/local-dev/traefik/traefik.yaml
+++ b/local-dev/traefik/traefik.yaml
@@ -20,7 +20,7 @@ metrics:
   prometheus:
     addServicesLabels: true
 tracing:
-  openTelemetry:
-    address: clair-jaeger:4318
-    insecure: true
+  otlp:
+    http:
+      endpoint: http://clair-jaeger:4318/v1/traces
 accessLog: {}


### PR DESCRIPTION
Both clair-* containers and the traefik container were complaining about invalid configuations.

https://doc.traefik.io/traefik/observability/tracing/opentelemetry/