### PR TITLE
go.mod: Update Go version to 1.24.9 for CVE-2025-47907

### DIFF
--- a/contrib/cmd/quaybackstop/Dockerfile
+++ b/contrib/cmd/quaybackstop/Dockerfile
@@ -20,7 +20,7 @@
 #     --local context=. --local dockerfile=contrib/cmd/quaybackstop
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.24.9
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
PROJQUAY-9434: Upgraded Go from 1.24.0 to 1.24.9 to address security vulnerability CVE-2025-47907. Updated both main go.mod and config/go.mod files.