### PR TITLE
ci: Allow go test to access un-vendored dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -182,6 +182,7 @@ jobs:
           STOMP_CONNECTION_STRING: "stomp://clair:password@localhost:${{ job.services.rabbitmq.ports[61613] }}/"
           GOARCH: ${{ matrix.platform }}
           CGO_ENABLED: '0'
+          GOFLAGS: '-mod=mod'
         working-directory: ./${{ inputs.cd }}
         run: |
           # Go Tests


### PR DESCRIPTION
There is a situation where claircore has a dependency but because the code using the dependency isn't accessible in clair, it is not added to the go.mod/go.sum files. As this CI job not only tests clair it also tests claircore (and others), these missing dependencies cause the tests to fail. This flag allows go test to modify the go.sum file to add any missing dependencies.