### PR TITLE
httptransport: fix negotiated error responses

### DIFF
--- a/httptransport/common.go
+++ b/httptransport/common.go
@@ -35,8 +35,8 @@ func getDigest(_ http.ResponseWriter, r *http.Request) (d claircore.Digest, err 
 // "allow" slice is used.
 //
 // If "Accept" headers are present, the first (ordered by "q" value) media type
-// in the "allow" slice is chosen. If there are no common media types, "415
-// Unsupported Media Type" is written and ErrMediaType is reported.
+// in the "allow" slice is chosen. If there are no common media types,
+// ErrMediaType is reported.
 func pickContentType(w http.ResponseWriter, r *http.Request, allow []string) error {
 	// There's no canonical algorithm for this, it's all server-dependent
 	// behavior. Our algorithm is:
@@ -84,7 +84,6 @@ func pickContentType(w http.ResponseWriter, r *http.Request, allow []string) err
 			}
 		}
 	}
-	w.WriteHeader(http.StatusUnsupportedMediaType)
 	return ErrMediaType
 }
 

--- a/httptransport/discoveryhandler_test.go
+++ b/httptransport/discoveryhandler_test.go
@@ -67,5 +67,8 @@ func TestDiscovery(t *testing.T) {
 		if got, want := resp.StatusCode, http.StatusUnsupportedMediaType; got != want {
 			t.Errorf("got status code: %v want status code: %v", got, want)
 		}
+		if got, want := resp.Header.Get("content-type"), "application/json"; got != want {
+			t.Errorf("got content-type: %q, want: %q", got, want)
+		}
 	})
 }


### PR DESCRIPTION
Small cleanup for content negotiation error path.

Before this, `pickContentType` wrote `415` itself, then callers tried to send `apiError`. Too late: headers were already committed, so `/openapi/v1` with `Accept: application/xml` got a `415` with no JSON content-type. tiny paper cut, but annoying for clients.

Repro:
- before: `go test ./httptransport -run 'TestDiscovery/Failure' -count=1 -v` fails with `got content-type: "", want: "application/json"`
- after: same test passes

Validation:
- `go test ./httptransport -run 'TestDiscovery' -count=1`
- `go test ./...`

Related: #1441, #1523-ish