### PR TITLE
feature: update logging

### DIFF
--- a/cmd/clairctl/config.go
+++ b/cmd/clairctl/config.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 
-	"github.com/quay/zlog"
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
 )
@@ -46,12 +46,12 @@ Again:
 		j.SetIndent("", "\t")
 		enc = j
 	case "yaml":
-		zlog.Warn(ctx).Msg("some values do no round-trip the yaml encoder correctly -- make sure to consult the documentation")
+		slog.WarnContext(ctx, "some values do no round-trip the yaml encoder correctly -- make sure to consult the documentation")
 		y := yaml.NewEncoder(os.Stdout)
 		y.SetIndent(2)
 		enc = y
 	default:
-		zlog.Info(ctx).Str("out", v).Msg("unknown 'out' kind, using 'json'")
+		slog.InfoContext(ctx, "unknown 'out' kind, using 'json'", "out", v)
 		c.Set("out", "json")
 		goto Again
 	}

--- a/cmd/clairctl/report.go
+++ b/cmd/clairctl/report.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
 	"github.com/urfave/cli/v2"
 	"golang.org/x/sync/errgroup"
 
@@ -79,20 +79,20 @@ func (o *outFmt) String() string {
 func (o *outFmt) Formatter(ctx context.Context, w io.WriteCloser) Formatter {
 	switch o.fmt {
 	case "", "text":
-		zlog.Debug(ctx).Msg("using text output")
+		slog.DebugContext(ctx, "using text output")
 		r, err := newTextFormatter(w)
 		if err != nil {
 			panic(err)
 		}
 		return r
 	case "json":
-		zlog.Debug(ctx).Msg("using json output")
+		slog.DebugContext(ctx, "using json output")
 		return &jsonFormatter{
 			enc: codec.GetEncoder(w),
 			c:   w,
 		}
 	case "xml":
-		zlog.Debug(ctx).Msg("using xml output")
+		slog.DebugContext(ctx, "using xml output")
 		return &xmlFormatter{
 			enc: xml.NewEncoder(w),
 			c:   w,
@@ -169,20 +169,16 @@ func reportAction(c *cli.Context) error {
 
 	for i := 0; i < args.Len(); i++ {
 		ref := args.Get(i)
-		ctx := zlog.ContextWithValues(ctx, "ref", ref)
-		zlog.Debug(ctx).
-			Msg("fetching")
+		log := slog.With("ref", ref)
+		log.DebugContext(ctx, "fetching")
 		eg.Go(func() error {
 			d, err := resolveRef(ctx, ref)
 			if err != nil {
-				zlog.Debug(ctx).
-					Err(err).
-					Send()
+				log.DebugContext(ctx, "unable to resolve ref", "reason", err)
 				return err
 			}
-			ctx := zlog.ContextWithValues(ctx, "digest", d.String())
-			zlog.Debug(ctx).
-				Msg("found manifest")
+			log := log.With("digest", d)
+			log.DebugContext(ctx, "found manifest")
 
 			// This bit is tricky:
 			//
@@ -196,29 +192,25 @@ func reportAction(c *cli.Context) error {
 			if ct > 20 {
 				return errors.New("too many attempts")
 			}
-			zlog.Debug(ctx).
-				Int("attempt", ct).
-				Msg("requesting index_report")
+			log.DebugContext(ctx, "requesting index_report",
+				"attempt", ct)
 			err = cc.IndexReport(ctx, d, m)
 			switch {
 			case err == nil:
 			case errors.Is(err, errNeedManifest):
 				if c.Bool("novel") {
-					zlog.Debug(ctx).
-						Msg("manifest already known, skipping upload")
+					log.DebugContext(ctx, "manifest already known, skipping upload")
 					break
 				}
 				fallthrough
 			case errors.Is(err, errNovelManifest):
 				m, err = Inspect(ctx, ref)
 				if err != nil {
-					zlog.Debug(ctx).
-						Err(err).
-						Msg("manifest error")
+					log.DebugContext(ctx, "manifest error",
+						"reason", err)
 					if keepgoing {
-						zlog.Info(ctx).
-							Err(err).
-							Msg("ignoring manifest error")
+						log.InfoContext(ctx, "ignoring manifest error",
+							"reason", err)
 						return nil
 					}
 					return err
@@ -226,9 +218,8 @@ func reportAction(c *cli.Context) error {
 				ct++
 				goto Again
 			default:
-				zlog.Debug(ctx).
-					Err(err).
-					Msg("index error")
+				log.DebugContext(ctx, "index error",
+					"reason", err)
 				if keepgoing {
 					return nil
 				}

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,11 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/quay/clair/config v1.4.3
 	github.com/quay/claircore v1.5.50
-	github.com/quay/zlog v1.1.9
+	github.com/quay/claircore/toolkit v1.4.0
+	github.com/quay/zlog/v2 v2.1.0
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rogpeppe/go-internal v1.14.1
-	github.com/rs/zerolog v1.34.0
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/ugorji/go/codec v1.2.14
 	github.com/urfave/cli/v2 v2.27.7
@@ -72,7 +72,6 @@ require (
 	github.com/knqyf263/go-deb-version v0.0.0-20190517075300-09fca494f03d // indirect
 	github.com/knqyf263/go-rpm-version v0.0.0-20170716094938-74609b86c936 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -84,7 +83,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
-	github.com/quay/claircore/toolkit v1.4.0 // indirect
 	github.com/quay/claircore/updater/driver v1.0.0 // indirect
 	github.com/quay/goval-parser v0.8.8 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/containerd/stargz-snapshotter/estargz v0.18.1 h1:cy2/lpgBXDA3cDKSyEfNOFMA/c10O1axL69EU7iirO8=
 github.com/containerd/stargz-snapshotter/estargz v0.18.1/go.mod h1:ALIEqa7B6oVDsrF37GkGN20SuvG/pIMm7FwP7ZmRb0Q=
-github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
 github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -40,7 +39,6 @@ github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stomp/stomp/v3 v3.1.5 h1:Pikz1OSusmSKUm5mRKYfXQZaDatfZ+EnBBA1JJ2xENQ=
 github.com/go-stomp/stomp/v3 v3.1.5/go.mod h1:ztzZej6T2W4Y6FlD+Tb5n7HQP3/O5UNQiuC169pIp10=
-github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -103,10 +101,6 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.2 h1:AqzbZs4ZoCBp+GtejcpCpcxM3zlSMx29dXbUSeVtJb8=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-sqlite3 v1.10.0 h1:jbhqpg7tQe4SupckyijYiy0mJJ/pRyHvXf7JdWK860o=
@@ -148,8 +142,8 @@ github.com/quay/claircore/updater/driver v1.0.0 h1:w7dAUjO3GBK6RjNyTZ2Kwz0l/Wuic
 github.com/quay/claircore/updater/driver v1.0.0/go.mod h1:My5aY1wBpgxcWaHQZ0VoPmmj/EzuH7fq4ntzJbos4OI=
 github.com/quay/goval-parser v0.8.8 h1:Uf+f9iF2GIR5GPUY2pGoa9il2+4cdES44ZlM0mWm4cA=
 github.com/quay/goval-parser v0.8.8/go.mod h1:Y0NTNfPYOC7yxsYKzJOrscTWUPq1+QbtHw4XpPXWPMc=
-github.com/quay/zlog v1.1.9 h1:O9/vfCUcGGUs0ukqQ77xPCJBPqpZBJ00jt7IUMsRco8=
-github.com/quay/zlog v1.1.9/go.mod h1:O7OCW9oe7igrswhjKlyOvTo2+6FPsV7L0/owWEX6JHE=
+github.com/quay/zlog/v2 v2.1.0 h1:U55jQXHqB3NyWEt0iPESzIOjQho3PG4HWfXj9j40vEs=
+github.com/quay/zlog/v2 v2.1.0/go.mod h1:+FmBwcNIbXOKRWfaIqHGPF+g9WW4hn+OiomLN7eC/dM=
 github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
 github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319 h1:ukjThsA2ou7AmovpwtMVkNQSuoN/v5U16+JomTz3c7o=
@@ -158,9 +152,6 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
-github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
-github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
@@ -271,11 +262,9 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/httptransport/auth_test.go
+++ b/httptransport/auth_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/quay/clair/config"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/internal/httputil"
 )
@@ -33,7 +33,7 @@ var defaultClaims = jwt.Claims{
 
 func (tc *authTestcase) Run(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		// Generate a nonce to return upon request.
 		b := make([]byte, 16)
 		if _, err := io.ReadFull(rand.Reader, b); err != nil {
@@ -170,7 +170,7 @@ func TestAuth(t *testing.T) {
 		},
 	}
 
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	for _, tc := range tt {
 		t.Run(tc.Name, tc.Run(ctx))
 	}

--- a/httptransport/common.go
+++ b/httptransport/common.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 
 	"github.com/quay/claircore"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/toolkit/log"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -141,7 +141,7 @@ func withRequestID(r *http.Request) *http.Request {
 		defer idPool.Put(rng)
 		tid = fmt.Sprintf("%016x", rng.Uint64())
 	}
-	ctx = zlog.ContextWithValues(ctx, key, tid)
+	ctx = log.With(ctx, key, tid)
 	ctx = pprof.WithLabels(ctx, pprof.Labels(profile, tid))
 	return r.WithContext(ctx)
 }

--- a/httptransport/concurrentlimit_test.go
+++ b/httptransport/concurrentlimit_test.go
@@ -9,15 +9,14 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/quay/clair/v4/internal/httputil"
 )
 
 func TestConcurrentRequests(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	sem := semaphore.NewWeighted(1)
 	// Ret controls when the http server returns.
 	// Ready is strobed once the first request is seen.

--- a/httptransport/discoveryhandler.go
+++ b/httptransport/discoveryhandler.go
@@ -7,12 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"slices"
 	"sync"
 	"time"
 
-	"github.com/quay/zlog"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/quay/clair/v4/internal/httputil"
@@ -98,18 +98,16 @@ func DiscoveryHandler(_ context.Context, prefix string, topt otelhttp.Option) ht
 			case errors.Is(err, http.ErrNotSupported):
 				// Skip
 			default:
-				zlog.Warn(ctx).
-					Err(err).
-					Msg("unable to flush http response")
+				slog.WarnContext(ctx, "unable to flush http response",
+					"reason", err)
 			}
-			zlog.Info(ctx).
-				Str("remote_addr", r.RemoteAddr).
-				Str("method", r.Method).
-				Str("request_uri", r.RequestURI).
-				Int("status", status).
-				Int64("written", length).
-				Dur("duration", time.Since(start)).
-				Msg("handled HTTP request")
+			slog.InfoContext(ctx, "handled HTTP request",
+				"remote_addr", r.RemoteAddr,
+				"method", r.Method,
+				"request_uri", r.RequestURI,
+				"status", status,
+				"written", length,
+				"duration", time.Since(start))
 		}()
 		inner.ServeHTTP(w, r)
 	})

--- a/httptransport/discoveryhandler_test.go
+++ b/httptransport/discoveryhandler_test.go
@@ -1,21 +1,20 @@
 package httptransport
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestDiscovery(t *testing.T) {
 	t.Run("Endpoint", func(t *testing.T) {
-		ctx := zlog.Test(context.Background(), t)
+		ctx := test.Logging(t)
 		h := DiscoveryHandler(ctx, OpenAPIV1Path, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 
 		r := httptest.NewRecorder()
@@ -49,7 +48,7 @@ func TestDiscovery(t *testing.T) {
 	})
 
 	t.Run("Failure", func(t *testing.T) {
-		ctx := zlog.Test(context.Background(), t)
+		ctx := test.Logging(t)
 		h := DiscoveryHandler(ctx, OpenAPIV1Path, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 
 		r := httptest.NewRecorder()

--- a/httptransport/error_test.go
+++ b/httptransport/error_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/internal/httputil"
 )
@@ -24,7 +24,7 @@ func TestClientDisconnect(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() { close(handlerDone) }()
 		w = httputil.ResponseRecorder(&status, nil, w)
-		ctx := zlog.Test(r.Context(), t) // The error handler emits logs.
+		ctx := test.Logging(t, r.Context()) // The error handler emits logs.
 		close(reqStart)
 		<-ctx.Done()
 		apiError(ctx, w, http.StatusOK, "hello from the handler")

--- a/httptransport/indexer_v1_test.go
+++ b/httptransport/indexer_v1_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/pkg/tarfs"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
@@ -22,8 +22,7 @@ import (
 )
 
 func TestIndexReportBadLayer(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 
 	i := &indexer.Mock{
 		State_: func(ctx context.Context) (string, error) {
@@ -42,7 +41,7 @@ func TestIndexReportBadLayer(t *testing.T) {
 	srv.Start()
 	defer srv.Close()
 	t.Run("Report", func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const path = `/index_report`
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",` +
@@ -65,8 +64,7 @@ func TestIndexReportBadLayer(t *testing.T) {
 }
 
 func TestIndexerV1(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 
 	digest := claircore.MustParseDigest("sha256:0000000000000000000000000000000000000000000000000000000000000000")
 	i := &indexer.Mock{
@@ -105,7 +103,7 @@ func TestIndexerV1(t *testing.T) {
 	defer srv.Close()
 
 	t.Run("State", func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const path = `/index_state`
 		t.Run("GET", func(t *testing.T) {
 			req, err := httputil.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
@@ -124,7 +122,7 @@ func TestIndexerV1(t *testing.T) {
 		})
 	})
 	t.Run("Report", func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const path = `/index_report`
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"hash":"sha256:0000000000000000000000000000000000000000000000000000000000000000",` +
@@ -185,7 +183,7 @@ func TestIndexerV1(t *testing.T) {
 		})
 	})
 	t.Run("ReportOne", func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const path = `/index_report/sha256:0000000000000000000000000000000000000000000000000000000000000000`
 		t.Run("DELETE", func(t *testing.T) {
 			req, err := httputil.NewRequestWithContext(ctx, http.MethodDelete, srv.URL+path, nil)
@@ -219,7 +217,7 @@ func TestIndexerV1(t *testing.T) {
 		})
 	})
 	t.Run("AffectedManifests", func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const path = `/internal/affected_manifest/`
 		t.Run("POST", func(t *testing.T) {
 			const body = `{"vulnerabilities":[]}`

--- a/httptransport/instrumentation.go
+++ b/httptransport/instrumentation.go
@@ -2,11 +2,11 @@ package httptransport
 
 import (
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/quay/zlog"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
@@ -119,9 +119,8 @@ func catchAbort(h http.Handler) http.Handler {
 				return
 			}
 			w.WriteHeader(http.StatusInternalServerError)
-			zlog.Warn(r.Context()).
-				Interface("panic", rec).
-				Msg("handler panicked; please file a bug")
+			slog.WarnContext(r.Context(), "handler panicked; please file a bug",
+				"panic", rec)
 		}()
 		h.ServeHTTP(w, r)
 	})

--- a/httptransport/instrumentation_test.go
+++ b/httptransport/instrumentation_test.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 )
 
 func TestMetric(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	want := strings.NewReader(`
 # HELP clair_http_test_request_total A total count of http requests for the given path
 # TYPE clair_http_test_request_total counter

--- a/httptransport/matcher_v1_test.go
+++ b/httptransport/matcher_v1_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
@@ -33,8 +33,7 @@ func TestUpdateDiffHandler(t *testing.T) {
 // TestUpdateDiffMatcher confirms the UpdateDiff handler provides
 // the correct status codes when a matcher returns an error or success
 func testUpdateDiffMatcher(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 	mOK := &matcher.Mock{
 		UpdateDiff_: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) {
@@ -117,8 +116,7 @@ func testUpdateDiffMatcher(t *testing.T) {
 // TestUpdateDiffHandlerParams confirms the UpdateDiff handler
 // returns correct status codes given a set or url parameters
 func testUpdateDiffHandlerParams(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 	table := []struct {
 		name       string
@@ -196,8 +194,7 @@ func testUpdateDiffHandlerParams(t *testing.T) {
 // TestUpdateDiffHandlerMethods confirms the UpdateDiffHandler responds correctly
 // to unaccepted HTTP methods.
 func testUpdateDiffHandlerMethods(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 	mOK := &matcher.Mock{
 		UpdateDiff_: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) {
@@ -251,8 +248,7 @@ func TestUpdateOperationHandler(t *testing.T) {
 // testUpdateOperationHandlerErrors confirms the handler perfoms the correct
 // actions when a matcher.Differ is failing.
 func testUpdateOperationHandlerErrors(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 
 	id := uuid.New().String()
@@ -308,8 +304,7 @@ func testUpdateOperationHandlerErrors(t *testing.T) {
 // testUpdateOperationHandlerMethods confirms the handler only responds
 // to the desired methods.
 func testUpdateOperationHandlerMethods(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 	h := NewMatcherV1(ctx, "", &matcher.Mock{}, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
@@ -344,8 +339,7 @@ func testUpdateOperationHandlerMethods(t *testing.T) {
 // testUpdateOperationHandlerGet confirms the handler performs the correct
 // actions on GET.
 func testUpdateOperationHandlerGet(t *testing.T) {
-	ctx := context.Background()
-	ctx = zlog.Test(ctx, t)
+	ctx := test.Logging(t)
 	t.Parallel()
 
 	id := uuid.New()

--- a/httptransport/notification_v1_test.go
+++ b/httptransport/notification_v1_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/trace"
 
@@ -22,7 +22,7 @@ import (
 
 // TestUpdateOperationHandler is a parallel harness for testing a UpdateOperation handler.
 func TestNotificationsHandler(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	t.Run("Methods", testNotificationsHandlerMethods(ctx))
 	t.Run("Get", testNotificationHandlerGet(ctx))
 	t.Run("GetParams", testNotificationHandlerGetParams(ctx))
@@ -36,7 +36,7 @@ var notifierTraceOpt = otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()
 func testNotificationHandlerDelete(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		noteID := uuid.New()
 
 		nm := &service.Mock{
@@ -71,7 +71,7 @@ func testNotificationHandlerDelete(ctx context.Context) func(*testing.T) {
 func testNotificationHandlerGet(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		var (
 			nextID     = uuid.New()
 			inPageWant = notifier.Page{
@@ -130,7 +130,7 @@ func testNotificationHandlerGet(ctx context.Context) func(*testing.T) {
 func testNotificationHandlerGetParams(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		const (
 			pageSizeParam = "100"
 			pageParam     = "10"
@@ -195,7 +195,7 @@ func testNotificationHandlerGetParams(ctx context.Context) func(*testing.T) {
 func testNotificationsHandlerMethods(ctx context.Context) func(*testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		h, err := NewNotificationV1(ctx, `/notifier/api/v1/`, &service.Mock{}, notifierTraceOpt)
 		if err != nil {
 			t.Error(err)

--- a/httptransport/server_test.go
+++ b/httptransport/server_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/quay/clair/config"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"
@@ -44,7 +44,7 @@ func TestUpdateEndpoints(t *testing.T) {
 			return nil, nil
 		},
 	}
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	h, err := New(ctx, &config.Config{Mode: config.MatcherMode}, i, m, nil)
 	if err != nil {
 		t.Error(err)

--- a/initialize/auto/auto.go
+++ b/initialize/auto/auto.go
@@ -6,8 +6,7 @@ package auto
 
 import (
 	"context"
-
-	"github.com/quay/zlog"
+	"log/slog"
 )
 
 var msgs = []func(context.Context){}
@@ -18,7 +17,7 @@ func init() {
 	Profiling()
 }
 
-// PrintLogs uses zlog to report any messages queued up from the runs of
+// PrintLogs uses slog to report any messages queued up from the runs of
 // functions since the last call to PrintLogs.
 func PrintLogs(ctx context.Context) {
 	for _, f := range msgs {
@@ -30,13 +29,13 @@ func PrintLogs(ctx context.Context) {
 // DebugLog is a helper to log static strings.
 func debugLog(m string) {
 	msgs = append(msgs, func(ctx context.Context) {
-		zlog.Debug(ctx).Msg(m)
+		slog.DebugContext(ctx, m)
 	})
 }
 
 // InfoLog is a helper to log static strings.
 func infoLog(m string) {
 	msgs = append(msgs, func(ctx context.Context) {
-		zlog.Info(ctx).Msg(m)
+		slog.InfoContext(ctx, m)
 	})
 }

--- a/initialize/auto/cpu_linux.go
+++ b/initialize/auto/cpu_linux.go
@@ -6,12 +6,11 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"runtime"
 	"strconv"
-
-	"github.com/quay/zlog"
 )
 
 // CPU guesses a good number for GOMAXPROCS based on information gleaned from
@@ -25,18 +24,16 @@ func CPU() {
 	gmp, err := cgLookup(root)
 	if err != nil {
 		msgs = append(msgs, func(ctx context.Context) {
-			zlog.Error(ctx).
-				Err(err).
-				Msg("unable to guess GOMAXPROCS value")
+			slog.ErrorContext(ctx, "unable to guess GOMAXPROCS value",
+				"reason", err)
 		})
 		return
 	}
 	prev := runtime.GOMAXPROCS(gmp)
 	msgs = append(msgs, func(ctx context.Context) {
-		zlog.Info(ctx).
-			Int("cur", gmp).
-			Int("prev", prev).
-			Msg("set GOMAXPROCS value")
+		slog.InfoContext(ctx, "set GOMAXPROCS value",
+			"cur", gmp,
+			"prev", prev)
 	})
 }
 

--- a/initialize/auto/cpu_linux_test.go
+++ b/initialize/auto/cpu_linux_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 )
 
 var (
@@ -41,7 +41,7 @@ type cgTestcase struct {
 
 func (tc cgTestcase) Run(ctx context.Context, t *testing.T) {
 	t.Run(tc.Name, func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t)
 		gmp, err := cgLookup(tc.In)
 		if err != tc.Err {
 			t.Error(err)
@@ -54,7 +54,7 @@ func (tc cgTestcase) Run(ctx context.Context, t *testing.T) {
 }
 
 func TestCPUDetection(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	t.Run("V1", func(t *testing.T) {
 		tt := []cgTestcase{
 			{
@@ -94,7 +94,7 @@ func TestCPUDetection(t *testing.T) {
 				Want: 1,
 			},
 		}
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		for _, tc := range tt {
 			tc.Run(ctx, t)
 		}
@@ -122,7 +122,7 @@ func TestCPUDetection(t *testing.T) {
 				Want: 4,
 			},
 		}
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		for _, tc := range tt {
 			tc.Run(ctx, t)
 		}

--- a/initialize/auto/memory_linux.go
+++ b/initialize/auto/memory_linux.go
@@ -6,12 +6,11 @@ import (
 	"context"
 	"errors"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path"
 	"runtime/debug"
 	"strconv"
-
-	"github.com/quay/zlog"
 )
 
 // Memory sets the runtime's memory limit based on information gleaned from the
@@ -30,9 +29,8 @@ func Memory() {
 	switch {
 	case err != nil:
 		msgs = append(msgs, func(ctx context.Context) {
-			zlog.Error(ctx).
-				Err(err).
-				Msg("unable to guess memory limit")
+			slog.ErrorContext(ctx, "unable to guess memory limit",
+				"reason", err)
 		})
 		return
 	case lim == doNothing:
@@ -46,10 +44,9 @@ func Memory() {
 	tgt := lim - (lim / 20)
 	debug.SetMemoryLimit(tgt)
 	msgs = append(msgs, func(ctx context.Context) {
-		zlog.Info(ctx).
-			Int64("lim", lim).
-			Int64("target", tgt).
-			Msg("set memory limit")
+		slog.InfoContext(ctx, "set memory limit",
+			"lim", lim,
+			"target", tgt)
 	})
 }
 

--- a/initialize/auto/memory_linux_test.go
+++ b/initialize/auto/memory_linux_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"testing/fstest"
 
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 )
 
 type memTestcase struct {
@@ -22,7 +22,7 @@ func (tc memTestcase) Run(ctx context.Context, t *testing.T) {
 	t.Helper()
 	t.Run(tc.Name, func(t *testing.T) {
 		t.Helper()
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t)
 		lim, err := memLookup(tc.In)
 		if err != tc.Err {
 			t.Error(err)
@@ -43,7 +43,7 @@ func TestMemoryDetection(t *testing.T) {
 		lim   = &fstest.MapFile{Data: []byte(fmt.Sprintln(limInt))}
 		noLim = &fstest.MapFile{Data: []byte(fmt.Sprintln(noLimInt))}
 	)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	t.Run("V1", func(t *testing.T) {
 		tt := []memTestcase{
 			{
@@ -71,7 +71,7 @@ func TestMemoryDetection(t *testing.T) {
 				Want: limInt,
 			},
 		}
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		for _, tc := range tt {
 			tc.Run(ctx, t)
 		}
@@ -102,7 +102,7 @@ func TestMemoryDetection(t *testing.T) {
 				Want: limInt,
 			},
 		}
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		for _, tc := range tt {
 			tc.Run(ctx, t)
 		}

--- a/initialize/auto/profiling.go
+++ b/initialize/auto/profiling.go
@@ -3,13 +3,12 @@ package auto
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/quay/zlog"
 )
 
 // Profiling enables block and mutex profiling.
@@ -47,11 +46,10 @@ func Profiling() {
 	runtime.SetBlockProfileRate(blockCur)
 	mutexPrev := runtime.SetMutexProfileFraction(mutexCur)
 	msgs = append(msgs, func(ctx context.Context) {
-		zlog.Info(ctx).
-			Bool("from_env", fromEnv).
-			Dur("block_rate", time.Duration(blockCur)*time.Nanosecond).
-			Str("prev_mutex_frac", fmt.Sprintf("1/%d", mutexPrev)).
-			Str("cur_mutex_frac", fmt.Sprintf("1/%d", mutexCur)).
-			Msg("profiling rates configured")
+		slog.InfoContext(ctx, "profiling rates configured",
+			"from_env", fromEnv,
+			"block_rate", time.Duration(blockCur)*time.Nanosecond,
+			"prev_mutex_frac", fmt.Sprintf("1/%d", mutexPrev),
+			"cur_mutex_frac", fmt.Sprintf("1/%d", mutexCur))
 	})
 }

--- a/initialize/logging.go
+++ b/initialize/logging.go
@@ -3,42 +3,37 @@ package initialize
 import (
 	"context"
 	"fmt"
-	"os"
+	"log/slog"
 
 	"github.com/quay/clair/config"
-	"github.com/quay/zlog"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
+
+	"github.com/quay/clair/v4/internal/logging"
 )
 
-// Logging configures zlog according to the provided configuration.
+// Logging configures slog according to the provided configuration.
 func Logging(ctx context.Context, cfg *config.Config) error {
-	l := zerolog.New(os.Stderr)
 	switch cfg.LogLevel {
 	case config.DebugColorLog:
-		// set logger to use ConsoleWriter for colorized output
-		l = l.Level(zerolog.DebugLevel).
-			Output(zerolog.ConsoleWriter{Out: os.Stderr})
+		opts := logging.DefaultOptions()
+		opts.ProseFormat = true
+		logging.SetLogger(opts)
+		fallthrough
 	case config.DebugLog:
-		l = l.Level(zerolog.DebugLevel)
+		logging.Level.Set(slog.LevelDebug)
 	case config.InfoLog:
-		l = l.Level(zerolog.InfoLevel)
+		logging.Level.Set(slog.LevelInfo)
 	case config.WarnLog:
-		l = l.Level(zerolog.WarnLevel)
+		logging.Level.Set(slog.LevelWarn)
 	case config.ErrorLog:
-		l = l.Level(zerolog.ErrorLevel)
+		logging.Level.Set(slog.LevelError)
 	case config.FatalLog:
-		l = l.Level(zerolog.FatalLevel)
+		logging.Level.Set(slog.LevelError + 4)
 	case config.PanicLog:
-		l = l.Level(zerolog.PanicLevel)
+		logging.Level.Set(slog.LevelError + 8)
 	default:
 		return fmt.Errorf("unknown log level: %v", cfg.LogLevel)
 	}
-	l = l.With().
-		Timestamp().
-		Logger()
-	zlog.Set(&l)
-	log.Logger = zerolog.Nop()
-	zlog.Debug(ctx).Str("component", "initialize/Logging").Msg("logging initialized")
+
+	slog.DebugContext(ctx, "logging configured")
 	return nil
 }

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,36 @@
+// Package logging holds the logging singletons for Clair.
+//
+// An init function sets the [slog] default Logger.
+package logging
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/quay/claircore/toolkit/log"
+	"github.com/quay/zlog/v2"
+)
+
+func init() {
+	slog.SetLogLoggerLevel(slog.LevelDebug)
+	SetLogger(DefaultOptions())
+}
+
+// Level is the [slog.Leveler] that the [zlog.Options] returned by
+// [DefaultOptions] points to.
+var Level slog.LevelVar
+
+// DefaultOptions returns a default set of options for a zlog/v2 [slog.Handler].
+func DefaultOptions() *zlog.Options {
+	return &zlog.Options{
+		Level:      &Level,
+		ContextKey: log.AttrsKey,
+		LevelKey:   log.LevelKey,
+	}
+}
+
+// SetLogger configures the default [slog.Logger] to use a zlog-backed
+// [slog.Handler] writing to [os.Stderr] using the passed [zlog.Options].
+func SetLogger(opts *zlog.Options) {
+	slog.SetDefault(slog.New(zlog.NewHandler(os.Stderr, opts)))
+}

--- a/notifier/amqp/deliverer_integration_test.go
+++ b/notifier/amqp/deliverer_integration_test.go
@@ -1,20 +1,18 @@
 package amqp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/google/uuid"
 	"github.com/quay/clair/config"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-	"github.com/quay/zlog"
 	amqp "github.com/rabbitmq/amqp091-go"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -25,7 +23,7 @@ const (
 // callback is successfully delivered to the amqp broker.
 func TestDeliverer(t *testing.T) {
 	integration.Skip(t)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	const (
 		callback = "http://clair-notifier/notifier/api/v1/notification"
 	)

--- a/notifier/amqp/directdeliverer_integration_test.go
+++ b/notifier/amqp/directdeliverer_integration_test.go
@@ -1,7 +1,6 @@
 package amqp
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -11,8 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/quay/clair/config"
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-	"github.com/quay/zlog"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"golang.org/x/sync/errgroup"
 
@@ -23,7 +22,7 @@ import (
 // to the AMQP queue with rollup works correctly.
 func TestDirectDeliverer(t *testing.T) {
 	integration.Skip(t)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	// test start
 	table := []struct {
 		name         string
@@ -94,7 +93,7 @@ func TestDirectDeliverer(t *testing.T) {
 	}
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := zlog.Test(ctx, t)
+			ctx := test.Logging(t, ctx)
 			// rabbitmq queue declare
 
 			queueAndKey := tt.name + "-" + uuid.New().String()

--- a/notifier/postgres/notifications.go
+++ b/notifier/postgres/notifications.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/quay/zlog"
 
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/notifier"
@@ -322,7 +321,6 @@ func (r *notificationSource) Columns() []string {
 // may decide to gc notifications which have not been set deleted after some
 // period of time, thus this condition should not be checked.
 func (s *Store) CollectNotifications(ctx context.Context) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "notifier/postgres/Store.CollectNotifications")
 	const (
 		tryLock            = `SELECT pg_try_advisory_xact_lock($1, $2);`
 		deleteNotification = `DELETE FROM notification USING receipt WHERE id = receipt.notification_id AND receipt.status = 'deleted'::receiptstatus;`

--- a/notifier/postgres/notifications_test.go
+++ b/notifier/postgres/notifications_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-	"github.com/quay/zlog"
 
 	"github.com/quay/clair/v4/notifier"
 )
 
 func TestNotificationCopy(t *testing.T) {
 	integration.NeedDB(t)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	for _, tc := range []notificationCopyTestcase{
 		{Count: 1},
 		{Count: 10},
@@ -58,7 +57,7 @@ func (n *notificationCopyTestcase) Setup(t testing.TB) {
 func (n notificationCopyTestcase) Func(ctx context.Context) func(*testing.T) {
 	id := uuid.New()
 	return func(t *testing.T) {
-		ctx := zlog.Test(ctx, t)
+		ctx := test.Logging(t, ctx)
 		n.Setup(t)
 		src := copyNotifications(&id, n.Notifications)
 		s := TestingStore(ctx, t)

--- a/notifier/postgres/pagination_test.go
+++ b/notifier/postgres/pagination_test.go
@@ -1,13 +1,12 @@
 package postgres
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-	"github.com/quay/zlog"
 
 	"github.com/quay/clair/v4/notifier"
 )
@@ -68,8 +67,7 @@ func TestPagination(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			ctx = zlog.Test(ctx, t)
+			ctx := test.Logging(t)
 			store := TestingStore(ctx, t)
 
 			noteID := uuid.New()

--- a/notifier/postgres/store.go
+++ b/notifier/postgres/store.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/quay/zlog"
 	"github.com/remind101/migrate"
 
 	"github.com/quay/clair/v4/notifier/migrations"
@@ -30,14 +30,13 @@ func NewStore(pool *pgxpool.Pool) *Store {
 
 // Init initializes the database using the specified config.
 func Init(ctx context.Context, cfg *pgx.ConnConfig) error {
-	ctx = zlog.ContextWithValues(ctx, "component", "notifier/postgres/Init")
 	db, err := sql.Open("pgx", stdlib.RegisterConnConfig(cfg))
 	if err != nil {
 		return fmt.Errorf("failed to open db: %w", err)
 	}
 	defer db.Close()
 
-	zlog.Info(ctx).Msg("performing notifier migrations")
+	slog.InfoContext(ctx, "performing notifier migrations")
 	migrator := migrate.NewPostgresMigrator(db)
 	migrator.Table = migrations.MigrationTable
 	if err := migrator.Exec(migrate.Up, migrations.Migrations...); err != nil {

--- a/notifier/processor_create_test.go
+++ b/notifier/processor_create_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"sort"
 	"sync/atomic"
 	"testing"
@@ -12,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"
@@ -80,7 +81,7 @@ func TestProcessCreate(t *testing.T) {
 // available
 func testProcessorStoreErr(t *testing.T) {
 	t.Parallel()
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	e := Event{
 		updater: testUpdater,
 		uo:      processorUpdateOps[testUpdater][0],
@@ -114,7 +115,7 @@ func testProcessorStoreErr(t *testing.T) {
 		matcher: mm,
 	}
 
-	err := p.create(ctx, e, uuid.Nil)
+	err := p.create(ctx, slog.Default(), e, uuid.Nil)
 	if err == nil {
 		t.Fatalf("expected err")
 	}
@@ -124,7 +125,7 @@ func testProcessorStoreErr(t *testing.T) {
 // available
 func testProcessorIndexerErr(t *testing.T) {
 	t.Parallel()
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	e := Event{
 		updater: testUpdater,
 		uo:      processorUpdateOps[testUpdater][0],
@@ -155,7 +156,7 @@ func testProcessorIndexerErr(t *testing.T) {
 		matcher: mm,
 	}
 
-	err := p.create(ctx, e, uuid.Nil)
+	err := p.create(ctx, slog.Default(), e, uuid.Nil)
 	if err == nil {
 		t.Fatalf("expected err")
 	}
@@ -165,7 +166,7 @@ func testProcessorIndexerErr(t *testing.T) {
 // available
 func testProcessorMatcherErr(t *testing.T) {
 	t.Parallel()
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	e := Event{
 		updater: testUpdater,
 		uo:      processorUpdateOps[testUpdater][0],
@@ -193,7 +194,7 @@ func testProcessorMatcherErr(t *testing.T) {
 		matcher: mm,
 	}
 
-	err := p.create(ctx, e, uuid.Nil)
+	err := p.create(ctx, slog.Default(), e, uuid.Nil)
 	if err == nil {
 		t.Fatalf("expected err")
 	}
@@ -202,7 +203,7 @@ func testProcessorMatcherErr(t *testing.T) {
 // testProcessorCreate confirms notifications are created correctly.
 func testProcessorCreate(t *testing.T) {
 	t.Parallel()
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	e := Event{
 		updater: testUpdater,
 		uo:      processorUpdateOps[testUpdater][0],
@@ -261,7 +262,7 @@ func testProcessorCreate(t *testing.T) {
 		matcher: mm,
 	}
 
-	err := p.create(ctx, e, uuid.Nil)
+	err := p.create(ctx, slog.Default(), e, uuid.Nil)
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}

--- a/notifier/stomp/directdeliverer.go
+++ b/notifier/stomp/directdeliverer.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 
 	"github.com/google/uuid"
 	"github.com/quay/clair/config"
-	"github.com/quay/zlog"
 
 	clairerror "github.com/quay/clair/v4/clair-error"
 	"github.com/quay/clair/v4/notifier"
@@ -66,7 +66,7 @@ func (d *DirectDeliverer) Deliver(ctx context.Context, nID uuid.UUID) error {
 			return
 		}
 		if err := tx.AbortWithReceipt(); err != nil {
-			zlog.Warn(ctx).Err(err).Msg("transaction aborted")
+			slog.WarnContext(ctx, "transaction aborted", "reason", err)
 		}
 	}()
 

--- a/notifier/stomp/integration_test.go
+++ b/notifier/stomp/integration_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/quay/clair/config"
 	"github.com/quay/claircore"
+	"github.com/quay/claircore/test"
 	"github.com/quay/claircore/test/integration"
-	"github.com/quay/zlog"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/quay/clair/v4/notifier"
@@ -127,7 +127,7 @@ func TestDeliverer(t *testing.T) {
 	// code tested against ActiveMQ, but this was migrated to make the setup
 	// simpler.
 	integration.Skip(t)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	const (
 		callback = "http://clair-notifier/notifier/api/v1/notifications/"
 	)
@@ -196,7 +196,7 @@ func TestDeliverer(t *testing.T) {
 func TestDirectDeliverer(t *testing.T) {
 	t.Parallel()
 	integration.Skip(t)
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 
 	table := []struct {
 		name         string
@@ -216,7 +216,7 @@ func TestDirectDeliverer(t *testing.T) {
 	for _, tt := range table {
 		queue := `/queue/` + uuid.New().String()
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := zlog.Test(ctx, t)
+			ctx := test.Logging(t, ctx)
 			// deliverer test
 			conf := config.STOMP{
 				Direct:      true,

--- a/notifier/summary_test.go
+++ b/notifier/summary_test.go
@@ -2,19 +2,20 @@ package notifier
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/libvuln/driver"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/matcher"
 )
 
 func TestNotificationSummary(t *testing.T) {
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 
 	// This is a bunch of supporting data structures.
 	updater := uuid.New().String()
@@ -81,7 +82,7 @@ func TestNotificationSummary(t *testing.T) {
 			return nil
 		},
 	}
-	if err := p.create(ctx, e, uuid.Nil); err != nil {
+	if err := p.create(ctx, slog.Default(), e, uuid.Nil); err != nil {
 		t.Error(err)
 	}
 
@@ -99,7 +100,7 @@ func TestNotificationSummary(t *testing.T) {
 			return nil
 		},
 	}
-	if err := p.create(ctx, e, uuid.Nil); err != nil {
+	if err := p.create(ctx, slog.Default(), e, uuid.Nil); err != nil {
 		t.Error(err)
 	}
 }

--- a/notifier/webhook/cmd/webhookd/main.go
+++ b/notifier/webhook/cmd/webhookd/main.go
@@ -15,7 +15,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -32,17 +32,35 @@ import (
 	"github.com/quay/clair/v4/notifier"
 )
 
-// This program is unlike the other Clair binaries in that it uses the stdlib
-// "log" package in a format that I like rather than "zlog".
 func main() {
-	debug := flag.Bool("D", false, "print debugging output")
+	var code int
+	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer done()
+	defer func() {
+		done()
+		if code != 0 {
+			os.Exit(code)
+		}
+	}()
+	var level slog.LevelVar
+	flag.BoolFunc("D", "print debugging output", func(arg string) error {
+		l := slog.LevelInfo
+		if ok, _ := strconv.ParseBool(arg); ok {
+			l = slog.LevelDebug
+		}
+		level.Set(l)
+		return nil
+	})
 	addr := flag.String("listen", ":http", "address to listen on")
 	keyEnc := flag.String("key", "", "base64 encoded PSK for signed requests")
 	iss := flag.String("iss", "quay", "issuer for signed requests")
 	flag.Parse()
 
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: &level,
+	})))
+
 	h := &Recv{
-		Debug:  *debug,
 		Client: http.DefaultClient,
 	}
 
@@ -52,25 +70,24 @@ func main() {
 		key := make([]byte, l)
 		n, err := base64.StdEncoding.Decode(key, b)
 		if err != nil {
-			log.Fatal(err)
+			slog.ErrorContext(ctx, "unable to decode key", "reason", err)
+			code = 1
+			return
 		}
 		key = key[:n]
-		if h.Debug {
-			log.Printf("D decoded key: %+#q", key)
-		}
+		slog.DebugContext(ctx, "decoded key", "key", key)
 		sk := jose.SigningKey{
 			Algorithm: jose.HS256,
 			Key:       key,
 		}
 		h.Signer, err = jose.NewSigner(sk, nil)
 		if err != nil {
-			log.Fatal(err)
+			slog.ErrorContext(ctx, "unable to create signer", "reason", err)
+			code = 1
+			return
 		}
 		h.Claim = &jwt.Claims{Issuer: *iss}
 	}
-	ctx := context.Background()
-	ctx, done := signal.NotifyContext(ctx, os.Interrupt)
-	defer done()
 	srv := http.Server{
 		Addr:        *addr,
 		Handler:     h,
@@ -78,15 +95,18 @@ func main() {
 	}
 	go func() {
 		if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-			log.Fatal(err)
+			slog.ErrorContext(ctx, "unable to start HTTP server", "reason", err)
+			done()
+			code = 1
+			return
 		}
 	}()
 
-	log.Println(":", "ready")
+	slog.InfoContext(ctx, "ready")
 	defer func() {
-		log.Println(":", "shutting down")
+		slog.InfoContext(ctx, "shutting down")
 		if err := srv.Shutdown(ctx); err != nil && err != context.Canceled {
-			log.Println(err)
+			slog.ErrorContext(ctx, "HTTP server shutdown", "reason", err)
 		}
 	}()
 	<-ctx.Done()
@@ -97,36 +117,34 @@ type Recv struct {
 	Client *http.Client
 	Signer jose.Signer
 	Claim  *jwt.Claims
-	Debug  bool
 }
+
+const contentType = `application/json`
 
 // ServeHTTP implements [http.Handler].
 func (h *Recv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	rc := http.NewResponseController(w)
 	defer rc.Flush()
 
-	if h.Debug {
-		b, err := httputil.DumpRequest(r, true)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Println("D", "received hook:", strconv.Quote(string(b)))
-	}
+	slog.DebugContext(ctx, "received hook", "request", (*logRequest)(r))
 
 	if r.Method != http.MethodPost {
-		http.Error(w, fmt.Sprintf("bad method: %s", r.Method), http.StatusBadRequest)
-		log.Println("E", "bad method:", r.Method)
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "", http.StatusMethodNotAllowed)
+		slog.WarnContext(ctx, "bad request", "method", r.Method)
 		return
 	}
-	if ct := r.Header.Get(`content-type`); ct != `application/json` {
-		http.Error(w, fmt.Sprintf("bad content-type: %s", ct), http.StatusBadRequest)
-		log.Println("E", "bad content-type:", r.Method)
+	if ct := r.Header.Get(`content-type`); ct != contentType {
+		w.Header().Set("Accept-Post", contentType)
+		http.Error(w, "", http.StatusUnsupportedMediaType)
+		slog.WarnContext(ctx, "bad request", "content-type", ct)
 		return
 	}
 
 	defer func() {
 		if err := r.Body.Close(); err != nil {
-			log.Println("E", "unable to close:", err.Error())
+			slog.WarnContext(ctx, "unable to close request body", "reason", err)
 			panic(http.ErrAbortHandler)
 		}
 	}()
@@ -134,17 +152,17 @@ func (h *Recv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	dec := json.NewDecoder(r.Body)
 	if err := dec.Decode(&payload); err != nil {
 		http.Error(w, fmt.Sprintf("bad content: %v", err), http.StatusBadRequest)
-		log.Println("E", "bad content:", err.Error())
+		slog.WarnContext(ctx, "bad payload", "reason", err)
 		return
 	}
 	whid := path.Base(payload.Callback.Path)
 
 	var resp response
 	for next := new(uuid.UUID); next != nil; next = resp.Page.Next {
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, payload.Callback.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, payload.Callback.String(), nil)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to create request: %v", err), http.StatusInternalServerError)
-			log.Println("E", "unable to create request:", err.Error())
+			slog.WarnContext(ctx, "unable to create request", "reason", err)
 			return
 		}
 		if pg := resp.Page.Next; pg != nil {
@@ -154,86 +172,69 @@ func (h *Recv) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		if err := h.sign(req); err != nil {
 			http.Error(w, fmt.Sprintf("unable to sign request: %v", err), http.StatusInternalServerError)
-			log.Println("E", "unable to sign request:", err.Error())
+			slog.WarnContext(ctx, "unable to sign request", "reason", err)
 			return
 		}
 
-		if h.Debug {
-			b, err := httputil.DumpRequest(req, true)
-			if err != nil {
-				log.Fatal(err)
-			}
-			log.Println("D", "making request:", strconv.Quote(string(b)))
-		}
+		slog.DebugContext(ctx, "making request", "request", (*logRequest)(req))
 
 		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("error making request: %v", err), http.StatusInternalServerError)
-			log.Println("E", "unable to make request:", err.Error())
+			slog.WarnContext(ctx, "unable to make request", "reason", err)
 			return
 		}
 		defer res.Body.Close()
 
-		if h.Debug {
-			b, err := httputil.DumpResponse(res, true)
-			if err != nil {
-				log.Fatal(err)
-			}
-			log.Println("D", "got response:", strconv.Quote(string(b)))
-		}
-
+		slog.DebugContext(ctx, "got response", "response", (*logResponse)(res))
 		if res.StatusCode != http.StatusOK {
 			http.Error(w, fmt.Sprintf("bad response from upstream: %q", res.Status), http.StatusInternalServerError)
-			log.Println("E", "bad status:", res.Status)
+			slog.WarnContext(ctx, "bad status", "status", res.Status)
 			return
 		}
 
 		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 			http.Error(w, fmt.Sprintf("bad content from upstream: %v", err), http.StatusTeapot)
-			log.Println("E", "bad content:", err)
+			slog.WarnContext(ctx, "bad content", "reason", err)
 			return
 		}
 
 		for _, n := range resp.Notifications {
-			log.Println(":", whid, n.ID, n.Manifest, n.Reason, n.Vulnerability.Name)
+			slog.InfoContext(ctx, "notification", "id", whid, slog.Group("notification",
+				"id", n.ID,
+				"manifest", n.Manifest,
+				"reason", n.Reason,
+				"name", n.Vulnerability.Name,
+			))
 		}
 	}
-	req, err := http.NewRequestWithContext(r.Context(), http.MethodDelete, payload.Callback.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, payload.Callback.String(), nil)
 	if err != nil {
-		log.Fatal(err)
+		http.Error(w, fmt.Sprintf("unable to create request: %v", err), http.StatusInternalServerError)
+		slog.WarnContext(ctx, "unable to create request", "reason", err)
+		return
 	}
 	if err := h.sign(req); err != nil {
 		http.Error(w, fmt.Sprintf("unable to sign request: %v", err), http.StatusInternalServerError)
-		log.Println("E", "unable to sign request:", err.Error())
+		slog.WarnContext(ctx, "unable to sign request", "reason", err)
 		return
 	}
-	if h.Debug {
-		b, err := httputil.DumpRequest(req, true)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Println("D", "making request:", strconv.Quote(string(b)))
-	}
+	slog.DebugContext(ctx, "making request", "request", (*logRequest)(req))
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("error making request: %v", err), http.StatusInternalServerError)
+		slog.WarnContext(ctx, "unable to make request", "reason", err)
 		return
 	}
 	defer res.Body.Close()
-	if h.Debug {
-		b, err := httputil.DumpResponse(res, true)
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Println("D", "got response:", strconv.Quote(string(b)))
-	}
+	slog.DebugContext(ctx, "got response", "response", (*logResponse)(res))
 	if res.StatusCode != http.StatusOK {
 		http.Error(w, fmt.Sprintf("bad response from upstream: %q", res.Status), http.StatusInternalServerError)
-		log.Println("E", "bad status:", res.Status)
+		slog.WarnContext(ctx, "bad status", "status", res.Status)
 		return
 	}
-	log.Println(":", "deleted:", whid)
+	slog.InfoContext(ctx, "deleted", "id", whid)
 }
 
 // Response is a page of notifications.
@@ -258,4 +259,33 @@ func (h *Recv) sign(req *http.Request) error {
 	}
 	req.Header.Set("authorization", "Bearer "+tok)
 	return nil
+}
+
+var (
+	_ slog.LogValuer = (*logRequest)(nil)
+	_ slog.LogValuer = (*logResponse)(nil)
+)
+
+type logRequest http.Request
+
+// LogValue implements [slog.LogValuer].
+func (l *logRequest) LogValue() slog.Value {
+	req := (*http.Request)(l)
+	b, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return slog.GroupValue(slog.String("error", err.Error()))
+	}
+	return slog.StringValue(string(b))
+}
+
+type logResponse http.Response
+
+// LogValue implements [slog.LogValuer].
+func (l *logResponse) LogValue() slog.Value {
+	res := (*http.Response)(l)
+	b, err := httputil.DumpResponse(res, true)
+	if err != nil {
+		return slog.GroupValue(slog.String("error", err.Error()))
+	}
+	return slog.StringValue(string(b))
 }

--- a/notifier/webhook/deliverer_test.go
+++ b/notifier/webhook/deliverer_test.go
@@ -1,7 +1,6 @@
 package webhook
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -13,7 +12,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/quay/clair/config"
-	"github.com/quay/zlog"
+	"github.com/quay/claircore/test"
 
 	"github.com/quay/clair/v4/notifier"
 )
@@ -48,7 +47,7 @@ func TestDeliverer(t *testing.T) {
 		},
 	))
 	defer server.Close()
-	ctx := zlog.Test(context.Background(), t)
+	ctx := test.Logging(t)
 	conf := config.Webhook{
 		Callback: callback,
 		Target:   server.URL,


### PR DESCRIPTION
This patch set switches the whole module over to using `log/slog` instead of `github.com/quay/zlog`.