### PR TITLE
Fix typo in api_internal.md

### DIFF
--- a/Documentation/concepts/api_internal.md
+++ b/Documentation/concepts/api_internal.md
@@ -11,7 +11,7 @@ Further information and usage is an effort left to the reader.
 ## Updates Diffs
 
 The `update_diff/` endpoint exposes the api for diffing two update operations. 
-This is used by the notifier to determine the added and removed vulnerabilities on security databsae update.
+This is used by the notifier to determine the added and removed vulnerabilities on security database update.
 
 ## Update Operation
 


### PR DESCRIPTION
Corrected a typo in the description of the update_diff endpoint.