### PR TITLE
chore: update minimum go version to 1.23

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.22']
+        image: ['quay.io/projectquay/golang:1.23']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  go: &go-image quay.io/projectquay/golang:1.22
+  go: &go-image quay.io/projectquay/golang:1.23
   grafana: &grafana-image docker.io/grafana/grafana:10.3.1
   jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1
   pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.22.7
+go 1.23.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
Dependencies will now require go1.23 and according to Go's support go1.22 is no longer supported (because of the release of 1.24).