### PR TITLE
chore: update go references to go1.24

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.23']
+        image: ['quay.io/projectquay/golang:1.24']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  go: &go-image quay.io/projectquay/golang:1.23
+  go: &go-image quay.io/projectquay/golang:1.24
   grafana: &grafana-image docker.io/grafana/grafana:10.3.1
   jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1
   pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7


### PR DESCRIPTION
With go1.25 being released we're switching to 1.24 as oldstable and 1.25 as stable, as such we should stop referencing 1.23 as it is no longer going to be part of the CI.