### PR TITLE
notifier: increase default durations to be more reasonable

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -17,13 +17,9 @@ const (
 	// DefaultNotifierPollInterval is the default (and minimum) interval for the
 	// notifier's change poll interval. The notifier will poll the database for
 	// updated vulnerability databases at this rate.
-	DefaultNotifierPollInterval = 5 * time.Second
+	DefaultNotifierPollInterval = 6 * time.Hour
 	// DefaultNotifierDeliveryInterval is the default (and minimum) interval for
 	// the notifier's delivery interval. The notifier will attempt to deliver
 	// outstanding notifications at this rate.
-	DefaultNotifierDeliveryInterval = 5 * time.Second
+	DefaultNotifierDeliveryInterval = 1 * time.Hour
 )
-
-// BUG(hank) The DefaultNotifierPollInterval is absurdly low.
-
-// BUG(hank) The DefaultNotifierDeliveryInterval is absurdly low.

--- a/config/notifier.go
+++ b/config/notifier.go
@@ -40,15 +40,15 @@ type Notifier struct {
 	// A time.ParseDuration parsable string
 	//
 	// The frequency at which the notifier will query at Matcher for Update Operations.
-	// If a value smaller then 1 second is provided it will be replaced with the
-	// default 5 second poll interval.
+	// If a value smaller then 1 minute is provided it will be replaced with the
+	// default 6 hour poll interval as the default updater period is 6 hours.
 	PollInterval Duration `yaml:"poll_interval,omitempty" json:"poll_interval,omitempty"`
 	// A time.ParseDuration parsable string
 	//
 	// The frequency at which the notifier attempt delivery of created or previously failed
 	// notifications
-	// If a value smaller then 1 second is provided it will be replaced with the
-	// default 5 second delivery interval.
+	// If a value smaller then 1 minute is provided it will be replaced with the
+	// default 1 hour delivery interval.
 	DeliveryInterval Duration `yaml:"delivery_interval,omitempty" json:"delivery_interval,omitempty"`
 	// DisableSummary disables summarizing vulnerabilities per-manifest.
 	//
@@ -70,10 +70,10 @@ func (n *Notifier) validate(mode Mode) ([]Warning, error) {
 	if mode != ComboMode && mode != NotifierMode {
 		return nil, nil
 	}
-	if n.PollInterval < Duration(1*time.Second) {
+	if n.PollInterval < Duration(1*time.Minute) {
 		n.PollInterval = Duration(DefaultNotifierPollInterval)
 	}
-	if n.DeliveryInterval < Duration(1*time.Second) {
+	if n.DeliveryInterval < Duration(1*time.Minute) {
 		n.DeliveryInterval = Duration(DefaultNotifierDeliveryInterval)
 	}
 	switch mode {

--- a/local-dev/clair/config.yaml
+++ b/local-dev/clair/config.yaml
@@ -31,7 +31,7 @@ notifier:
   matcher_addr: http://clair-matcher:6060/
   connstring: host=clair-database user=clair dbname=notifier sslmode=disable
   migrations: true
-  delivery_interval: 30s
+  delivery_interval: 1m
   poll_interval: 1m
   webhook:
     target: "http://webhook-target/"


### PR DESCRIPTION
This change increases the notifier.poll_interval and the notifier.delivery_interval default durations to be less aggressive. It doesn't make sense for them to so low given the default matcher.period is 6 hours and nothing can change in the vulnerability data within that period.