### PR TITLE
enrichments: disable enrichers if config option is set

### DIFF
--- a/Documentation/reference/config.md
+++ b/Documentation/reference/config.md
@@ -303,6 +303,11 @@ A boolean value.
 
 Whether to run background updates or not.
 
+#### `$.matcher.disable_enrichment`
+A boolean value.
+
+Whether to enrich the returned vulnerabilities or not.
+
 #### `$.matcher.update_retention`
 An integer value limiting the number of update operations kept in the database.
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/klauspost/compress v1.18.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/quay/clair/config v1.4.2
+	github.com/quay/clair/config v1.4.3
 	github.com/quay/claircore v1.5.42
 	github.com/quay/zlog v1.1.9
 	github.com/rabbitmq/amqp091-go v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -198,8 +198,8 @@ github.com/prometheus/otlptranslator v0.0.2 h1:+1CdeLVrRQ6Psmhnobldo0kTp96Rj80DR
 github.com/prometheus/otlptranslator v0.0.2/go.mod h1:P8AwMgdD7XEr6QRUJ2QWLpiAZTgTE2UYgjlu3svompI=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
-github.com/quay/clair/config v1.4.2 h1:6bB/3+3DJGO7pfDA4gC7WlXxA4G+Oz4X3h2nug8E4Ww=
-github.com/quay/clair/config v1.4.2/go.mod h1:MyYm2qGw55+I598zEpwpFFmBq1jp5NLIhBhCigv6tRM=
+github.com/quay/clair/config v1.4.3 h1:ZrvqKJrAR2Noyl1XcMl9oOucdMJsdjGzqQqT/rzxb50=
+github.com/quay/clair/config v1.4.3/go.mod h1:MyYm2qGw55+I598zEpwpFFmBq1jp5NLIhBhCigv6tRM=
 github.com/quay/claircore v1.5.42 h1:EC+JtIXkMhXB84I0k+n14Cmxxcry/8XbgeEIQ2iekzs=
 github.com/quay/claircore v1.5.42/go.mod h1:NtQyQECDSpU7WqyjKknD35cchdfbtpQ9qp7Paekdma0=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=

--- a/initialize/services.go
+++ b/initialize/services.go
@@ -276,6 +276,12 @@ func localMatcher(ctx context.Context, cfg *config.Config) (matcher.Service, err
 		return nil, mkErr(err)
 	}
 
+	ers := []driver.Enricher{}
+	if !cfg.Matcher.DisableEnrichment {
+		zlog.Info(ctx).Msg("enrichment enabled")
+		ers = append(ers, &cvss.Enricher{})
+	}
+
 	s, err := libvuln.New(ctx, &libvuln.Options{
 		Store:           store,
 		Locker:          locker,
@@ -286,9 +292,7 @@ func localMatcher(ctx context.Context, cfg *config.Config) (matcher.Service, err
 		MatcherNames:    cfg.Matchers.Names,
 		MatcherConfigs:  matcherConfigs,
 		Client:          cl,
-		Enrichers: []driver.Enricher{
-			&cvss.Enricher{},
-		},
+		Enrichers:       ers,
 	})
 	if err != nil {
 		return nil, mkErr(err)


### PR DESCRIPTION
This change allows an operator to set the matcher.DisableEnrichment config option to stop the application from enriching vulnerability data.