### PR TITLE
Add Containerfile.art for ART onboarding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *	@quay/clair @quay/clair-maintainers
+contrib/art/Containerfile.art	@quay/automated-release-tooling

--- a/contrib/art/Containerfile.art
+++ b/contrib/art/Containerfile.art
@@ -1,0 +1,41 @@
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS build
+
+WORKDIR /app
+COPY . .
+
+RUN GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -mod=mod \
+	-ldflags="-s -w" \
+	-o . \
+	-trimpath \
+	./cmd/...
+
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
+
+LABEL com.redhat.component="clair-container"
+LABEL name="quay/clair-rhel9"
+LABEL io.k8s.display-name="Red Hat Quay - Clair"
+LABEL io.k8s.description="Clair vulnerability scanner for Red Hat Quay"
+LABEL io.openshift.tags="quay,clair,security"
+LABEL summary="Clair vulnerability scanner for Red Hat Quay"
+LABEL description="Clair vulnerability scanner for Red Hat Quay"
+#LABEL cpe="cpe:/a:redhat:quay::el9"
+LABEL vendor="Red Hat, Inc."
+LABEL distribution-scope="restricted"
+LABEL url="https://docs.redhat.com/en/documentation/red_hat_quay"
+LABEL maintainer="support@redhat.com"
+
+ENTRYPOINT ["/usr/bin/clair"]
+VOLUME /config
+EXPOSE 6060
+WORKDIR /run
+
+ENV CLAIR_CONF=/config/config.yaml \
+    CLAIR_MODE=combo \
+    SSL_CERT_DIR="/etc/ssl/certs:/etc/pki/tls/certs:/var/run/certs"
+
+USER nobody:nobody
+
+COPY --from=build /app/clair /bin/clair
+COPY --from=build /app/clairctl /bin/clairctl
+ADD https://raw.githubusercontent.com/quay/quay-konflux-components/redhat-3.17/components/clair/data/repository-to-cpe.json /data/
+ADD https://raw.githubusercontent.com/quay/quay-konflux-components/redhat-3.17/components/clair/data/container-name-repos-map.json /data/


### PR DESCRIPTION
## Summary

Adds ART-compatible Containerfile for building Clair container images through the Konflux pipeline for Red Hat OpenShift releases.

- Adds `contrib/Containerfile.art` with Red Hat-specific labels and metadata
- Updates `CODEOWNERS` to assign contrib/Containerfile.art to @quay/redhat-team  

## Changes

**contrib/Containerfile.art** — Multi-stage Dockerfile for ART builds:
- Build stage: Go 1.25 toolset, builds with FIPS-compliant flags
- Runtime stage: UBI 9 minimal base with Red Hat labels
- Includes required data files for Clair vulnerability scanning

**CODEOWNERS** — Adds entry for contrib/Containerfile.art maintenance

## Tracking

ART-19361: Quay onboarding to ART pipeline