### PR TITLE
chore: Remove refs to deprecated trace.NewNoopTracerProvider

### DIFF
--- a/httptransport/indexer_v1_test.go
+++ b/httptransport/indexer_v1_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/quay/claircore/pkg/tarfs"
 	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/internal/httputil"
@@ -32,7 +32,7 @@ func TestIndexReportBadLayer(t *testing.T) {
 			return nil, tarfs.ErrFormat
 		},
 	}
-	v1, err := NewIndexerV1(ctx, "", i, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	v1, err := NewIndexerV1(ctx, "", i, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestIndexerV1(t *testing.T) {
 		},
 	}
 
-	v1, err := NewIndexerV1(ctx, "", i, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	v1, err := NewIndexerV1(ctx, "", i, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/httptransport/matcher_v1_test.go
+++ b/httptransport/matcher_v1_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/quay/claircore/libvuln/driver"
 	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/quay/clair/v4/indexer"
 	"github.com/quay/clair/v4/internal/httputil"
@@ -40,13 +40,13 @@ func testUpdateDiffMatcher(t *testing.T) {
 			return nil, nil
 		},
 	}
-	hOK := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	hOK := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	mErr := &matcher.Mock{
 		UpdateDiff_: func(context.Context, uuid.UUID, uuid.UUID) (*driver.UpdateDiff, error) {
 			return nil, fmt.Errorf("expected error")
 		},
 	}
-	hErr := NewMatcherV1(ctx, "", mErr, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	hErr := NewMatcherV1(ctx, "", mErr, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 
 	srvOK := httptest.NewUnstartedServer(hOK)
 	srvOK.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
@@ -155,7 +155,7 @@ func testUpdateDiffHandlerParams(t *testing.T) {
 			return nil, nil
 		},
 	}
-	h := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	h := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
 	srv.Start()
@@ -201,7 +201,7 @@ func testUpdateDiffHandlerMethods(t *testing.T) {
 			return nil, nil
 		},
 	}
-	h := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	h := NewMatcherV1(ctx, "", mOK, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
 	srv.Start()
@@ -266,7 +266,7 @@ func testUpdateOperationHandlerErrors(t *testing.T) {
 			return nil, ErrExpected
 		},
 	}
-	h := NewMatcherV1(ctx, "", m, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	h := NewMatcherV1(ctx, "", m, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
 	srv.Start()
@@ -306,7 +306,7 @@ func testUpdateOperationHandlerErrors(t *testing.T) {
 func testUpdateOperationHandlerMethods(t *testing.T) {
 	ctx := test.Logging(t)
 	t.Parallel()
-	h := NewMatcherV1(ctx, "", &matcher.Mock{}, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	h := NewMatcherV1(ctx, "", &matcher.Mock{}, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
 	srv.Start()
@@ -359,7 +359,7 @@ func testUpdateOperationHandlerGet(t *testing.T) {
 			return nil, nil
 		},
 	}
-	h := NewMatcherV1(ctx, "", m, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(trace.NewNoopTracerProvider()))
+	h := NewMatcherV1(ctx, "", m, &indexer.Mock{}, time.Second*10, otelhttp.WithTracerProvider(noop.NewTracerProvider()))
 	srv := httptest.NewUnstartedServer(h)
 	srv.Config.BaseContext = func(_ net.Listener) context.Context { return ctx }
 	srv.Start()

--- a/httptransport/notification_v1_test.go
+++ b/httptransport/notification_v1_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/quay/claircore/test"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/quay/clair/v4/internal/httputil"
 	"github.com/quay/clair/v4/notifier"
@@ -29,7 +29,7 @@ func TestNotificationsHandler(t *testing.T) {
 	t.Run("Delete", testNotificationHandlerDelete(ctx))
 }
 
-var notifierTraceOpt = otelhttp.WithTracerProvider(trace.NewNoopTracerProvider())
+var notifierTraceOpt = otelhttp.WithTracerProvider(noop.NewTracerProvider())
 
 // testNotificationHandlerDelete confirms the handler performs a delete
 // correctly


### PR DESCRIPTION
Remove refs to deprecated `trace.NewNoopTracerProvider()` and replace it with `noop.NewTracerProvider()`.

Reference: https://github.com/open-telemetry/opentelemetry-go/blob/40867014cd53ffaba6c31b75403d3f439ff5381b/trace/noop.go#L18