### PR TITLE
contrib: Update Containerfile.art for ART onboading

### DIFF
--- a/contrib/art/Containerfile.art
+++ b/contrib/art/Containerfile.art
@@ -18,7 +18,7 @@ LABEL io.k8s.description="Clair vulnerability scanner for Red Hat Quay"
 LABEL io.openshift.tags="quay,clair,security"
 LABEL summary="Clair vulnerability scanner for Red Hat Quay"
 LABEL description="Clair vulnerability scanner for Red Hat Quay"
-#LABEL cpe="cpe:/a:redhat:quay::el9"
+LABEL cpe="cpe:/a:redhat:quay::el9"
 LABEL vendor="Red Hat, Inc."
 LABEL distribution-scope="restricted"
 LABEL url="https://docs.redhat.com/en/documentation/red_hat_quay"
@@ -33,9 +33,9 @@ ENV CLAIR_CONF=/config/config.yaml \
     CLAIR_MODE=combo \
     SSL_CERT_DIR="/etc/ssl/certs:/etc/pki/tls/certs:/var/run/certs"
 
-USER nobody:nobody
+RUN mkdir -p /data && cp /cachi2/output/deps/generic/repository-to-cpe.json /cachi2/output/deps/generic/container-name-repos-map.json /data/
 
 COPY --from=build /app/clair /bin/clair
 COPY --from=build /app/clairctl /bin/clairctl
-ADD https://raw.githubusercontent.com/quay/quay-konflux-components/redhat-3.17/components/clair/data/repository-to-cpe.json /data/
-ADD https://raw.githubusercontent.com/quay/quay-konflux-components/redhat-3.17/components/clair/data/container-name-repos-map.json /data/
+
+USER nobody:nobody


### PR DESCRIPTION
Adds contrib/art/Containerfile.art with ART-compatible labels for building Clair container images through the Konflux pipeline for Red Hat OpenShift releases. The file uses COPY directives to fetch JSON data files (repository-to-cpe.json and container-name-repos-map.json) that are prefetched by cachi2 during the build phase.

Creates artifacts.lock.yaml in the repository root to declare the data file artifacts for cachi2 prefetch. Files are downloaded and verified with SHA256 checksums during prefetch and made available at /cachi2/output/deps/generic/ for the build phase. This enables both hermetic and open builds without external network calls during the container build.

Tracking: ART-19361