### PR TITLE
all: fix formatted print calls

### DIFF
--- a/httptransport/matcher_v1.go
+++ b/httptransport/matcher_v1.go
@@ -114,7 +114,7 @@ func (h *MatcherV1) vulnerabilityReport(w http.ResponseWriter, r *http.Request) 
 
 	initd, err := h.srv.Initialized(ctx)
 	if err != nil {
-		apiError(ctx, w, http.StatusInternalServerError, err.Error())
+		apiError(ctx, w, http.StatusInternalServerError, "initialization error: %v", err)
 	}
 	if !initd {
 		w.WriteHeader(http.StatusAccepted)

--- a/notifier/postgres/e2e_test.go
+++ b/notifier/postgres/e2e_test.go
@@ -264,7 +264,7 @@ func (e *e2e) SetDeliveryFailed(ctx context.Context) func(*testing.T) {
 			t.Errorf("got: %d, want: %d", got, want)
 		}
 		if got := ids[0]; !cmp.Equal(got, want) {
-			t.Errorf(cmp.Diff(got, want))
+			t.Error(cmp.Diff(got, want))
 		}
 	}
 }
@@ -296,7 +296,7 @@ func (e *e2e) SetDeleted(ctx context.Context) func(*testing.T) {
 			t.Errorf("got: %d, want: %d", got, want)
 		}
 		if got := ids[0]; !cmp.Equal(got, want) {
-			t.Errorf(cmp.Diff(got, want))
+			t.Error(cmp.Diff(got, want))
 		}
 	}
 }


### PR DESCRIPTION
The test suite started failing on this vet check. Not sure why, but these should be fixed anyway.