### PR TITLE
chore: update go version to 1.24.9 (excluding config) (PROJQUAY-9434)

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.22']
+        image: ['quay.io/projectquay/golang:1.24']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.24
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ version: "3.7"
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  go: &go-image quay.io/projectquay/golang:1.22
+  go: &go-image quay.io/projectquay/golang:1.24
   grafana: &grafana-image docker.io/grafana/grafana:8.0.3
   jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1.26
   pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair/v4
 
-go 1.22.0
+go 1.24.9
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/httptransport/matcher_v1.go
+++ b/httptransport/matcher_v1.go
@@ -114,7 +114,7 @@ func (h *MatcherV1) vulnerabilityReport(w http.ResponseWriter, r *http.Request) 
 
 	initd, err := h.srv.Initialized(ctx)
 	if err != nil {
-		apiError(ctx, w, http.StatusInternalServerError, err.Error())
+		apiError(ctx, w, http.StatusInternalServerError, "%v", err.Error())
 	}
 	if !initd {
 		w.WriteHeader(http.StatusAccepted)

--- a/notifier/postgres/e2e_test.go
+++ b/notifier/postgres/e2e_test.go
@@ -264,7 +264,7 @@ func (e *e2e) SetDeliveryFailed(ctx context.Context) func(*testing.T) {
 			t.Errorf("got: %d, want: %d", got, want)
 		}
 		if got := ids[0]; !cmp.Equal(got, want) {
-			t.Errorf(cmp.Diff(got, want))
+			t.Errorf("%s", cmp.Diff(got, want))
 		}
 	}
 }
@@ -296,7 +296,7 @@ func (e *e2e) SetDeleted(ctx context.Context) func(*testing.T) {
 			t.Errorf("got: %d, want: %d", got, want)
 		}
 		if got := ids[0]; !cmp.Equal(got, want) {
-			t.Errorf(cmp.Diff(got, want))
+			t.Errorf("%s", cmp.Diff(got, want))
 		}
 	}
 }


### PR DESCRIPTION
Update go version to 1.24.9 (excluding config)
Fix for CVE-2025-47907 