### PR TITLE
cicd: additional dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
     groups:
       otel:
         patterns:
-          - "go.opentelemetry.io/otel/*"
+          - "go.opentelemetry.io/*"
       golang-x:
         patterns:
           - "golang.org/x/*"
@@ -32,7 +32,7 @@ updates:
     groups:
       otel:
         patterns:
-          - "go.opentelemetry.io/otel/*"
+          - "go.opentelemetry.io/*"
       golang-x:
         patterns:
           - "golang.org/x/*"


### PR DESCRIPTION
Change the dependabot grouping to more closely match Claircore.