### PR TITLE
docs: describe the published container tags accurately

### DIFF
--- a/Documentation/howto/getting_started.md
+++ b/Documentation/howto/getting_started.md
@@ -12,8 +12,9 @@ The release artifacts also include the clairctl command line tool.
 ## Official Containers
 
 Clair is officially packaged and released as a container at
-[quay.io/projectquay/clair]. The `latest` tag tracks the git development branch,
-and version tags are built from the corresponding release.
+[quay.io/projectquay/clair]. The `nightly` tag tracks the git development branch
+(dated `nightly-YYYY-MM-DD` tags are kept as well), and version tags are built
+from the corresponding release. There is no `latest` tag.
 
 [quay.io/projectquay/clair]: https://quay.io/repository/projectquay/clair
 


### PR DESCRIPTION
Fixes #2398

The getting-started guide says the `latest` tag tracks the development branch, but that tag does not
exist on the registry — which is why `podman pull quay.io/projectquay/clair:latest` returns
`manifest unknown`.

Current tags on quay.io/projectquay/clair (via `https://quay.io/api/v1/repository/projectquay/clair/tag/`,
fetched today):

```
nightly              Tue, 28 Jul 2026 06:21:50 -0000
nightly-2026-07-28   Tue, 28 Jul 2026 06:21:53 -0000
nightly-2026-07-25   ...
4.9.0                Wed, 10 Dec 2025 18:38:54 -0000
4.8.0                Wed, 09 Oct 2024 20:22:40 -0000
4.7.4 ... 4.4.4      (release tags)
```

So the development branch is published as `nightly`, with dated `nightly-YYYY-MM-DD` tags kept alongside,
and releases as version tags. The doc now says that, and states explicitly that there is no `latest` tag,
so the next person doesn't have to find out via `manifest unknown`.

Documentation-only change; no code touched.

AI-assisted (LLM used for drafting); the tag listing above was fetched and checked by me.
