### PR TITLE
chore: update general project go version to 1.25

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       matrix:
-        image: ['quay.io/projectquay/golang:1.24']
+        image: ['quay.io/projectquay/golang:1.25']
     container:
       image: ${{ matrix.image }}
     outputs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/contrib/cmd/quaybackstop/Dockerfile
+++ b/contrib/cmd/quaybackstop/Dockerfile
@@ -20,7 +20,7 @@
 #     --local context=. --local dockerfile=contrib/cmd/quaybackstop
 
 ARG GOTOOLCHAIN=local
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 FROM --platform=$BUILDPLATFORM quay.io/projectquay/golang:${GO_VERSION} AS build
 WORKDIR /build
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 # This is just to hold a bunch of yaml anchors and try to consolidate parts of
 # the config.
 x-anchors:
-  go: &go-image quay.io/projectquay/golang:1.24
+  go: &go-image quay.io/projectquay/golang:1.25
   grafana: &grafana-image docker.io/grafana/grafana:10.3.1
   jaeger: &jaeger-image docker.io/jaegertracing/all-in-one:1
   pgadmin: &pgadmin-image docker.io/dpage/pgadmin4:5.7


### PR DESCRIPTION
Now go1.26 is stable and go1.24 is no longer officially supported we need to update all the references of go1.24 to go1.25.