### PR TITLE
chore: remove reviews from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
       - dependency-type: "direct"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -28,8 +26,6 @@ updates:
       - dependency-type: "direct"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "quay/babysitters"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
This option is being removed in favor of looking at the CODEOWNERS file, https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/