### PR TITLE
clair: enable h2c

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -115,6 +115,12 @@ func serveAPI(ctx context.Context, cfg *config.Config) func() error {
 			BaseContext: func(_ net.Listener) context.Context {
 				return context.WithoutCancel(ctx)
 			},
+			Protocols: func() *http.Protocols {
+				var p http.Protocols
+				p.SetHTTP1(true)
+				p.SetUnencryptedHTTP2(true)
+				return &p
+			}(),
 		}
 		srv.Handler, err = httptransport.New(ctx, cfg, srvs.Indexer, srvs.Matcher, srvs.Notifier)
 		if err != nil {
@@ -131,6 +137,7 @@ func serveAPI(ctx context.Context, cfg *config.Config) func() error {
 			}
 			cfg.NextProtos = []string{"h2"}
 			srv.TLSConfig = cfg
+			srv.Protocols.SetHTTP2(true)
 			l = tls.NewListener(l, cfg)
 		}
 		health.Ready()

--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -116,6 +116,12 @@ func serveAPI(ctx context.Context, cfg *config.Config) func() error {
 			BaseContext: func(_ net.Listener) context.Context {
 				return context.WithoutCancel(ctx)
 			},
+			Protocols: func() *http.Protocols {
+				var p http.Protocols
+				p.SetHTTP1(true)
+				p.SetUnencryptedHTTP2(true)
+				return &p
+			}(),
 		}
 		srv.Handler, err = httptransport.New(ctx, cfg, srvs.Indexer, srvs.Matcher, srvs.Notifier)
 		if err != nil {
@@ -132,6 +138,7 @@ func serveAPI(ctx context.Context, cfg *config.Config) func() error {
 			}
 			cfg.NextProtos = []string{"h2"}
 			srv.TLSConfig = cfg
+			srv.Protocols.SetHTTP2(true)
 			l = tls.NewListener(l, cfg)
 		}
 		health.Ready()


### PR DESCRIPTION
Go1.24 added stdlib support for `h2c` without upgrade, so this is "just" enabling that.