### PR TITLE
backport: Add Containerfile.art for ART onboarding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-*	@quay/clair
+*	@quay/clair @quay/clair-maintainers
+contrib/art/*	@quay/automated-release-tooling

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -1,0 +1,10 @@
+---
+metadata:
+  version: "1.0"
+artifacts:
+  - download_url: https://www.redhat.com/security/data/metrics/repository-to-cpe.json
+    checksum: sha256:e7d94a73a4cae50d3c33443c92c61369d2ce4e58c6efdbdf262cac399c8d0046
+    filename: repository-to-cpe.json
+  - download_url: https://www.redhat.com/security/data/metrics/container-name-repos-map.json
+    checksum: sha256:4f5e76f99db36252ff83cbf492ac9bb85c10e7abbe890a2769281469105d2608
+    filename: container-name-repos-map.json

--- a/contrib/art/Containerfile.art
+++ b/contrib/art/Containerfile.art
@@ -1,0 +1,40 @@
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS build
+
+WORKDIR /app
+COPY . .
+
+RUN GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -mod=mod \
+	-ldflags="-s -w" \
+	-o . \
+	-trimpath \
+	./cmd/...
+
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
+
+LABEL com.redhat.component="clair-container"
+LABEL name="quay/clair-rhel9"
+LABEL io.k8s.display-name="Red Hat Quay - Clair"
+LABEL io.k8s.description="Clair vulnerability scanner for Red Hat Quay"
+LABEL io.openshift.tags="quay,clair,security"
+LABEL summary="Clair vulnerability scanner for Red Hat Quay"
+LABEL description="Clair vulnerability scanner for Red Hat Quay"
+LABEL cpe="cpe:/a:redhat:quay::el9"
+LABEL vendor="Red Hat, Inc."
+LABEL distribution-scope="restricted"
+LABEL url="https://docs.redhat.com/en/documentation/red_hat_quay"
+LABEL maintainer="support@redhat.com"
+
+ENTRYPOINT ["/usr/bin/clair"]
+VOLUME /config
+EXPOSE 6060
+WORKDIR /run
+
+ENV CLAIR_CONF=/config/config.yaml \
+    CLAIR_MODE=combo \
+    SSL_CERT_DIR="/etc/ssl/certs:/etc/pki/tls/certs:/var/run/certs"
+
+USER nobody:nobody
+
+COPY --from=build /app/clair /bin/clair
+COPY --from=build /app/clairctl /bin/clairctl
+COPY /cachi2/output/deps/generic/repository-to-cpe.json /cachi2/output/deps/generic/container-name-repos-map.json /data/


### PR DESCRIPTION
Adds contrib/art/Containerfile.art for ART onboarding (ART-19361).

Include repository-to-cpe.json and container-name-repos-map.json data
files in contrib/art/ for use during container build. 

ADD https:// fails in hermetic as well as open builds as quay-konflux-components is a private repository, hence using COPY with local files instead to enable both hermetic and open builds without external network calls.