### PR TITLE
chore: upgrade config module to v1.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/klauspost/compress v1.18.0
 	github.com/prometheus/client_golang v1.22.0
-	github.com/quay/clair/config v1.4.1
+	github.com/quay/clair/config v1.4.2
 	github.com/quay/claircore v1.5.36
 	github.com/quay/zlog v1.1.8
 	github.com/rabbitmq/amqp091-go v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/quay/clair/config v1.4.1 h1:4z/7aaeWrSOdhG+sPJmXEOEUJ/4JqenKj5oXRG5Q1k0=
-github.com/quay/clair/config v1.4.1/go.mod h1:GHMVGl7WIq2WB+mFrFkUFHGphDojOPEdoAhjpcTTgLg=
+github.com/quay/clair/config v1.4.2 h1:6bB/3+3DJGO7pfDA4gC7WlXxA4G+Oz4X3h2nug8E4Ww=
+github.com/quay/clair/config v1.4.2/go.mod h1:MyYm2qGw55+I598zEpwpFFmBq1jp5NLIhBhCigv6tRM=
 github.com/quay/claircore v1.5.36 h1:FO+0QMvzvrN2y91DIXCMdpFuWUeTTKK6i023vLYdOns=
 github.com/quay/claircore v1.5.36/go.mod h1:3yfkeVOtu1BW54yyNrC4hWKxQQkPRbcH6AvQVInBeIU=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=


### PR DESCRIPTION
There are some notifier config changes that should make it into main via the new version of config.