### PR TITLE
clair: print flag parse errors

### DIFF
--- a/cmd/clair/main.go
+++ b/cmd/clair/main.go
@@ -46,6 +46,7 @@ func main() {
 	case errors.Is(err, flag.ErrHelp):
 		os.Exit(0)
 	default:
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(2)
 	}
 	cpu, err := flags.SetupCPUProfile()


### PR DESCRIPTION
Previously, unrecognized or invalid flags caused a silent failure exit.
Print the error to stderr so users can see what went wrong.